### PR TITLE
docs: user guide + MCP documentation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,121 @@ brew install qemu  # macOS
 
 ---
 
+<details>
+<summary><b>📖 User Guide &amp; Tutorial</b></summary>
+
+### Quick Start (5 Minutes)
+
+```bash
+# 1. Clone and verify
+git clone https://github.com/ruvnet/rvm.git && cd rvm
+cargo test --workspace --lib    # 797 tests, 0 failures
+
+# 2. Run benchmarks
+cargo bench -p rvm-benches      # 11 criterion benchmarks
+
+# 3. Build for bare metal
+rustup target add aarch64-unknown-none
+cargo install cargo-binutils && rustup component add llvm-tools
+make build                      # AArch64 release binary
+
+# 4. Boot in QEMU
+brew install qemu               # macOS (or apt install qemu-system-aarch64)
+make run                        # Boots at 0x4000_0000, PL011 UART output
+
+# 5. Use as a library
+# Add to Cargo.toml: rvm-kernel = { path = "crates/rvm-kernel" }
+```
+
+```rust
+use rvm_kernel::{
+    types, hal, cap, witness, proof, partition,
+    sched, memory, coherence, boot, wasm, security,
+};
+```
+
+### Full User Guide
+
+The [`userguide/`](userguide/) directory contains 17 chapters covering every subsystem:
+
+| Chapter | Topic |
+|---------|-------|
+| [01 Quick Start](userguide/01-quickstart.md) | Build, test, and boot in 5 minutes |
+| [02 Core Concepts](userguide/02-core-concepts.md) | Partitions, capabilities, witnesses, proofs, coherence |
+| [03 Architecture](userguide/03-architecture.md) | Layer diagram, data flow, boot sequence, feature flags |
+| [04 Crate Reference](userguide/04-crate-reference.md) | All 13 crates with types, APIs, and dependencies |
+| [05 Capabilities & Proofs](userguide/05-capabilities-proofs.md) | 7 rights, delegation trees, 3 proof tiers, TEE |
+| [06 Witness & Audit](userguide/06-witness-audit.md) | 64-byte records, hash chains, signing, querying |
+| [07 Partitions & Scheduling](userguide/07-partitions-scheduling.md) | Lifecycle, IPC, split/merge, 2-signal scheduler |
+| [08 Memory Model](userguide/08-memory-model.md) | 4 tiers, buddy allocator, reconstruction |
+| [09 WASM Agents](userguide/09-wasm-agents.md) | Module validation, 7-state lifecycle, migration |
+| [10 Security](userguide/10-security.md) | 3-stage gate, attestation, audit results |
+| [11 Performance](userguide/11-performance.md) | 11 benchmarks, build profiles, tuning |
+| [12 Bare Metal](userguide/12-bare-metal.md) | Linker script, QEMU, measured boot, Seed/Appliance |
+| [13 Advanced & Exotic](userguide/13-advanced-exotic.md) | 6 novel capabilities, fault rollback, RuVector |
+| [14 Troubleshooting](userguide/14-troubleshooting.md) | 12 categories of common issues |
+| [15 Glossary](userguide/15-glossary.md) | 60+ terms with cross-references |
+| [Cross-Reference](userguide/cross-reference.md) | Concept index, API finder, "I want to..." tasks |
+
+</details>
+
+<details>
+<summary><b>🔌 MCP Documentation Tools</b></summary>
+
+RVM ships with an MCP (Model Context Protocol) server and CLI for AI-assisted documentation search and navigation.
+
+### Installation
+
+```bash
+cd userguide/mcp
+npm install && npm run build
+```
+
+### Register with Claude Code
+
+```bash
+claude mcp add rvm-docs -- node /path/to/rvm/userguide/mcp/dist/index.js
+```
+
+### MCP Tools (6 tools)
+
+| Tool | Description | Example |
+|------|-------------|---------|
+| `docs_search` | Full-text keyword search across all docs | `{ "query": "witness chain" }` |
+| `docs_navigate` | Browse table of contents or read a chapter | `{ "chapter": "05" }` |
+| `docs_xref` | Find all cross-references for a concept | `{ "concept": "coherence" }` |
+| `docs_glossary` | Look up a term definition | `{ "term": "partition" }` |
+| `docs_api` | Find documentation for an RVM type/function | `{ "symbol": "SecurityGate" }` |
+| `docs_howto` | Task-oriented "I want to..." search | `{ "task": "build rvm" }` |
+
+### CLI Usage
+
+```bash
+cd userguide/mcp
+node dist/cli.js search "capability"      # Full-text search
+node dist/cli.js nav                       # Table of contents
+node dist/cli.js nav 05                    # Read chapter 05
+node dist/cli.js xref "witness"            # Cross-references
+node dist/cli.js glossary "partition"       # Term lookup
+node dist/cli.js api "CapToken"            # API documentation
+node dist/cli.js howto "build rvm"         # Task-oriented guide
+```
+
+### Shorthand Aliases
+
+```bash
+node dist/cli.js s "proof"    # search
+node dist/cli.js n 03         # navigate
+node dist/cli.js x "memory"   # xref
+node dist/cli.js g "EMA"      # glossary
+node dist/cli.js a "verify"   # api
+node dist/cli.js h "deploy"   # howto
+```
+
+</details>
+
+---
+
 ## RuVector Integration
 
 | Crate | Role in RVM |

--- a/userguide/01-quickstart.md
+++ b/userguide/01-quickstart.md
@@ -1,0 +1,219 @@
+# Quick Start: Your First RVM Build in 5 Minutes
+
+This guide takes you from zero to a booted RVM instance in five steps. By the end you will have compiled every crate, run the test suite, executed benchmarks, booted the kernel on a virtual AArch64 machine, and explored the public API.
+
+---
+
+## Prerequisites
+
+You need four things on your machine before you start.
+
+**1. Rust 1.77 or later**
+
+```bash
+rustup update stable
+rustc --version   # should print 1.77.0 or higher
+```
+
+**2. AArch64 bare-metal target**
+
+```bash
+rustup target add aarch64-unknown-none
+```
+
+**3. cargo-binutils (for binary conversion)**
+
+```bash
+cargo install cargo-binutils
+rustup component add llvm-tools
+```
+
+**4. QEMU (for running the kernel)**
+
+```bash
+# macOS
+brew install qemu
+
+# Ubuntu / Debian
+sudo apt install qemu-system-aarch64
+
+# Verify
+qemu-system-aarch64 --version   # should print 8.0 or higher
+```
+
+---
+
+## Step 1: Clone and Build
+
+Clone the repository and verify that all 648 tests pass on your host machine:
+
+```bash
+git clone https://github.com/ruvnet/rvm.git
+cd rvm
+
+# Run all library tests across the workspace
+cargo test --workspace --lib
+```
+
+This command compiles every crate (`rvm-types`, `rvm-hal`, `rvm-cap`, `rvm-witness`, `rvm-proof`, `rvm-partition`, `rvm-sched`, `rvm-memory`, `rvm-coherence`, `rvm-boot`, `rvm-wasm`, `rvm-security`, `rvm-kernel`) and their integration tests. All crates are `#![no_std]` but include conditional `std` support for host testing.
+
+You should see output ending with:
+
+```
+test result: ok. 648 passed; 0 failed; 0 ignored
+```
+
+> **Tip:** If a test fails, check [Troubleshooting](14-troubleshooting.md) for common host-build issues.
+
+---
+
+## Step 2: Run Benchmarks
+
+RVM ships with 21 criterion benchmarks covering every performance-critical path:
+
+```bash
+cargo bench -p rvm-benches
+```
+
+This produces HTML reports in `target/criterion/`. Key benchmarks to look at:
+
+| Benchmark | What It Measures | ADR Target | Typical Result |
+|-----------|-----------------|-----------|----------------|
+| `witness_emit` | Time to emit a 64-byte witness record | < 500 ns | ~17 ns |
+| `p1_verify` | P1 capability check latency | < 1 us | < 1 ns |
+| `p2_pipeline` | Full P2 proof pipeline | < 100 us | ~996 ns |
+| `partition_switch` | Context switch stub | < 10 us | ~6 ns |
+| `mincut_16` | Stoer-Wagner mincut on 16 nodes | < 50 us | ~331 ns |
+| `security_gate_p1` | Unified security gate (P1 tier) | -- | ~17 ns |
+
+> **See also:** [Performance](11-performance.md) for full benchmark analysis and optimization guidance.
+
+---
+
+## Step 3: Build for Bare Metal
+
+Cross-compile the kernel for AArch64:
+
+```bash
+make build
+```
+
+Under the hood this runs:
+
+```bash
+RUSTFLAGS="-C link-arg=-Trvm.ld" \
+    cargo build --target aarch64-unknown-none --release -p rvm-kernel
+```
+
+The linker script `rvm.ld` places the kernel entry point at `0x4000_0000`, which is the address QEMU's `-kernel` flag expects for the `virt` machine.
+
+The output is an ELF binary at:
+
+```
+target/aarch64-unknown-none/release/rvm-kernel
+```
+
+> **See also:** [Bare Metal](12-bare-metal.md) for details on the linker script, EL2 entry, and stage-2 page tables.
+
+---
+
+## Step 4: Boot in QEMU
+
+Launch the kernel in QEMU:
+
+```bash
+make run
+```
+
+This starts QEMU with the following configuration:
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| Machine | `virt` | ARM virtual platform with GICv2, PL011, generic timer |
+| CPU | `cortex-a72` | ARMv8-A with EL2 support |
+| Memory | `128M` | Sufficient for development; Seed profile needs far less |
+| Display | `-nographic` | All output goes to the terminal via PL011 UART |
+
+You should see boot output on your terminal. The kernel executes a 7-phase boot sequence (ADR-137):
+
+```
+Phase 0: Reset vector
+Phase 1: Hardware detect
+Phase 2: MMU setup
+Phase 3: Hypervisor mode (EL2)
+Phase 4: Kernel object init
+Phase 5: First witness (genesis attestation)
+Phase 6: Scheduler entry
+```
+
+Each phase emits a witness record before advancing to the next.
+
+**To exit QEMU:** press `Ctrl-A` then `X`.
+
+> **See also:** [Bare Metal](12-bare-metal.md) for hardware details, [Core Concepts](02-core-concepts.md) for what the boot phases mean.
+
+---
+
+## Step 5: Explore the API
+
+The easiest way to use RVM as a library is to depend on `rvm-kernel`, which re-exports every subsystem crate under a unified namespace:
+
+```toml
+# In your Cargo.toml
+[dependencies]
+rvm-kernel = { path = "crates/rvm-kernel" }
+```
+
+Then import the modules you need:
+
+```rust
+use rvm_kernel::{
+    types,      // Foundation types: PartitionId, Capability, WitnessRecord, etc.
+    cap,        // Capability manager, derivation trees, proof verifier
+    witness,    // Witness log, emitter, hash chain, replay queries
+    proof,      // Proof engine, P1/P2/P3 tiers, TEE pipeline, signers
+    partition,  // Partition manager, lifecycle, IPC, split/merge
+    sched,      // Scheduler, 2-signal priority, SMP coordinator
+    memory,     // Buddy allocator, tier manager, reconstruction pipeline
+    coherence,  // Coherence graph, mincut, scoring, pressure signals
+    boot,       // 7-phase boot sequence, measured boot
+    wasm,       // WebAssembly agent runtime (optional)
+    security,   // Unified security gate, attestation, DMA budgets
+};
+```
+
+Each module corresponds to one crate in the workspace. You can also depend on individual crates directly if you only need a subset:
+
+```toml
+[dependencies]
+rvm-types   = { path = "crates/rvm-types" }
+rvm-cap     = { path = "crates/rvm-cap" }
+rvm-witness = { path = "crates/rvm-witness" }
+```
+
+> **See also:** [Crate Reference](04-crate-reference.md) for the full API surface of each crate.
+
+---
+
+## What's Next?
+
+Now that you have a working build, choose where to go based on what you want to learn:
+
+| Your Goal | Next Chapter |
+|-----------|-------------|
+| Understand the mental model behind RVM | [Core Concepts](02-core-concepts.md) |
+| See how the crates fit together | [Architecture](03-architecture.md) |
+| Write code against the API | [Crate Reference](04-crate-reference.md) |
+| Deploy on real hardware | [Bare Metal](12-bare-metal.md) |
+| Understand the benchmark numbers | [Performance](11-performance.md) |
+| Run WASM agents | [WASM Agents](09-wasm-agents.md) |
+
+---
+
+## Cross-References
+
+- [Core Concepts](02-core-concepts.md) -- what coherence domains, capabilities, and witnesses mean
+- [Architecture](03-architecture.md) -- the four-layer stack and crate dependency graph
+- [Bare Metal](12-bare-metal.md) -- AArch64 details, linker script, EL2, PL011 UART
+- [Performance](11-performance.md) -- full benchmark analysis and tuning
+- [Troubleshooting](14-troubleshooting.md) -- common build errors and QEMU issues

--- a/userguide/02-core-concepts.md
+++ b/userguide/02-core-concepts.md
@@ -1,0 +1,337 @@
+# Core Concepts: How RVM Thinks
+
+This chapter explains the ideas behind RVM in plain language. No code, no API details -- just the mental model you need before diving into any of the technical chapters.
+
+---
+
+## Partitions, Not VMs
+
+A traditional VM emulates a complete computer: CPU, memory controller, network card, disk, BIOS. That abstraction was designed for running Linux or Windows inside a box. AI agents do not need any of that. They need fast isolation, dynamic boundaries, and dense communication.
+
+RVM replaces VMs with **partitions**. A partition is a coherence domain -- a lightweight container that holds:
+
+- A capability table (what this partition is allowed to do)
+- Communication edges to other partitions (who it talks to)
+- Coherence and cut-pressure metrics (how tightly coupled it is)
+- CPU affinity and a VMID assignment (where it runs)
+
+A partition has no emulated hardware, no guest BIOS, and no virtual device model. It is the unit of **scheduling**, **isolation**, **migration**, and **fault containment**.
+
+```
+Traditional VM:
+  +--------------------------+
+  | Guest OS                 |
+  | Virtual NIC, Disk, GPU   |
+  | Emulated BIOS            |
+  +--------------------------+
+  | Hypervisor (KVM, Xen)    |
+  +--------------------------+
+
+RVM Partition:
+  +--------------------------+
+  | Capability table         |
+  | CommEdges (graph links)  |
+  | Coherence score          |
+  +--------------------------+
+  | RVM Kernel (bare Rust)   |
+  +--------------------------+
+```
+
+The key difference: partition boundaries are **dynamic**. When agents inside two partitions start talking heavily, RVM can merge them or migrate one agent closer. When trust drops or coupling weakens, RVM can split a partition along the graph's natural cut boundary. No existing hypervisor can do this.
+
+> **See also:** [Partitions and Scheduling](07-partitions-scheduling.md) for lifecycle states, split/merge semantics, and the 256-partition VMID limit.
+
+---
+
+## Capabilities: Unforgeable Keys
+
+In most operating systems, access control is based on identity: "user X is allowed to read file Y." RVM uses a different model called **capability-based security**. Instead of asking "who are you?", RVM asks "what key do you hold?"
+
+A **capability** is an unforgeable kernel-resident token. It has three parts:
+
+1. **Target** -- the object it grants access to (a partition, memory region, device, etc.)
+2. **Rights** -- a bitmask of what operations are allowed
+3. **Lineage** -- who created this capability and how deep the delegation chain goes
+
+### The 7 Rights
+
+| Right | Meaning |
+|-------|---------|
+| `READ` | Inspect the target object's state |
+| `WRITE` | Mutate the target object's state |
+| `GRANT` | Delegate this capability to another partition (transitive) |
+| `REVOKE` | Revoke a previously granted capability |
+| `EXECUTE` | Invoke the target (run code, send IPC) |
+| `PROVE` | Use the target in a proof context |
+| `GRANT_ONCE` | Delegate exactly once (non-transitive) |
+
+### Monotonic Attenuation
+
+When you delegate a capability, you can only give away rights you already hold, and you can remove rights but never add them. This is called **monotonic attenuation** -- capabilities can only get weaker as they flow through the system, never stronger.
+
+```
+Root capability: READ + WRITE + GRANT + EXECUTE
+        |
+        +---> Delegated: READ + WRITE + EXECUTE   (GRANT removed)
+                    |
+                    +---> Delegated: READ          (WRITE + EXECUTE removed)
+```
+
+### Delegation Depth
+
+To prevent unbounded chains, delegation depth is capped at **8 levels** (DC-3). This means the longest chain from a root capability to a leaf is at most 8 hops.
+
+### Epoch-Based Revocation
+
+Capabilities carry an **epoch counter**. When the kernel increments the epoch (for example, during a security event), all capabilities from the old epoch become stale. This provides a fast, global invalidation mechanism without walking every capability tree.
+
+> **See also:** [Capabilities and Proofs](05-capabilities-proofs.md) for the derivation tree API, P1/P2/P3 verification, and nonce ring details.
+
+---
+
+## Witness Trail: Every Action Recorded
+
+RVM follows a simple rule: **no witness, no mutation**. Every privileged action -- creating a partition, granting a capability, remapping memory, switching context -- emits a witness record *before* the mutation commits. If the witness cannot be written, the mutation does not happen.
+
+### What a Witness Record Looks Like
+
+Each record is exactly **64 bytes**, designed to fit in a single cache line:
+
+```
++-------+-------+--------+-------+--------+--------+---------+---------+----------+----------+-----+
+| seq   | time  | action | proof | flags  | actor  | target  | cap     | payload  | prev     | rec  | aux |
+| (u64) | (u64) | (u8)   | (u8)  | (u16)  | (u32)  | (u32)   | (u32)  | (u64)    | hash     | hash | (u64)|
+|       |       |        |       |        |        |         |        |          | (u64)    | (u64)|     |
++-------+-------+--------+-------+--------+--------+---------+---------+----------+----------+-----+
+  8B      8B      1B       1B      2B       4B       4B        4B       8B         8B         8B    8B
+                                                                                          = 64 bytes
+```
+
+### Hash Chain
+
+Every record includes the hash of the **previous** record in its `prev_hash` field. This creates a tamper-evident chain: if anyone modifies a past record, all subsequent hashes break. The chain uses SHA-256 (with FNV-1a as a lightweight fallback for constrained hardware).
+
+### Performance
+
+Emitting a witness record takes approximately **17 nanoseconds** -- far below the ADR target of 500 ns. The witness log uses a ring buffer that holds 262,144 records (16 MB at 64 bytes each).
+
+### Why It Matters
+
+The witness trail enables three things no other hypervisor provides:
+
+1. **Deterministic replay** -- given a checkpoint and the witness log, you can reconstruct exactly what happened
+2. **Memory time travel** -- dormant memory is rebuilt from witness + checkpoint, not stored as raw bytes
+3. **Forensic queries** -- "which partition mutated this region between 14:00 and 14:05?"
+
+> **See also:** [Witness and Audit](06-witness-audit.md) for the emitter API, HMAC signing, replay queries, and `StrictSigner`.
+
+---
+
+## Proof Gates: Trust but Verify
+
+Every state mutation in RVM must pass through a **proof gate**. This means you cannot remap memory, split a partition, grant a capability, or perform any other privileged operation without presenting a valid proof token.
+
+The proof system has **three tiers**, each trading speed for assurance depth:
+
+### Tier 1: Capability Check (P1)
+
+| Property | Value |
+|----------|-------|
+| Budget | < 1 us |
+| Measured | < 1 ns |
+| What it checks | Does the caller hold a valid capability with the required rights? |
+| When to use | Every routine operation (IPC send, memory read, context switch) |
+
+P1 is a constant-time bitmask comparison. It is the hot path -- it runs on every hypercall.
+
+### Tier 2: Policy Validation (P2)
+
+| Property | Value |
+|----------|-------|
+| Budget | < 100 us |
+| Measured | ~996 ns |
+| What it checks | 6 policy rules (resource limits, partition state, epoch freshness, etc.) |
+| When to use | Cross-partition operations, grants, device leases |
+
+P2 runs a set of policy rules in constant time. It is more expensive than P1 but still sub-microsecond.
+
+### Tier 3: Deep Proof (P3)
+
+| Property | Value |
+|----------|-------|
+| Budget | < 10 ms |
+| What it checks | Full derivation chain walk to root, ancestor integrity, epoch monotonicity |
+| When to use | High-assurance operations, deferred zero-knowledge proofs |
+
+P3 walks the entire capability derivation tree from leaf to root. It is the most expensive tier but provides the strongest guarantee.
+
+```
+Hypercall arrives
+       |
+       v
+  +--------+     fail     +--------+
+  |  P1    |------------->| DENY   |
+  | (caps) |              +--------+
+  +---+----+
+      | pass
+      v
+  +--------+     fail     +--------+
+  |  P2    |------------->| DENY   |
+  |(policy)|              +--------+
+  +---+----+
+      | pass
+      v
+  +--------+
+  | COMMIT | ---> emit witness ---> apply mutation
+  +--------+
+```
+
+> **See also:** [Capabilities and Proofs](05-capabilities-proofs.md) for the proof engine API, TEE pipeline, and cryptographic signers (Ed25519, HMAC-SHA256).
+
+---
+
+## The Coherence Graph
+
+RVM models agent communication as a **weighted graph**. Each partition is a node. Each communication channel between partitions is a **CommEdge** -- a weighted edge whose weight reflects how much traffic flows between the two endpoints.
+
+```
+  Partition A -----(w=150)------- Partition B
+       |                              |
+    (w=20)                        (w=200)
+       |                              |
+  Partition C -----(w=5)-------- Partition D
+```
+
+### Coherence Score
+
+Every partition has a **coherence score** in the range [0.0, 1.0], stored as fixed-point basis points (0..10000). The score measures how much of the partition's communication is *internal* versus *external*:
+
+```
+coherence = internal_weight / total_weight
+```
+
+A score near 1.0 means the partition is well-isolated -- its agents mostly talk to each other. A score near 0.0 means its agents are heavily entangled with other partitions.
+
+### Cut Pressure
+
+When a partition's coherence drops below a threshold, RVM computes **cut pressure** -- a signal that the partition should be split. The coherence engine uses a budgeted Stoer-Wagner mincut algorithm (DC-2: < 50 us per epoch, measured at ~331 ns) to find the optimal cut boundary.
+
+### Split and Merge
+
+- **Split**: when cut pressure exceeds the split threshold, RVM divides the partition along the mincut boundary. Capabilities follow their owning objects (DC-8). Memory regions are assigned using weighted scoring (DC-9).
+- **Merge**: when two adjacent partitions have high mutual coherence and sufficient resources, they can merge into one. Merges require 7 preconditions to be satisfied (DC-11).
+
+### Why a Graph?
+
+The graph is what makes RVM *coherence-native*. Traditional hypervisors treat communication as a side effect. RVM treats it as the primary signal for resource allocation. The scheduler reads coherence scores. The memory tier manager reads them. The split/merge engine reads them. The graph is the source of truth.
+
+> **See also:** [Architecture](03-architecture.md) for where the coherence engine sits in the crate stack, [Partitions and Scheduling](07-partitions-scheduling.md) for split/merge details.
+
+---
+
+## Memory Time Travel
+
+RVM does not use demand paging. Memory is not silently swapped to disk and fetched back on fault. Instead, RVM organizes memory into **four explicit tiers**:
+
+| Tier | Name | Description |
+|------|------|-------------|
+| 0 | **Hot** | Per-core SRAM or L1-adjacent. Always resident during execution. |
+| 1 | **Warm** | Shared DRAM. Resident if the residency rule is met. |
+| 2 | **Dormant** | Compressed checkpoint + delta. Not directly accessible. |
+| 3 | **Cold** | Persistent archival. Accessed only during recovery. |
+
+### Tier Transitions Are Explicit
+
+When the coherence score for a partition drops, its memory regions may be demoted:
+
+```
+Hot ---(coherence drops)---> Warm ---(idle too long)---> Dormant ---(archived)---> Cold
+```
+
+When the memory is needed again, it is **reconstructed**, not demand-paged:
+
+```
+Cold ---> Dormant ---> decompress checkpoint + replay witness deltas ---> Warm ---> Hot
+```
+
+### Why This Matters
+
+Because dormant memory is stored as `checkpoint + witness deltas` rather than raw bytes, RVM can reconstruct **any historical state**. If you have the witness log and the checkpoint, you can answer questions like:
+
+- What was partition 7's memory state at timestamp T?
+- Which agent wrote to address 0x8000 between two specific witness records?
+- What would have happened if we skipped mutation #4,219?
+
+This is what the README calls "memory time travel." No other hypervisor provides this capability.
+
+> **See also:** [Memory Model](08-memory-model.md) for the buddy allocator, tier thresholds, compression, and the reconstruction pipeline API.
+
+---
+
+## The Scheduler's Two Signals
+
+RVM's scheduler combines two signals into a single priority number:
+
+```
+priority = deadline_urgency + cut_pressure_boost
+```
+
+### Signal 1: Deadline Urgency
+
+How close is this partition to missing its deadline? Higher urgency means the partition runs sooner. This is the traditional real-time scheduling signal.
+
+### Signal 2: Cut Pressure Boost
+
+How much structural tension does this partition have in the coherence graph? A partition under high cut pressure needs CPU time to complete its migration or split. The coherence engine feeds this signal directly to the scheduler.
+
+### Three Scheduling Modes
+
+| Mode | Behavior | When Used |
+|------|----------|-----------|
+| **Reflex** | Hard real-time. Bounded local execution only. No cross-partition traffic. | Safety-critical paths (sensor fusion, PLC control) |
+| **Flow** | Normal execution with coherence-aware placement. | Default mode for most agents |
+| **Recovery** | Stabilization. Replay, rollback, split. | After a fault (F1-F3) |
+
+### Degraded Mode
+
+If the coherence engine is unavailable (DC-1 / DC-6), the scheduler falls back to **degraded mode**: it zeros out `cut_pressure_boost` and uses `deadline_urgency` alone. The system still works -- it just loses the ability to make graph-aware placement decisions.
+
+> **See also:** [Partitions and Scheduling](07-partitions-scheduling.md) for the scheduler API, SMP coordination, and per-CPU runqueues.
+
+---
+
+## Design Constraints
+
+RVM's behavior is governed by 15 design constraints (DC-1 through DC-15), defined in ADRs 132-140. These are not guidelines -- they are hard rules enforced by the implementation.
+
+| ID | Constraint | Status |
+|----|-----------|--------|
+| DC-1 | Coherence engine is optional; system degrades gracefully | Implemented |
+| DC-2 | MinCut budget: < 50 us per epoch | Implemented (~331 ns) |
+| DC-3 | Capabilities are unforgeable, monotonically attenuated | Implemented |
+| DC-4 | 2-signal priority: `deadline_urgency + cut_pressure_boost` | Implemented |
+| DC-5 | Three systems cleanly separated (kernel + coherence + agents) | Enforced via features |
+| DC-6 | Degraded mode when coherence unavailable | Implemented |
+| DC-7 | Migration timeout enforcement (100 ms) | Implemented |
+| DC-8 | Capabilities follow objects during partition split | Implemented |
+| DC-9 | Coherence score range [0.0, 1.0] as fixed-point (u16 basis points) | Implemented |
+| DC-10 | Epoch-based witness batching (no per-switch records) | Implemented |
+| DC-11 | Merge requires coherence above threshold + adjacency + resources | Implemented |
+| DC-12 | Max 256 physical VMIDs, multiplexed for >256 partitions | Implemented |
+| DC-13 | WASM is optional; native bare partitions are first class | Enforced |
+| DC-14 | Failure classes: transient (F1), recoverable (F2), permanent (F3), catastrophic (F4) | Implemented |
+| DC-15 | All types are `no_std`, `forbid(unsafe_code)`, `deny(missing_docs)` | Enforced |
+
+> **See also:** [Architecture](03-architecture.md) for how these constraints map to crate boundaries, [Security](10-security.md) for failure class escalation, [Glossary](15-glossary.md) for precise definitions.
+
+---
+
+## Cross-References
+
+- [Architecture](03-architecture.md) -- how the crates implement these concepts
+- [Capabilities and Proofs](05-capabilities-proofs.md) -- deep dive into the 3-tier proof system
+- [Witness and Audit](06-witness-audit.md) -- witness record format, hash chain, signing
+- [Partitions and Scheduling](07-partitions-scheduling.md) -- partition lifecycle, split/merge, scheduler modes
+- [Memory Model](08-memory-model.md) -- four-tier memory, buddy allocator, reconstruction
+- [Security](10-security.md) -- security gate, attestation, failure classes
+- [Glossary](15-glossary.md) -- precise definitions for all RVM-specific terms

--- a/userguide/03-architecture.md
+++ b/userguide/03-architecture.md
@@ -1,0 +1,314 @@
+# Architecture: How RVM Is Built
+
+RVM is composed of 13 Rust crates organized into well-defined layers. Each layer
+has a single responsibility, and dependencies flow strictly downward. This
+chapter explains the layer structure, shows how data flows through the system
+during a hypercall, walks through the seven-phase boot sequence, and catalogues
+the feature flags and platform targets that shape a build.
+
+If you are new to RVM, start with the [Quickstart](01-quickstart.md) and
+[Core Concepts](02-core-concepts.md) chapters first. For a per-crate API
+reference, see [Crate Reference](04-crate-reference.md).
+
+---
+
+## Layer Diagram
+
+The ASCII diagram below shows the crate dependency tree from top to bottom.
+Arrows point from a crate to its dependencies.
+
+```text
+ +-------------------------------------------------------------+
+ |                        rvm-kernel                            |
+ |       (integration crate -- re-exports all 12 subsystems)    |
+ +----+-------------------+-------------------+---------+-------+
+      |                   |                   |         |
+      v                   v                   v         |
+ +----------+       +----------+       +-----------+    |
+ | rvm-boot |       | rvm-sched|       | rvm-memory|    |
+ +----+-----+       +----+-----+       +-----+-----+    |
+      |                   |                   |         |
+      +-------------------+-------------------+         |
+                          |                             |
+                          v                             |
+              +-----------------------+                 |
+              |    rvm-partition      |                 |
+              | (central hub crate)   |                 |
+              +--+------+------+--+--+                 |
+                 |      |      |  |                    |
+      +----------+      |      +----------+            |
+      |          +------+------+          |            |
+      v          v      v      v          v            v
+ +--------+ +--------+ +--------+ +-----------+ +-----------+
+ |rvm-cap | |rvm-wit.| |rvm-prf.| |rvm-secur. | |rvm-coher. |
+ +---+----+ +---+----+ +---+----+ +-----+-----+ +-----+-----+
+     |          |           |            |             |
+     +----------+-----------+------------+-------------+
+                            |
+                            v
+                   +------------------+
+                   |    rvm-types     |
+                   | (foundation --   |
+                   |  zero deps*)     |
+                   +------------------+
+
+ * rvm-types depends only on the bitflags crate.
+
+ Standalone / edge crates (depend on rvm-types only):
+
+ +--------+     +----------+
+ |rvm-hal |     | rvm-wasm |  (optional)
+ +--------+     +----------+
+```
+
+**Reading the diagram:**
+
+- **rvm-kernel** sits at the top. It depends on every other crate and
+  re-exports them as `rvm_kernel::boot`, `rvm_kernel::cap`, and so on.
+- **rvm-boot**, **rvm-sched**, and **rvm-memory** form the mid-layer. They
+  orchestrate initialization, scheduling, and address-space management.
+- **rvm-partition** is the central hub. It defines the partition object that
+  nearly every other crate references.
+- **rvm-cap**, **rvm-witness**, **rvm-proof**, and **rvm-security** form the
+  security layer. Together they enforce capability-based access control,
+  generate audit trails, and gate state transitions with proofs.
+- **rvm-types** is the foundation. It defines shared types such as
+  `PartitionId`, `CapToken`, `WitnessHash`, and `RvmError`. Every crate in
+  the workspace depends on it.
+- **rvm-hal** abstracts platform hardware behind traits. It depends only on
+  `rvm-types` and is used by crates that touch timers, MMU, or interrupts.
+- **rvm-wasm** and **rvm-coherence** are optional. They activate with feature
+  flags and provide WebAssembly guest support and coherence monitoring,
+  respectively.
+
+For details on every exported type in each crate, see
+[Crate Reference](04-crate-reference.md).
+
+---
+
+## Data Flow: Anatomy of a Hypercall
+
+When a guest partition makes a hypercall, the request passes through several
+subsystems before any state mutation occurs. Understanding this pipeline is
+essential for reasoning about security and auditability.
+
+```text
+  Caller (guest partition)
+      |
+      v
+  +-----------------+
+  |  SecurityGate   |  (rvm-security)
+  |  Stage 1: Cap   |----> Does the caller hold a valid CapToken
+  |  Stage 2: Proof |----> Is the proof commitment correct?
+  |  Stage 3: Wit.  |----> Log the decision to the witness ring
+  +-----------------+
+      |
+      | (only if all three stages pass)
+      v
+  +-----------------+
+  |   Partition     |  (rvm-partition)
+  |   Apply the     |
+  |   requested     |
+  |   mutation      |
+  +-----------------+
+      |
+      v
+  State updated
+```
+
+### Stage 1 -- Capability Check
+
+The `SecurityGate` inspects the caller's `CapToken`. A token encodes a
+`CapType` (what resource it grants access to), `CapRights` (which operations
+are allowed), and a delegation depth. The gate verifies that the token has not
+been revoked and that the requested operation falls within the granted rights.
+See [Capabilities and Proofs](05-capabilities-proofs.md) for the full
+capability model.
+
+### Stage 2 -- Proof Verification
+
+State-mutating operations require a `ProofToken` that commits to the
+before-and-after state of the affected resource. The proof engine
+(`rvm-proof`) verifies this commitment at one of three tiers: `Hash` (a
+SHA-256 digest), `Witness` (a signed witness chain), or `Zk` (a
+zero-knowledge proof, reserved for future use). See
+[Capabilities and Proofs](05-capabilities-proofs.md) for proof tiers.
+
+### Stage 3 -- Witness Logging
+
+Regardless of whether the hypercall is allowed or denied, the decision is
+appended to the witness ring buffer (`rvm-witness`). Each `WitnessRecord`
+captures the partition ID, the action kind, a timestamp, and a cryptographic
+signature. This creates a tamper-evident audit trail that can be queried later
+by time range, partition, or action kind. See
+[Witness and Audit](06-witness-audit.md) for querying the log.
+
+### After the Gate
+
+If all three stages pass, the request reaches the target `Partition` in
+`rvm-partition`. The partition manager applies the mutation -- for example,
+mapping a memory region, sending an IPC message, or adjusting a device lease.
+The mutation itself may trigger further witness records.
+
+---
+
+## Boot Sequence: Seven Phases
+
+RVM boots through a deterministic, phased sequence. Each phase is gated: it
+must complete successfully before the next phase begins, and every transition
+is recorded in the witness trail. The `BootTracker` struct in `rvm-boot`
+enforces this ordering at the type level.
+
+| Phase | Name               | What Happens                                          |
+|-------|--------------------|-------------------------------------------------------|
+| 0     | HAL Init           | Initialize the hardware abstraction layer: timer, MMU, and interrupt controller. |
+| 1     | Memory Init        | Bring up the physical page allocator and the buddy allocator. Enumerate available RAM. |
+| 2     | Capability Init    | Create the root capability table with `DEFAULT_CAP_TABLE_CAPACITY` (256) slots. |
+| 3     | Witness Init       | Initialize the witness ring buffer (`DEFAULT_RING_CAPACITY` = 262,144 entries) and emit the genesis record. |
+| 4     | Scheduler Init     | Set up per-CPU run queues and the SMP coordinator. Choose the initial `SchedulerMode`. |
+| 5     | Root Partition     | Create the root partition with full capabilities. This is the first partition and the parent of all others. |
+| 6     | Handoff            | Transfer control to the root partition's entry point. Boot is complete. |
+
+```text
+  Phase 0      Phase 1      Phase 2       Phase 3      Phase 4      Phase 5       Phase 6
+  HAL Init --> Memory   --> Capability --> Witness  --> Scheduler --> Root Part --> Handoff
+               Init         Init           Init         Init         Creation
+     |            |            |              |            |             |            |
+     +--- witness record ---  witness record  --- witness record ---  witness record -+
+```
+
+Each phase transition produces a witness record. If the `crypto-sha256`
+feature is enabled, the `MeasuredBootState` accumulates a hash chain over all
+phase measurements, providing a boot attestation similar to a TPM PCR extend
+operation. See [Bare-Metal Deployment](12-bare-metal.md) for how to verify
+measured boot on real hardware.
+
+---
+
+## Feature Flags
+
+RVM uses Cargo feature flags to control binary size and functionality. All
+features propagate from `rvm-kernel` down to the relevant subsystem crate.
+
+| Flag               | Default | Effect                                                    |
+|--------------------|---------|-----------------------------------------------------------|
+| `std`              | off     | Enables `std` across all 12 subsystem crates. Only needed for hosted testing or user-space mode. |
+| `alloc`            | off     | Enables `alloc` across all 12 subsystem crates. Permits heap allocation in crates that support it. |
+| `wasm`             | off     | Activates the WebAssembly guest runtime in `rvm-wasm`. See [WASM Agents](09-wasm-agents.md). |
+| `coherence`        | off     | Activates the coherence monitoring engine in `rvm-coherence`. See [Core Concepts](02-core-concepts.md). |
+| `coherence-sched`  | off     | Enables the feedback loop between `rvm-coherence` and `rvm-sched`, so coherence scores influence scheduling priority. |
+| `crypto-sha256`    | **on**  | Enables SHA-256 hashing and HMAC signing in `rvm-witness` and `rvm-proof`. Pulls in `sha2` and `hmac`. |
+| `ed25519`          | off     | Enables Ed25519 signature verification in `rvm-proof`. Pulls in `ed25519-dalek`. Implies `crypto-sha256`. |
+| `strict-signing`   | **on**  | Enforces that every witness record must be signed. Disabling this (with `null-signer`) is only appropriate for testing. |
+| `null-signer`      | off     | Allows unsigned witness records. **Do not use in production.** |
+
+To build with no optional features:
+
+```bash
+cargo build --no-default-features
+```
+
+To build with the coherence engine and Ed25519 proofs:
+
+```bash
+cargo build --features coherence,ed25519
+```
+
+See [Performance](11-performance.md) for how feature flags affect binary size
+and runtime overhead, and [Security](10-security.md) for guidance on which
+flags are safe to disable.
+
+---
+
+## Design Principles
+
+Five principles guide every design decision in RVM.
+
+### 1. `#![no_std]` Everywhere
+
+Every crate in the workspace is `no_std` by default. This means RVM can run on
+bare metal without an operating system, on microcontrollers with no heap, and
+inside firmware environments. The `std` and `alloc` feature flags opt in to
+hosted functionality when needed for testing or user-space deployment.
+
+### 2. `#![forbid(unsafe_code)]`
+
+No crate in the workspace contains `unsafe` blocks. All hardware interaction
+is abstracted behind safe trait boundaries in `rvm-hal`. When RVM runs on real
+hardware, the platform-specific HAL implementation (outside this workspace)
+provides the necessary `unsafe` implementations. Inside the hypervisor itself,
+the type system enforces correctness.
+
+### 3. `#![deny(missing_docs)]`
+
+Every public item must have a documentation comment. This is enforced by the
+compiler. If you add a public type or function without a doc comment, the build
+fails.
+
+### 4. Zero Heap by Default
+
+When built without the `alloc` feature, RVM uses only stack and static
+allocations. All core data structures -- capability tables, witness ring
+buffers, partition arrays, scheduler queues -- use fixed-capacity arrays. This
+makes memory usage predictable and eliminates allocation failure as a failure
+mode.
+
+### 5. `Copy + Clone + Eq` Types
+
+The foundation types in `rvm-types` are designed to be small, copyable value
+types. A `PartitionId` is a `u16`. A `CapToken` is a fixed-size struct.
+Passing these types around never involves heap allocation, reference counting,
+or lifetime complexity. This keeps the API surface simple and the generated
+code efficient.
+
+---
+
+## Platform Targets
+
+RVM targets three deployment profiles, each with different resource budgets and
+use cases.
+
+### Seed (64 KB -- 1 MB RAM)
+
+The Seed profile targets microcontrollers and deeply embedded systems. At this
+scale, RVM runs with `no_std` and no allocator. All data structures use their
+default fixed capacities: 256 capability slots, 256 partitions, and a witness
+ring sized to fit available memory.
+
+Typical use cases: sensor hubs, secure enclaves, IoT gateways.
+
+See [Bare-Metal Deployment](12-bare-metal.md) for flashing instructions.
+
+### Appliance (1 -- 32 GB RAM)
+
+The Appliance profile targets edge servers, single-board computers, and
+embedded PCs. At this scale, RVM can enable the `alloc` feature for dynamic
+partition creation and the `coherence` feature for live system monitoring. The
+`wasm` feature enables hosting WebAssembly agents as lightweight guests.
+
+Typical use cases: edge inference nodes, network appliances, multi-agent
+orchestrators.
+
+See [WASM Agents](09-wasm-agents.md) for running agents on the Appliance
+profile.
+
+### Chip (Future Silicon)
+
+The Chip profile is a forward-looking target for hardware implementations of
+RVM concepts. It envisions coherence monitoring, capability checking, and
+witness logging implemented in silicon, with RVM as the reference software
+model. This profile is not yet available.
+
+---
+
+## Where to Go Next
+
+- **Per-crate API details:** [Crate Reference](04-crate-reference.md)
+- **Capabilities and proofs in depth:** [Capabilities and Proofs](05-capabilities-proofs.md)
+- **Witness trail queries:** [Witness and Audit](06-witness-audit.md)
+- **Partition lifecycle and scheduling:** [Partitions and Scheduling](07-partitions-scheduling.md)
+- **Memory regions and tiers:** [Memory Model](08-memory-model.md)
+- **Security hardening guidance:** [Security](10-security.md)
+- **Performance tuning:** [Performance](11-performance.md)
+- **Bare-metal deployment:** [Bare-Metal Deployment](12-bare-metal.md)
+- **Full cross-reference index:** [Cross-Reference](cross-reference.md)

--- a/userguide/04-crate-reference.md
+++ b/userguide/04-crate-reference.md
@@ -1,0 +1,521 @@
+# Crate Reference: All 13 RVM Crates
+
+This chapter provides a concise reference for every crate in the RVM workspace.
+Each section describes what the crate does, lists its key public types, notes
+its feature flags and internal dependencies, and points to the chapter with
+deeper coverage.
+
+For the big picture of how these crates fit together, see
+[Architecture](03-architecture.md). For a quick setup guide, see
+[Quickstart](01-quickstart.md).
+
+---
+
+## 1. rvm-types
+
+**Foundation types for the entire hypervisor.**
+
+`rvm-types` defines every shared type used across the workspace. It has no
+dependencies on other RVM crates and only one external dependency (`bitflags`),
+making it the stable foundation that all other crates build on. If you are
+reading RVM source code for the first time, start here.
+
+**Key public types:**
+
+- `PartitionId` -- 16-bit identifier for a partition
+- `VcpuId` -- virtual CPU identifier
+- `CapRights`, `CapToken`, `CapType`, `Capability`, `CapabilityId` -- capability model primitives
+- `WitnessHash`, `WitnessRecord`, `ActionKind` -- witness trail types
+- `CoherenceScore`, `CommEdge`, `CutPressure`, `PhiValue` -- coherence monitoring types
+- `PartitionConfig`, `PartitionState` -- partition lifecycle types
+- `MemoryRegion`, `MemoryTier` -- memory model types
+- `DeviceLease` -- device assignment type
+- `ProofResult`, `ProofTier`, `ProofToken` -- proof engine types
+- `Priority`, `SchedulerMode` -- scheduling types
+- `FailureClass`, `RecoveryCheckpoint` -- fault recovery types
+- `RvmConfig` -- top-level configuration
+- `RvmError`, `RvmResult` -- error handling
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** None (only `bitflags`)
+
+**See also:** [Core Concepts](02-core-concepts.md) for how these types model
+the hypervisor's domain, [Glossary](15-glossary.md) for definitions.
+
+---
+
+## 2. rvm-hal
+
+**Hardware abstraction layer.**
+
+`rvm-hal` defines the trait boundaries between RVM and the underlying hardware
+platform. It does not contain any hardware-specific code itself; instead, it
+specifies what a platform implementation must provide. A bare-metal deployment
+supplies a concrete implementation of these traits; the test suite uses stubs.
+
+**Key public traits:**
+
+- `Platform` -- top-level platform trait: `cpu_count()`, `total_memory()`, `halt()`
+- `MmuOps` -- memory management unit: `map_page()`, `unmap_page()`, `translate()`, `flush_tlb()`
+- `TimerOps` -- timer access: `now_ns()`, `set_deadline_ns()`, `cancel_deadline()`
+- `InterruptOps` -- interrupt controller: `enable()`, `disable()`, `acknowledge()`, `end_of_interrupt()`
+
+**Modules:**
+
+- `aarch64` -- type stubs for AArch64 bare-metal targets
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** `rvm-types`
+
+**See also:** [Bare-Metal Deployment](12-bare-metal.md) for writing a HAL
+implementation, [Architecture](03-architecture.md) for where `rvm-hal` sits in
+the dependency tree.
+
+---
+
+## 3. rvm-cap
+
+**Capability-based access control.**
+
+`rvm-cap` manages the capability tables that control which partitions can
+access which resources. Capabilities form a derivation tree: a parent
+capability can delegate a subset of its rights to a child, up to a configurable
+maximum delegation depth. Revocation cascades from parent to all descendants.
+
+**Key public types and functions:**
+
+- `CapabilityManager` -- top-level manager for creating, delegating, and revoking capabilities
+- `CapabilityTable` -- per-partition table mapping `CapabilityId` to `Capability`
+- `DerivationTree` -- tracks parent-child relationships for cascading revocation
+- `ProofVerifier` -- verifies proof tokens against capability state
+- `GrantPolicy` -- policy for whether a delegation request should be allowed
+- `revoke_single()` -- revoke a single capability and its descendants
+
+**Constants:**
+
+- `DEFAULT_MAX_DELEGATION_DEPTH` = 8
+- `DEFAULT_CAP_TABLE_CAPACITY` = 256
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** `rvm-types`, `spin`
+
+**See also:** [Capabilities and Proofs](05-capabilities-proofs.md) for the
+full capability model, [Security](10-security.md) for hardening guidance.
+
+---
+
+## 4. rvm-witness
+
+**Tamper-evident witness logging.**
+
+`rvm-witness` maintains an append-only ring buffer of `WitnessRecord` entries.
+Every security decision, partition lifecycle event, and state transition is
+logged here. Records are cryptographically signed (when the `crypto-sha256`
+feature is enabled) and can be chained to detect tampering.
+
+**Key public types and functions:**
+
+- `WitnessEmitter` -- emits new witness records into the log
+- `WitnessLog` -- the ring buffer holding all records
+- `WitnessRecord` -- a single audit entry: partition, action, timestamp, signature
+- `verify_chain()` -- verify the cryptographic integrity of a range of records
+- `query_by_partition()` -- filter records by partition ID
+- `query_by_action_kind()` -- filter records by action type
+- `query_by_time_range()` -- filter records by timestamp range
+
+**Signers:**
+
+- `DefaultSigner` -- HMAC-SHA256 signer (requires `crypto-sha256`)
+- `StrictSigner` -- enforces non-null signatures (default behavior with `strict-signing`)
+- `HmacWitnessSigner` -- explicit HMAC-based signer for witness records
+
+**Constants:**
+
+- `DEFAULT_RING_CAPACITY` = 262,144 entries
+
+**Feature flags:** `std`, `alloc`, `crypto-sha256` (on by default),
+`strict-signing` (on by default), `null-signer` (off -- testing only)
+
+**Workspace dependencies:** `rvm-types`, `spin`, optionally `sha2` and `hmac`
+
+**See also:** [Witness and Audit](06-witness-audit.md) for querying and
+verifying the witness trail, [Security](10-security.md) for why
+`null-signer` should never be used in production.
+
+---
+
+## 5. rvm-proof
+
+**Proof-gated state transitions.**
+
+`rvm-proof` ensures that every state-mutating operation in the hypervisor is
+backed by a verifiable proof. Proofs operate at three tiers of increasing
+strength. The crate also provides software TEE (Trusted Execution Environment)
+support for environments that lack hardware TEE.
+
+**Key public types and functions:**
+
+- `ProofTier` -- the three proof tiers: `Hash`, `Witness`, `Zk`
+- `Proof` -- a proof object containing tier, data hash, and optional signature
+- `verify()` -- verify a standalone proof
+- `verify_with_cap()` -- verify a proof in the context of a capability
+- `compute_data_hash()` -- compute the SHA-256 hash of a data buffer
+
+**TEE support:**
+
+- `SoftwareTeeProvider` -- software-emulated TEE for development and testing
+- `SoftwareTeeVerifier` -- verifies attestations from the software TEE
+- `TeeWitnessSigner` -- signs witness records using TEE-derived keys
+
+**Modules:**
+
+- `policy` -- proof policy engine with a context builder for constructing policy decisions
+
+**Feature flags:** `std`, `alloc`, `crypto-sha256` (on by default),
+`ed25519` (off -- adds Ed25519 signature support via `ed25519-dalek`),
+`strict-signing` (on by default), `null-signer` (off -- testing only)
+
+**Workspace dependencies:** `rvm-types`, `rvm-cap`, `rvm-witness`, `spin`,
+`subtle`, optionally `sha2`, `hmac`, `ed25519-dalek`
+
+**See also:** [Capabilities and Proofs](05-capabilities-proofs.md) for proof
+tiers and verification flow, [Security](10-security.md) for TEE attestation
+guidance.
+
+---
+
+## 6. rvm-partition
+
+**Partition lifecycle and communication.**
+
+`rvm-partition` defines the partition -- the fundamental isolation boundary in
+RVM. A partition owns a set of memory regions, capabilities, virtual CPUs, and
+device leases. This crate also manages inter-partition communication (IPC) via
+message queues and scored region assignment for partition split and merge.
+
+**Key public types:**
+
+- `PartitionManager` -- creates, destroys, and queries partitions
+- `Partition` -- the partition object itself
+- `CapabilityTable` -- per-partition capability storage (delegated from `rvm-cap`)
+- `CommEdge` -- a communication edge between two partitions in the coherence graph
+- `IpcManager` -- manages IPC channels between partitions
+- `MessageQueue` -- bounded message queue for inter-partition messages
+- `DeviceLeaseManager` -- assigns and revokes device leases to partitions
+
+**Operations:**
+
+- Split: `scored_region_assignment()` -- assigns memory regions to child partitions based on scoring
+- Merge: `merge_preconditions_met()` -- checks whether two partitions can be safely merged
+
+**Constants:**
+
+- `MAX_PARTITIONS` = 256
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** `rvm-types`, `rvm-cap`, `rvm-witness`, `spin`
+
+**See also:** [Partitions and Scheduling](07-partitions-scheduling.md) for the
+full partition lifecycle, [Memory Model](08-memory-model.md) for how partitions
+own memory regions.
+
+---
+
+## 7. rvm-sched
+
+**Coherence-aware scheduler.**
+
+`rvm-sched` assigns virtual CPUs to physical CPUs. It supports three
+scheduling modes that adapt to the current system state. When the `coherence`
+feature is enabled at the kernel level, the scheduler can receive coherence
+feedback to prioritize partitions that contribute to overall system coherence.
+
+**Key public types and functions:**
+
+- `Scheduler` -- the top-level scheduler interface
+- `PerCpuScheduler` -- per-physical-CPU run queue and dispatch logic
+- `SmpCoordinator` -- coordinates scheduling decisions across multiple CPUs
+- `EpochTracker` -- tracks scheduling epochs for fairness and starvation prevention
+- `SchedulerMode` -- the three modes: `Reflex` (low-latency), `Flow` (throughput), `Recovery` (fault handling)
+- `compute_priority()` -- compute the effective priority for a partition based on base priority, coherence score, and mode
+- `partition_switch()` -- perform a context switch between partitions
+
+**Context switch types:**
+
+- `SwitchContext` -- captures the state needed for a partition switch
+- `SwitchResult` -- the outcome of a switch attempt
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** `rvm-types`, `rvm-partition`, `rvm-witness`, `spin`
+
+**See also:** [Partitions and Scheduling](07-partitions-scheduling.md) for
+scheduling modes and priority computation,
+[Performance](11-performance.md) for tuning scheduler parameters.
+
+---
+
+## 8. rvm-memory
+
+**Memory management and address spaces.**
+
+`rvm-memory` manages physical memory allocation and guest physical address
+spaces. It provides a buddy allocator for page-level allocation, a region
+manager for tracking which memory regions belong to which partitions, and a
+tiered memory system that classifies memory by access frequency.
+
+**Key public types and functions:**
+
+- `BuddyAllocator` -- power-of-two page allocator
+- `TierManager` -- classifies memory regions into four tiers: `Hot`, `Warm`, `Dormant`, `Cold`
+- `RegionManager` -- tracks ownership and permissions of memory regions
+- `ReconstructionPipeline` -- reconstructs memory state after a partition crash or migration
+- `MemoryRegion` -- describes a contiguous range of physical memory
+- `MemoryPermissions` -- read/write/execute permission flags
+- `validate_region()` -- checks that a memory region is well-formed
+- `regions_overlap()` -- checks whether two guest regions overlap
+- `regions_overlap_host()` -- checks whether a guest region overlaps a host-reserved range
+
+**Constants:**
+
+- `PAGE_SIZE` = 4096 bytes
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** `rvm-types`
+
+**See also:** [Memory Model](08-memory-model.md) for the full memory
+architecture, [Bare-Metal Deployment](12-bare-metal.md) for physical memory
+layout on real hardware.
+
+---
+
+## 9. rvm-coherence
+
+**Coherence monitoring and Phi computation.**
+
+`rvm-coherence` implements the coherence monitoring engine that distinguishes
+RVM from traditional hypervisors. It models the partition communication
+topology as a graph and computes coherence metrics inspired by Integrated
+Information Theory (IIT). These metrics can feed back into the scheduler to
+prioritize partitions that contribute to system-wide coherence.
+
+**Key public types and functions:**
+
+- `CoherenceGraph` -- a graph of partitions connected by communication edges
+- `EmaFilter` -- exponential moving average filter for smoothing sensor readings
+- `MinCutBridge` -- computes the minimum cut of the coherence graph using a Stoer-Wagner heuristic
+- `CoherenceEngine` -- computes coherence scores from the graph topology
+- `AdaptiveCoherenceEngine` -- extends `CoherenceEngine` with adaptive thresholds and hysteresis
+- `SensorReading` -- a raw coherence measurement from a partition pair
+- `phi_to_coherence_bp()` -- converts a raw Phi value to a coherence score in basis points
+
+**Feature flags:** `std`, `alloc`, `sched` (enables scheduler integration via
+`rvm-sched`), `ruvector` (enables bridge to external ruvector crates)
+
+**Workspace dependencies:** `rvm-types`, `rvm-partition`, optionally `rvm-sched`
+
+**See also:** [Core Concepts](02-core-concepts.md) for what coherence means in
+RVM, [Advanced and Exotic Features](13-advanced-exotic.md) for the Phi
+computation algorithm, [Partitions and Scheduling](07-partitions-scheduling.md)
+for how coherence scores influence scheduling.
+
+---
+
+## 10. rvm-boot
+
+**Deterministic boot sequence.**
+
+`rvm-boot` orchestrates the seven-phase boot sequence that brings RVM from
+reset to a running system. Each phase is gated: it must complete before the
+next begins, and every transition is recorded in the witness trail. The crate
+also supports measured boot, where a hash chain accumulates over all phase
+measurements to produce a boot attestation.
+
+**Key public types and functions:**
+
+- `BootTracker` -- tracks progress through the seven boot phases
+- `BootPhase` -- enum of the seven phases: `HalInit`, `MemoryInit`, `CapabilityInit`, `WitnessInit`, `SchedulerInit`, `RootPartition`, `Handoff`
+- `BootSequence` -- the full boot sequence executor (ADR-137)
+- `BootContext` -- context object passed between boot phases
+- `MeasuredBootState` -- hash-chain accumulator for boot attestation
+- `run_boot_sequence()` -- execute the complete boot sequence
+- `BootStage`, `PhaseTiming` -- boot stage metadata and timing information
+
+**HAL initialization:**
+
+- `HalInit` -- trait that a platform must implement to initialize hardware during Phase 0
+- `StubHal` -- stub implementation for testing
+- `UartConfig`, `MmuConfig`, `InterruptConfig` -- configuration types for HAL initialization
+
+**Feature flags:** `std`, `alloc`, `crypto-sha256` (on by default, enables
+measured boot hash chain)
+
+**Workspace dependencies:** `rvm-types`, `rvm-hal`, `rvm-partition`,
+`rvm-witness`, `rvm-sched`, `rvm-memory`, `subtle`, optionally `sha2`
+
+**See also:** [Architecture](03-architecture.md) for the boot phase table,
+[Bare-Metal Deployment](12-bare-metal.md) for booting on real hardware,
+[Security](10-security.md) for measured boot verification.
+
+---
+
+## 11. rvm-wasm
+
+**WebAssembly guest runtime.**
+
+`rvm-wasm` provides an optional WebAssembly runtime for hosting lightweight
+agents inside RVM partitions. It validates Wasm modules, manages agent
+lifecycle (load, validate, run, terminate), supports live migration between
+partitions, and enforces resource quotas to prevent a misbehaving agent from
+starving other workloads.
+
+**Key public types and functions:**
+
+- `WasmModuleInfo` -- metadata about a loaded Wasm module
+- `WasmModuleState` -- lifecycle states: `Loaded`, `Validated`, `Running`, `Terminated`
+- `validate_module()` -- validates a Wasm binary for structural correctness and safety
+- `WasmSectionId` -- identifies sections within a Wasm module
+
+**Modules:**
+
+- Agent lifecycle management (load, start, stop, terminate)
+- Migration support (snapshot state, transfer, resume)
+- Quota enforcement (memory limits, instruction budgets)
+
+**Constants:**
+
+- `MAX_MODULE_SIZE` = 1 MB
+
+**Feature flags:** `std`, `alloc` (both off by default)
+
+**Workspace dependencies:** `rvm-types`, `rvm-partition`, `rvm-cap`, `rvm-witness`
+
+**See also:** [WASM Agents](09-wasm-agents.md) for writing and deploying Wasm
+agents, [Partitions and Scheduling](07-partitions-scheduling.md) for how Wasm
+agents interact with the partition model.
+
+---
+
+## 12. rvm-security
+
+**Unified security gate.**
+
+`rvm-security` is the single entry point for all security policy enforcement
+in RVM. Every hypercall passes through its three-stage gate: capability check,
+proof verification, and witness logging. The crate also provides input
+validation, attestation chain management, and DMA/resource budget enforcement.
+
+**Key public types and functions:**
+
+- `SecurityGate`, `SignedSecurityGate` -- the three-stage security gate (the signed variant uses cryptographic witness signatures)
+- `GateRequest`, `GateResponse` -- request and response types for the gate
+- `PolicyDecision` -- `Allow` or `Deny(RvmError)`
+- `PolicyRequest` -- lightweight policy evaluation request
+- `SecurityError` -- security-specific error type
+- `P3WitnessChain` -- witness chain for Phase 3 (witness logging stage) of the gate
+
+**Attestation:**
+
+- `AttestationChain` -- chain of attestation reports for platform verification
+- `AttestationReport` -- a single attestation measurement
+- `verify_attestation()` -- verify an attestation chain
+
+**Resource control:**
+
+- `DmaBudget` -- limits on DMA transfers per partition
+- `ResourceQuota` -- general resource quotas (memory, CPU time, I/O bandwidth)
+
+**Modules:**
+
+- `gate` -- the unified security gate implementation
+- `validation` -- input validation for security-critical parameters
+- `attestation` -- attestation chain and report generation
+- `budget` -- DMA and resource budget enforcement
+
+**Feature flags:** `std`, `alloc`, `crypto-sha256` (on by default)
+
+**Workspace dependencies:** `rvm-types`, `rvm-witness`, `subtle`, optionally `sha2`
+
+**See also:** [Architecture](03-architecture.md) for the hypercall data flow
+through the gate, [Security](10-security.md) for security hardening guidance,
+[Capabilities and Proofs](05-capabilities-proofs.md) for the capability and
+proof models that the gate enforces.
+
+---
+
+## 13. rvm-kernel
+
+**Top-level integration crate.**
+
+`rvm-kernel` wires all 12 subsystem crates together into a single API surface.
+It re-exports every subsystem under a short module name (e.g.,
+`rvm_kernel::cap`, `rvm_kernel::witness`), defines the `VERSION` constant, and
+provides the signer bridge (ADR-142) that connects the 64-byte proof-crate
+signer to the 8-byte witness-crate signer.
+
+**Key public items:**
+
+- `VERSION` -- the current RVM version string (from `Cargo.toml`)
+- `CRATE_COUNT` -- the number of subsystem crates (13)
+- Module re-exports: `boot`, `cap`, `coherence`, `hal`, `memory`, `partition`, `proof`, `sched`, `security`, `types`, `wasm`, `witness`
+
+**Signer bridge (ADR-142):**
+
+- `signer_bridge::CryptoSignerAdapter<S>` -- wraps a 64-byte proof-crate `WitnessSigner` and adapts it to the 8-byte witness-crate `WitnessSigner` interface by computing a SHA-256 digest and truncating the signature
+
+**Feature flags:** `std`, `alloc`, `wasm`, `coherence`, `coherence-sched`,
+`crypto-sha256` (on by default). All `std` and `alloc` flags propagate to
+every subsystem crate.
+
+**Workspace dependencies:** All 12 subsystem crates.
+
+**See also:** [Architecture](03-architecture.md) for how `rvm-kernel` sits
+atop the dependency tree, [Quickstart](01-quickstart.md) for building and
+running RVM, [README](README.md) for the project overview.
+
+---
+
+## Dependency Summary
+
+The table below shows which RVM crates each crate depends on. External
+dependencies (`bitflags`, `spin`, `sha2`, `hmac`, `subtle`, `ed25519-dalek`,
+`lz4_flex`) are not listed.
+
+| Crate          | Depends on                                              |
+|----------------|---------------------------------------------------------|
+| rvm-types      | *(none)*                                                |
+| rvm-hal        | rvm-types                                               |
+| rvm-cap        | rvm-types                                               |
+| rvm-witness    | rvm-types                                               |
+| rvm-proof      | rvm-types, rvm-cap, rvm-witness                         |
+| rvm-partition  | rvm-types, rvm-cap, rvm-witness                         |
+| rvm-sched      | rvm-types, rvm-partition, rvm-witness                   |
+| rvm-memory     | rvm-types                                               |
+| rvm-coherence  | rvm-types, rvm-partition, optionally rvm-sched          |
+| rvm-boot       | rvm-types, rvm-hal, rvm-partition, rvm-witness, rvm-sched, rvm-memory |
+| rvm-wasm       | rvm-types, rvm-partition, rvm-cap, rvm-witness          |
+| rvm-security   | rvm-types, rvm-witness                                  |
+| rvm-kernel     | *all 12 above*                                          |
+
+---
+
+## Where to Go Next
+
+- **How the crates fit together:** [Architecture](03-architecture.md)
+- **Capabilities and proof tiers:** [Capabilities and Proofs](05-capabilities-proofs.md)
+- **Witness trail in depth:** [Witness and Audit](06-witness-audit.md)
+- **Partition lifecycle:** [Partitions and Scheduling](07-partitions-scheduling.md)
+- **Memory regions and allocation:** [Memory Model](08-memory-model.md)
+- **WebAssembly agents:** [WASM Agents](09-wasm-agents.md)
+- **Security hardening:** [Security](10-security.md)
+- **Performance tuning:** [Performance](11-performance.md)
+- **Running on bare metal:** [Bare-Metal Deployment](12-bare-metal.md)
+- **Exotic features and Phi:** [Advanced and Exotic Features](13-advanced-exotic.md)
+- **Troubleshooting:** [Troubleshooting](14-troubleshooting.md)
+- **Term definitions:** [Glossary](15-glossary.md)
+- **Full cross-reference:** [Cross-Reference](cross-reference.md)

--- a/userguide/05-capabilities-proofs.md
+++ b/userguide/05-capabilities-proofs.md
@@ -1,0 +1,422 @@
+# Capabilities and Proofs: RVM's Trust Model
+
+Every resource in RVM -- a partition, a memory region, a device lease, a communication edge -- is accessed through an **unforgeable capability token**. No pointer, no file descriptor, no ambient authority. If you do not hold a capability with the right bits set, the kernel will not let you touch the object. This chapter explains what capabilities are, how they propagate, and how the three-tier proof system binds every mutation to a verifiable commitment.
+
+> **Prerequisite reading:** [Core Concepts](02-core-concepts.md) for an overview of the trust model. [Architecture](03-architecture.md) for crate layering.
+
+---
+
+## 1. Understanding Capabilities
+
+A **capability** is a kernel-managed, unforgeable token that grants specific rights over a specific object. Unlike traditional permission checks ("is this user in group X?"), capabilities are explicit: you either hold one, or you do not. They cannot be forged, guessed, or manufactured outside the kernel.
+
+### The 7 Rights
+
+Every capability carries a **rights bitmask** (`CapRights`). The seven possible rights are:
+
+| Right | Bit | Meaning |
+|-------|-----|---------|
+| `READ` | `0x01` | Inspect or read the resource |
+| `WRITE` | `0x02` | Mutate the resource |
+| `GRANT` | `0x04` | Copy (delegate) this capability to another partition |
+| `REVOKE` | `0x08` | Revoke capabilities derived from this one |
+| `EXECUTE` | `0x10` | Execute code within the resource's context |
+| `PROVE` | `0x20` | Create a proof referencing this capability |
+| `GRANT_ONCE` | `0x40` | One-time grant: consumed after a single delegation |
+
+Rights are combined with bitwise OR. A partition that holds `READ | WRITE` on a region can read and write it, but cannot delegate it (no `GRANT`), cannot revoke children (no `REVOKE`), and cannot use it as evidence in a proof (no `PROVE`).
+
+### Capability Types (`CapType`)
+
+Each capability targets a specific kind of kernel object:
+
+| CapType | Discriminant | Controls |
+|---------|-------------|----------|
+| `Partition` | 0 | Create, destroy, split, merge partitions |
+| `Region` | 1 | Map, transfer, tier-change memory regions |
+| `CommEdge` | 2 | Create, destroy, send on communication edges |
+| `Device` | 3 | Grant, revoke, renew device leases |
+| `Scheduler` | 4 | Mode switch, priority override |
+| `WitnessLog` | 5 | Query, export the witness trail |
+| `Proof` | 6 | Escalation, deep proof verification |
+| `Vcpu` | 7 | Virtual CPU control |
+| `Coherence` | 8 | Coherence observer operations |
+
+### The `CapToken` Struct
+
+A `CapToken` is the user-visible handle. It holds four fields:
+
+```rust
+pub struct CapToken {
+    id: u64,           // Globally unique identifier
+    cap_type: CapType, // What kind of object this targets
+    rights: CapRights, // What operations are permitted
+    epoch: u32,        // Monotonic epoch for staleness detection
+}
+```
+
+Create one like this:
+
+```rust
+let token = CapToken::new(
+    1,                                        // capability ID
+    CapType::Partition,                       // targets a partition
+    CapRights::READ | CapRights::WRITE,       // can read and write
+    0,                                        // epoch 0
+);
+
+assert!(token.has_rights(CapRights::READ));   // true
+assert!(!token.has_rights(CapRights::GRANT)); // false -- not granted
+```
+
+The `epoch` field is critical for revocation: when the kernel advances its epoch counter, any token minted in a prior epoch becomes stale and is rejected at P1 verification.
+
+---
+
+## 2. Delegation and Derivation Trees
+
+Capabilities propagate through **delegation**. When Partition A holds a capability and grants it to Partition B, a new derived capability is created. The derivation forms a tree:
+
+```
+Root (owner: Hypervisor, rights: ALL, depth: 0)
+  |
+  +-- Child A (owner: Partition 1, rights: READ|WRITE|GRANT, depth: 1)
+  |     |
+  |     +-- Grandchild (owner: Partition 2, rights: READ, depth: 2)
+  |
+  +-- Child B (owner: Partition 3, rights: READ, depth: 1)
+```
+
+### Monotonic Attenuation
+
+A child capability can only have **equal or fewer** rights than its parent. You cannot escalate. If a parent holds `READ | WRITE | GRANT`, it can grant `READ` or `READ | WRITE`, but never `EXECUTE` (which it does not hold).
+
+This is enforced in the `validate_grant` function during every delegation.
+
+### Maximum Delegation Depth
+
+The delegation depth is bounded at **8 levels** (`MAX_DELEGATION_DEPTH = 8`). Each derivation increments the depth counter. When depth reaches the limit, further grants are rejected with `CapError::DelegationDepthExceeded`. This prevents unbounded authority chains that would complicate revocation and audit.
+
+### `GRANT_ONCE` for Non-Transitive Delegation
+
+The `GRANT_ONCE` right enables a single delegation and is then consumed from the source. After Partition A grants a `GRANT_ONCE` capability to Partition B, the `GRANT_ONCE` bit is cleared from A's copy. B cannot re-delegate it further (unless B's copy also carries `GRANT` or `GRANT_ONCE`).
+
+This provides a clean non-transitive delegation pattern: "I give you this right, but you cannot pass it on."
+
+### Epoch-Based Invalidation
+
+Every capability records the epoch in which it was minted. When the kernel calls `increment_epoch()`, any token whose epoch does not match the new global epoch is considered stale. P1 verification rejects it immediately:
+
+```rust
+// Create a capability at epoch 0
+let (idx, gen) = mgr.create_root_capability(
+    CapType::Region, CapRights::READ, 0, owner,
+).unwrap();
+
+// Verification passes at epoch 0
+assert!(mgr.verify_p1(idx, gen, CapRights::READ).is_ok());
+
+// Advance epoch
+mgr.increment_epoch();
+
+// Now the same capability is stale
+assert_eq!(
+    mgr.verify_p1(idx, gen, CapRights::READ),
+    Err(ProofError::StaleCapability),
+);
+```
+
+### Code Example: Capability Derivation
+
+```rust
+use rvm_cap::{CapabilityManager, CapManagerConfig};
+use rvm_types::{CapType, CapRights, PartitionId};
+
+let mut mgr = CapabilityManager::<64>::with_defaults();
+let owner = PartitionId::new(1);
+let target = PartitionId::new(2);
+
+// Create a root capability with broad rights
+let (root_idx, root_gen) = mgr.create_root_capability(
+    CapType::Region,
+    CapRights::READ | CapRights::WRITE | CapRights::GRANT,
+    0,     // badge
+    owner,
+).unwrap();
+
+// Grant a read-only copy to another partition (attenuated)
+let (child_idx, child_gen) = mgr.grant(
+    root_idx, root_gen,
+    CapRights::READ,  // fewer rights than parent
+    42,               // badge for identifying this grant
+    target,
+).unwrap();
+
+// The child has depth 1 and read-only rights
+let child = mgr.table().lookup(child_idx, child_gen).unwrap();
+assert_eq!(child.token.rights(), CapRights::READ);
+assert_eq!(child.depth, 1);
+```
+
+---
+
+## 3. The Capability Manager
+
+The `CapabilityManager` is the single integration point for all capability operations. It coordinates three internal structures:
+
+- **`CapabilityTable<N>`** -- A fixed-size array (default N = 256) of `CapSlot` entries. Each slot holds a capability token, its owner, delegation depth, parent index, badge, and a generation counter for stale-handle detection.
+
+- **`DerivationTree<N>`** -- A first-child / next-sibling linked list tracking parent-child relationships. Used for revocation propagation.
+
+- **`ProofVerifier<N>`** -- Implements P1, P2, and P3 verification against the table and tree.
+
+### Core Operations
+
+| Operation | Method | Description |
+|-----------|--------|-------------|
+| Create | `create_root_capability()` | Allocates a root capability (no parent) |
+| Grant | `grant()` | Derives a child capability with attenuated rights |
+| Revoke | `revoke()` | Invalidates a capability and all its descendants |
+| P1 Verify | `verify_p1()` | Checks existence, epoch freshness, and rights |
+| P2 Verify | `verify_p2()` | Structural invariant validation |
+| P3 Verify | `verify_p3()` | Deep derivation chain walk to root |
+
+### Revocation Propagation
+
+When you revoke a capability, all its descendants are also invalidated. The implementation uses an **iterative** subtree walk (not recursive) to avoid stack overflow on deep derivation trees -- this was a security fix for a stack-overflow vulnerability found during audit.
+
+```rust
+let result = mgr.revoke(root_idx, root_gen).unwrap();
+// result.revoked_count includes the root and all descendants
+```
+
+The `RevokeResult` reports how many capabilities were invalidated. The `ManagerStats` struct tracks cumulative statistics:
+
+```rust
+let stats = mgr.stats();
+println!("Created: {}, Granted: {}, Revoked: {}", 
+    stats.caps_created, stats.caps_granted, stats.caps_revoked);
+```
+
+---
+
+## 4. The Three-Tier Proof System
+
+Every state mutation in RVM requires a **proof**. Proofs trade off verification cost against assurance level:
+
+| Tier | Name | Budget | Mechanism | Use Case |
+|------|------|--------|-----------|----------|
+| **P1** | Hash | < 1 us | FNV-1a preimage / capability check | Routine transitions |
+| **P2** | Witness | < 100 us | Witness chain + policy validation | Cross-partition ops |
+| **P3** | Zk | < 10 ms | Deep proof / deferred ZK | Privacy-preserving (deferred) |
+
+### P1: Hash Proof
+
+The cheapest tier. A SHA-256 preimage or FNV-1a hash is computed over the proof data and compared against a commitment. Under 1 microsecond.
+
+```rust
+use rvm_proof::{Proof, compute_data_hash, verify};
+
+// The prover commits to data by hashing it
+let data = b"partition-create-request";
+let commitment = compute_data_hash(data);
+
+// Later, the prover submits the preimage as proof
+let proof = Proof::hash_proof(commitment, data);
+
+// The verifier checks the proof against the commitment
+assert!(verify(&proof, &commitment).is_ok());
+```
+
+`compute_data_hash` produces a 32-byte `WitnessHash` from FNV-1a, placed in the first 8 bytes (little-endian) with the remaining 24 bytes zeroed.
+
+### P2: Witness Chain Proof
+
+A more expensive tier that validates witness chain linkage. The proof data contains one or more 16-byte links, each a `(prev_hash: u64, record_hash: u64)` pair. The verifier walks the chain and confirms that each record's `prev_hash` equals the preceding record's `record_hash`.
+
+```rust
+// Witness chain data: two 16-byte links
+// Link 0: prev_hash=0, record_hash=0xAABB
+// Link 1: prev_hash=0xAABB, record_hash=0xCCDD
+// The chain is valid because link[0].record_hash == link[1].prev_hash
+```
+
+The `ProofEngine` orchestrates the full pipeline: P1 capability check, then P2 policy validation, then witness emission. See the [Unified Proof Engine](#unified-proof-engine) section below.
+
+### P3: Deep Proof (Deferred)
+
+P3 walks the entire derivation chain from a capability back to its root, verifying that every ancestor is valid, depth is monotonic, and epochs are non-decreasing. Full zero-knowledge proof support requires TEE integration and is deferred to a future release.
+
+```rust
+// P3 verification walks the derivation tree
+mgr.verify_p3(cap_index, cap_generation, max_depth)?;
+```
+
+### Capability-Gated Proof Submission
+
+To submit a proof, the caller must hold a capability with the `PROVE` right:
+
+```rust
+use rvm_proof::verify_with_cap;
+
+// This checks PROVE right first, then verifies the proof
+verify_with_cap(&proof, &commitment, &token)?;
+// Returns Err(InsufficientCapability) if PROVE is missing
+```
+
+### Unified Proof Engine
+
+The `ProofEngine` ties P1 + P2 + witness emission into one call:
+
+```rust
+use rvm_proof::engine::ProofEngine;
+
+let mut engine = ProofEngine::<64>::new();
+engine.verify_and_witness(
+    &proof_token,   // which tier is being claimed
+    &context,       // proof context (partition, region, nonce, etc.)
+    &cap_manager,   // for P1 capability lookup
+    &witness_log,   // for witness emission
+)?;
+```
+
+If P1 fails, a `ProofRejected` witness is emitted and the error is returned. If P2 policy evaluation fails, same. Only on full success is a tier-specific success witness emitted.
+
+---
+
+## 5. TEE-Backed Verification (ADR-142)
+
+For environments with hardware attestation (Intel SGX, AMD SEV-SNP, Intel TDX, Arm CCA), RVM provides a TEE signing pipeline.
+
+### Software TEE Components
+
+RVM ships software-emulated TEE components for development and testing:
+
+| Component | Role |
+|-----------|------|
+| `SoftwareTeeProvider` | Generates attestation quotes using HMAC-SHA256 |
+| `SoftwareTeeVerifier` | Validates quotes against expected measurements |
+| `TeeWitnessSigner` | Combines quote generation + verification + HMAC signing |
+
+### The `TeeWitnessSigner` Pipeline
+
+The signing flow for every witness record is:
+
+1. **Generate** a TEE attestation quote binding the digest to the enclave measurement.
+2. **Verify** the quote against the expected measurement (self-attestation).
+3. **Sign** the digest with the inner HMAC-SHA256 signer.
+
+If self-attestation fails, the signer returns a zero signature, which will fail verification. This fail-closed design ensures that a compromised TEE environment cannot produce valid witness records.
+
+### Witness Signer Hierarchy
+
+| Signer | Strength | Feature Gate | Use Case |
+|--------|----------|--------------|----------|
+| `NullSigner` | None (always true) | `null-signer` or test | **Deprecated.** Testing only. |
+| `StrictSigner` | FNV-1a | Always available | Non-TEE deployments, lightweight tamper evidence |
+| `HmacWitnessSigner` | HMAC-SHA256 | `crypto-sha256` | Production without TEE |
+| `HmacSha256WitnessSigner` | HMAC-SHA256 (64-byte sig) | `crypto-sha256` | Proof-crate signer trait |
+| `Ed25519WitnessSigner` | Ed25519 (`verify_strict`) | `ed25519` | Asymmetric signing |
+| `DualHmacSigner` | Dual HMAC-SHA256 | `crypto-sha256` | Strong symmetric, 64-byte signatures |
+| `TeeWitnessSigner` | TEE-bound HMAC | `crypto-sha256` | Full attestation-backed signing |
+
+### Key Derivation
+
+The `KeyBundle` type and `derive_key_bundle` function (gated behind `crypto-sha256`) derive signing keys from a platform measurement and a salt. In production, the measurement comes from the TEE hardware. The compile-time default key (`SHA-256(b"rvm-witness-default-key-v1")`) is public and must be replaced.
+
+---
+
+## 6. Practical Examples
+
+### Creating a Capability and Checking Rights
+
+```rust
+use rvm_types::{CapToken, CapType, CapRights};
+
+let token = CapToken::new(
+    42, CapType::Region,
+    CapRights::READ | CapRights::WRITE | CapRights::PROVE,
+    0,
+);
+
+// Check individual rights
+assert!(token.has_rights(CapRights::READ));
+assert!(token.has_rights(CapRights::PROVE));
+assert!(!token.has_rights(CapRights::GRANT));
+
+// Truncated hash for witness embedding (32-bit, NOT the full token)
+let hash = token.truncated_hash();
+```
+
+### Submitting and Verifying a Hash Proof
+
+```rust
+use rvm_proof::{Proof, compute_data_hash, verify, verify_with_cap};
+use rvm_types::{CapToken, CapType, CapRights};
+
+let data = b"region-transfer-payload";
+let commitment = compute_data_hash(data);
+let proof = Proof::hash_proof(commitment, data);
+
+// Standalone verification (no capability check)
+verify(&proof, &commitment).expect("proof is valid");
+
+// Capability-gated verification
+let token = CapToken::new(1, CapType::Proof, CapRights::PROVE, 0);
+verify_with_cap(&proof, &commitment, &token).expect("cap + proof valid");
+```
+
+### End-to-End: Capability + Proof Engine + Witness
+
+```rust
+use rvm_cap::CapabilityManager;
+use rvm_proof::engine::ProofEngine;
+use rvm_proof::context::ProofContextBuilder;
+use rvm_types::{CapType, CapRights, PartitionId, ProofTier, ProofToken};
+use rvm_witness::WitnessLog;
+
+// Set up infrastructure
+let witness_log = WitnessLog::<256>::new();
+let mut cap_mgr = CapabilityManager::<64>::with_defaults();
+let owner = PartitionId::new(1);
+
+// Create a capability with PROVE rights
+let (idx, gen) = cap_mgr.create_root_capability(
+    CapType::Region,
+    CapRights::READ | CapRights::WRITE | CapRights::PROVE,
+    0, owner,
+).unwrap();
+
+// Build a proof context
+let context = ProofContextBuilder::new(owner)
+    .target_object(42)
+    .capability_handle(idx)
+    .capability_generation(gen)
+    .current_epoch(0)
+    .region_bounds(0x1000, 0x2000)
+    .time_window(500, 1000)
+    .nonce(1)
+    .build();
+
+let token = ProofToken { tier: ProofTier::P2, epoch: 0, hash: 0xABCD };
+
+// Run the full pipeline: P1 check -> P2 validate -> witness emit
+let mut engine = ProofEngine::<64>::new();
+engine.verify_and_witness(&token, &context, &cap_mgr, &witness_log)
+    .expect("pipeline passes");
+
+// A witness record was emitted
+assert!(witness_log.total_emitted() > 0);
+```
+
+---
+
+## Cross-References
+
+- **Security Gate** -- The unified gate that wraps capability check + proof + witness into a single pipeline: [Security Architecture](10-security.md)
+- **Witness Record format** -- How proof results are recorded in the audit trail: [Witness and Audit](06-witness-audit.md)
+- **Partition split and capability attenuation** -- How capabilities are attenuated during splits (DC-8): [Partitions and Scheduling](07-partitions-scheduling.md)
+- **Memory region capabilities** -- How region capabilities interact with memory tiers: [Memory Model](08-memory-model.md)
+- **WASM agent capabilities** -- How agents acquire and use capabilities: [WASM Agents](09-wasm-agents.md)
+- **Crate API surface** -- `rvm-cap`, `rvm-proof`, `rvm-types`: [Crate Reference](04-crate-reference.md)
+- **Glossary** -- Definitions of capability, proof tier, epoch, derivation depth: [Glossary](15-glossary.md)

--- a/userguide/06-witness-audit.md
+++ b/userguide/06-witness-audit.md
@@ -1,0 +1,308 @@
+# Witness Trail: Complete Audit by Construction
+
+RVM does not have an "audit mode" you can toggle on. Every privileged action -- creating a partition, granting a capability, transferring a memory region, sending an IPC message -- emits a fixed 64-byte, hash-chained witness record **before the mutation commits**. If the record cannot be emitted, the mutation does not proceed. The witness trail is not a feature; it is a structural invariant.
+
+> **Prerequisite reading:** [Capabilities and Proofs](05-capabilities-proofs.md) for the proof tiers that authorize mutations. [Core Concepts](02-core-concepts.md) for an overview of the witness invariant.
+
+---
+
+## 1. The Core Invariant
+
+**No witness, no mutation.**
+
+This is INV-3, the non-negotiable audit invariant of RVM. Every privileged action emits a witness record BEFORE the state change is committed. The sequence is:
+
+1. Validate the capability and proof (see [Capabilities and Proofs](05-capabilities-proofs.md)).
+2. Construct the witness record with all relevant fields.
+3. Append the record to the witness log (this sets the sequence number, chain hashes, and optional signature).
+4. Only after successful append: perform the mutation.
+
+If step 3 fails (ring buffer full is handled by overwrite, so this mainly concerns future persistent backends), the mutation is aborted. There is no code path that mutates kernel state without a prior witness emission.
+
+---
+
+## 2. Record Format (64 Bytes)
+
+Each witness record is exactly 64 bytes, cache-line aligned (`#[repr(C, align(64))]`). This is enforced at compile time with a static assertion. The fixed size means no heap allocation, predictable cache behavior, and constant-time emission.
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| 0 | 8 | `sequence` | Auto-incrementing sequence number (global ordering) |
+| 8 | 8 | `timestamp_ns` | Nanosecond timestamp (`CNTVCT_EL0` on AArch64, `rdtsc` on x86) |
+| 16 | 1 | `action_kind` | Which privileged action was performed (see Action Kinds below) |
+| 17 | 1 | `proof_tier` | Which proof tier authorized this action (1 = P1, 2 = P2, 3 = P3) |
+| 18 | 1 | `flags` | Action-specific status flags |
+| 19 | 1 | `_reserved` | Reserved, must be zero |
+| 20 | 4 | `actor_partition_id` | Partition that performed the action |
+| 24 | 8 | `target_object_id` | Object acted upon (partition ID, region handle, etc.) |
+| 32 | 4 | `capability_hash` | Truncated hash of the capability used (not the full token) |
+| 36 | 8 | `payload` | Action-specific data, packed by kind |
+| 44 | 4 | `prev_hash` | FNV-1a hash of the previous record (chain link) |
+| 48 | 4 | `record_hash` | FNV-1a hash of this record (self-integrity) |
+| 52 | 8 | `aux` | Auxiliary data: TEE signature, secondary payload |
+| 60 | 4 | `_pad` | Padding to 64 bytes |
+
+The `payload` field is interpreted differently depending on `action_kind`. For example:
+- `PartitionSplit`: bytes [0..4] = `new_id_a`, bytes [4..8] = `new_id_b`
+- `RegionTransfer`: bytes [0..4] = `from_partition`, bytes [4..8] = `to_partition`
+
+### Action Kinds
+
+Actions are organized by subsystem with hex prefixes for efficient filtering:
+
+| Prefix | Subsystem | Example Actions |
+|--------|-----------|-----------------|
+| `0x01-0x0F` | Partition lifecycle | Create, Destroy, Suspend, Resume, Split, Merge, Hibernate, Reconstruct, Migrate |
+| `0x10-0x1F` | Capability operations | Grant, Revoke, Delegate, Escalate, Attenuated |
+| `0x20-0x2F` | Memory operations | RegionCreate, Destroy, Transfer, Share, Promote, Demote, Map, Unmap |
+| `0x30-0x3F` | Communication | CommEdgeCreate, Destroy, IpcSend, IpcReceive, ZeroCopyShare, NotificationSignal |
+| `0x40-0x4F` | Device operations | LeaseGrant, LeaseRevoke, LeaseExpire, LeaseRenew |
+| `0x50-0x5F` | Proof verification | ProofVerifiedP1, P2, P3, ProofRejected, ProofEscalated |
+| `0x60-0x6F` | Scheduler decisions | Epoch, ModeSwitch, TaskSpawn, TaskTerminate, StructuralSplit, StructuralMerge |
+| `0x70-0x7F` | Recovery actions | RecoveryEnter, Exit, CheckpointCreated, Restored, MinCutBudgetExceeded, DegradedMode |
+| `0x80-0x8F` | Boot and attestation | BootAttestation, BootComplete, TeeAttestation |
+| `0x90-0x9F` | Vector/Graph | VectorPut, VectorDelete, GraphMutation, CoherenceRecomputed |
+| `0xA0-0xAF` | VMID management | VmidReclaim, MigrationTimeout |
+
+Filter by subsystem using `ActionKind::subsystem()`, which returns the upper nibble:
+
+```rust
+let kind = ActionKind::PartitionSplit;
+assert_eq!(kind.subsystem(), 0); // Partition subsystem
+```
+
+---
+
+## 3. Hash Chain
+
+Every record links to the previous one through an FNV-1a hash chain:
+
+```
+Record 0: prev_hash = 0 (genesis), record_hash = H(0, seq=0)
+Record 1: prev_hash = H(0, seq=0), record_hash = H(H(0, seq=0), seq=1)
+Record 2: prev_hash = H(..., seq=1), record_hash = H(H(..., seq=1), seq=2)
+...
+```
+
+The chain hash is computed as `FNV-1a(prev_chain_hash || sequence)`, then XOR-folded from 64 bits to 32 bits for storage in the record fields (`(h >> 32) ^ (h & 0xFFFF_FFFF)`).
+
+### Tamper Evidence
+
+If an attacker modifies any record, the chain breaks at the next record because its `prev_hash` will no longer match the tampered record's `record_hash`. The `verify_chain()` function walks a slice of records and confirms every link:
+
+```rust
+use rvm_witness::verify_chain;
+
+// records: &[WitnessRecord] -- a contiguous snapshot
+match verify_chain(&records) {
+    Ok(count) => println!("Chain valid: {count} records"),
+    Err(ChainIntegrityError::ChainBreak { sequence }) => {
+        println!("Chain broken at sequence {sequence}");
+    }
+    Err(ChainIntegrityError::RecordCorrupted { sequence }) => {
+        println!("Record corrupted at sequence {sequence}");
+    }
+    Err(ChainIntegrityError::EmptyLog) => {
+        println!("No records to verify");
+    }
+}
+```
+
+### Limitations
+
+FNV-1a is chosen for speed (under 50 ns for 64 bytes), not cryptographic strength. An adversary with direct memory access could recompute the chain after tampering. For protection against such adversaries, enable the `crypto-sha256` feature and use the `HmacWitnessSigner` or a TEE-backed signer. See [Signing](#4-signing) below.
+
+---
+
+## 4. Signing
+
+Witness records can optionally be **signed** by a `WitnessSigner`. The 8-byte `aux` field in each record stores a truncated signature. Signing occurs during append, after the chain hashes are set, so the signature covers all fields including `prev_hash` and `record_hash`.
+
+### Signer Implementations
+
+| Signer | How It Works | When to Use |
+|--------|-------------|-------------|
+| `StrictSigner` | FNV-1a over the first 52 bytes of the serialized record | Default fallback (no `crypto-sha256` feature). Non-cryptographic but non-trivial tamper evidence. |
+| `HmacWitnessSigner` | HMAC-SHA256 over the first 52 bytes, truncated to 8 bytes. Keyed PRF. | Production without TEE. Requires `crypto-sha256` feature. |
+| `NullSigner` | Returns all zeros. Accepts everything. | **Deprecated.** Testing only. Gated behind `null-signer` feature or `#[cfg(test)]`. |
+
+The `DefaultSigner` type alias resolves to `HmacWitnessSigner` when `crypto-sha256` is enabled, or `StrictSigner` otherwise. Use `default_signer()` to get the right one:
+
+```rust
+use rvm_witness::{default_signer, WitnessSigner, WitnessLog};
+use rvm_types::{WitnessRecord, ActionKind};
+
+let signer = default_signer();
+let log = WitnessLog::<256>::new();
+
+let mut record = WitnessRecord::zeroed();
+record.action_kind = ActionKind::PartitionCreate as u8;
+record.actor_partition_id = 1;
+record.target_object_id = 42;
+
+// signed_append fills chain hashes AND signs in one atomic step
+log.signed_append(record, &signer);
+
+// Retrieve and verify
+let stored = log.get(0).unwrap();
+assert!(signer.verify(&stored)); // signature is valid
+```
+
+### Signed Append vs Plain Append
+
+| Method | Chain Hashes | Signature | Use When |
+|--------|-------------|-----------|----------|
+| `log.append(record)` | Set | Not set (`aux` = caller's value) | No signing configured |
+| `log.signed_append(record, &signer)` | Set | Set in `aux` after chain hashes | Production deployments |
+
+The key difference: `signed_append` signs the fully-populated record (sequence, prev_hash, record_hash all set), so the signature covers the chain metadata. Signing before append would miss those fields.
+
+### Tampered Records Fail Verification
+
+```rust
+let mut stored = log.get(0).unwrap();
+stored.actor_partition_id = 999; // tamper
+assert!(!signer.verify(&stored)); // fails
+```
+
+---
+
+## 5. Querying the Trail
+
+The `rvm_witness::replay` module provides three query functions that filter a snapshot of records:
+
+### By Partition
+
+```rust
+use rvm_witness::query_by_partition;
+
+let records = /* snapshot from log.snapshot() */;
+for record in query_by_partition(&records, partition_id) {
+    // all records where actor_partition_id == partition_id
+}
+```
+
+### By Action Kind
+
+```rust
+use rvm_witness::query_by_action_kind;
+use rvm_types::ActionKind;
+
+for record in query_by_action_kind(&records, ActionKind::CapabilityGrant as u8) {
+    // all capability grant events
+}
+```
+
+### By Time Range
+
+```rust
+use rvm_witness::query_by_time_range;
+
+for record in query_by_time_range(&records, start_ns, end_ns) {
+    // all records with timestamp_ns in [start_ns, end_ns]
+}
+```
+
+All three return iterators, so they compose naturally:
+
+```rust
+// All capability grants by partition 3 in the last second
+let grants_by_p3 = query_by_partition(&records, 3)
+    .filter(|r| r.action_kind == ActionKind::CapabilityGrant as u8)
+    .filter(|r| r.timestamp_ns >= now_ns - 1_000_000_000);
+```
+
+---
+
+## 6. The Ring Buffer
+
+The `WitnessLog<N>` is an append-only ring buffer backed by a fixed-size array of `N` witness records, protected by a `spin::Mutex` for thread safety.
+
+### Default Capacity
+
+```
+DEFAULT_RING_CAPACITY = 262,144 records
+Record size = 64 bytes
+Total memory = 262,144 * 64 = 16 MiB
+```
+
+At a rate of 100,000 privileged actions per second, this provides approximately 2.6 seconds of hot storage before the oldest records are overwritten.
+
+### Overflow Behavior
+
+When the write position wraps around, the oldest records are silently overwritten. The ring buffer never blocks, never allocates, and never fails to accept a record. The `total_emitted()` counter tracks the total number of records ever written (not just the number currently in the buffer):
+
+```rust
+let log = WitnessLog::<4>::new();
+for i in 0..10 {
+    log.append(make_record(i));
+}
+assert_eq!(log.total_emitted(), 10); // 10 records written
+assert_eq!(log.len(), 4);            // only 4 in the buffer
+```
+
+### Snapshots
+
+To extract records for analysis, use `snapshot()`:
+
+```rust
+let mut buf = [WitnessRecord::zeroed(); 64];
+let copied = log.snapshot(&mut buf);
+// buf[0..copied] contains the most recent `copied` records
+```
+
+The snapshot is taken under the lock, so it is consistent. Records are returned in chronological order (oldest first within the copied range).
+
+---
+
+## 7. Deterministic Replay
+
+Because every mutation is witnessed, the witness trail combined with a checkpoint forms a **reconstructable execution history**. Given:
+
+1. A checkpoint of partition state at sequence S, and
+2. All witness records from sequence S onward,
+
+you can reconstruct the exact state at any later sequence number by replaying the mutations in order.
+
+### Chain Integrity as a Prerequisite
+
+Before replay, verify the chain:
+
+```rust
+use rvm_witness::verify_chain;
+
+let result = verify_chain(&records);
+match result {
+    Ok(count) => {
+        // Safe to replay: chain is intact
+    }
+    Err(e) => {
+        // Chain is compromised: do not trust replay
+        panic!("Chain integrity error: {e}");
+    }
+}
+```
+
+### Applications
+
+- **Memory reconstruction** -- Dormant memory regions are stored as a checkpoint plus delta-compressed witness trail. When a region is promoted back to Hot, the reconstruction pipeline replays the witness records to rebuild state. See [Memory Model: Memory Time Travel](08-memory-model.md).
+
+- **Forensic analysis** -- After an incident, the witness trail provides a complete record of who did what, when, with which capability, at which proof tier. See [Advanced: Forensics](13-advanced-exotic.md).
+
+- **Migration verification** -- When a partition migrates to another node, the receiving node can verify the witness chain to confirm the partition's history is untampered.
+
+- **Debugging** -- The witness trail provides a total ordering of all privileged actions, making it possible to reconstruct race conditions and timing-dependent bugs.
+
+---
+
+## Cross-References
+
+- **Proof tiers that authorize mutations** -- P1/P2/P3 and how they connect to witness emission: [Capabilities and Proofs](05-capabilities-proofs.md)
+- **The Security Gate pipeline** -- How capability check + proof + witness emission form the unified entry point: [Security Architecture](10-security.md)
+- **Memory time travel** -- Using the witness trail for dormant memory reconstruction: [Memory Model](08-memory-model.md)
+- **Partition lifecycle events** -- Which partition actions produce which witness records: [Partitions and Scheduling](07-partitions-scheduling.md)
+- **Forensic queries and advanced replay** -- Deeper analysis techniques: [Advanced and Exotic](13-advanced-exotic.md)
+- **Bare-metal boot attestation** -- The genesis witness record and boot sequence: [Bare Metal](12-bare-metal.md)
+- **Performance** -- Witness emission latency benchmarks (~17 ns target): [Performance](11-performance.md)
+- **Crate API surface** -- `rvm-witness`, `rvm-types`: [Crate Reference](04-crate-reference.md)
+- **Glossary** -- Definitions of witness record, hash chain, ring buffer, signer: [Glossary](15-glossary.md)

--- a/userguide/07-partitions-scheduling.md
+++ b/userguide/07-partitions-scheduling.md
@@ -1,0 +1,423 @@
+# Partitions and Scheduling: The Heart of RVM
+
+Partitions are the central abstraction in RVM. Everything else -- capabilities, witnesses, memory tiers, scheduling -- exists to serve partitions. This chapter is split into two parts: Part 1 covers what a partition is and how it lives; Part 2 covers how the scheduler decides which partition runs next.
+
+---
+
+## Part 1: Partitions
+
+### 1. What Is a Partition?
+
+A partition is **not** a virtual machine. There is no emulated hardware, no guest BIOS, no virtual device model. A partition is a lightweight container for:
+
+- **A scoped capability table** -- the set of access rights visible to code running inside the partition (see [Capabilities and Proofs](05-capabilities-proofs.md))
+- **Communication edges** -- weighted links to other partitions that represent how much two partitions talk to each other
+- **Coherence and cut-pressure metrics** -- graph-derived numbers that tell the scheduler how isolated or connected this partition is
+- **CPU affinity and VMID assignment** -- which physical cores the partition may run on, and the ARM VMID used for stage-2 address translation
+
+Partitions are the unit of:
+
+| Concern | What It Means |
+|---------|---------------|
+| **Scheduling** | The scheduler picks which partition runs next on each CPU |
+| **Isolation** | Stage-2 page tables enforce memory boundaries per partition |
+| **Migration** | A partition (and its agents) can move between physical cores |
+| **Fault containment** | A crash inside one partition cannot corrupt another |
+
+**Hard limit:** `MAX_PARTITIONS = 256`. This comes from the 8-bit ARM VMID field in `VTTBR_EL2`. Every partition gets a unique VMID; with 256 available, that is the ceiling. The constant lives in `rvm-partition/src/partition.rs`.
+
+### 2. Partition Lifecycle
+
+Every partition progresses through a well-defined state machine. The states are defined by the `PartitionState` enum:
+
+```
+                 +-----------+
+                 |  Created  |
+                 +-----+-----+
+                       |
+              +--------+--------+
+              v                 v
+         +----+----+     +-----+-----+
+         | Running |     | Destroyed |
+         +----+----+     +-----------+
+              |                 ^
+     +--------+--------+       |
+     v                 v       |
++----+------+    +-----+-----+|
+| Suspended |    | Hibernated |+
++----+------+    +-----+------+
+     |                 |
+     +--> Running      +--> Created
+```
+
+The valid transitions, enforced by `valid_transition()` in `rvm-partition/src/lifecycle.rs`:
+
+| From | To | When |
+|------|----|------|
+| Created | Running | First activation |
+| Created | Destroyed | Tear down before ever running |
+| Running | Suspended | Pause all vCPUs |
+| Running | Hibernated | Serialize state to cold storage |
+| Running | Destroyed | Clean shutdown |
+| Suspended | Running | Resume execution |
+| Suspended | Hibernated | Hibernate while paused |
+| Suspended | Destroyed | Tear down while paused |
+| Hibernated | Created | Restore from hibernation (re-enter the lifecycle) |
+| Hibernated | Destroyed | Discard the hibernation snapshot |
+
+Any transition not in this table is rejected. Destroyed is a terminal state: nothing can leave it. Every lifecycle transition emits a witness record before the mutation commits (see [Witness and Audit](06-witness-audit.md)).
+
+### 3. The Partition Manager
+
+`PartitionManager` in `rvm-partition/src/manager.rs` owns the array of all partitions. It provides:
+
+- **`create(partition_type, vcpu_count, epoch)`** -- allocate a slot, assign a unique `PartitionId`, return the ID. Fails with `PartitionLimitExceeded` if all 256 slots are full.
+- **`get(id)` / `get_mut(id)`** -- O(1) lookup via a direct index (falls back to linear scan for IDs beyond the index range).
+- **`remove(id)`** -- free a slot for reuse.
+- **`active_ids()`** -- iterate over all currently occupied partition IDs.
+- **`count()`** -- number of active partitions.
+
+Partition ID 0 is reserved for the hypervisor itself (`PartitionId::HYPERVISOR`). The first user partition gets ID 1.
+
+The `Partition` struct itself carries:
+
+```rust
+pub struct Partition {
+    pub id: PartitionId,
+    pub state: PartitionState,
+    pub partition_type: PartitionType,   // Agent | Infrastructure | Root
+    pub coherence: CoherenceScore,       // 0..10000 basis points
+    pub cut_pressure: CutPressure,       // graph-derived isolation signal
+    pub vcpu_count: u16,
+    pub cpu_affinity: u64,               // bitmask of allowed physical CPUs
+    pub epoch: u32,                      // creation epoch
+}
+```
+
+New partitions start with a default coherence score of 5000 basis points (50%) and a CPU affinity of `u64::MAX` (all CPUs allowed).
+
+There are three partition types (`PartitionType`):
+
+| Type | Purpose |
+|------|---------|
+| `Agent` | Normal workload partition for user agents |
+| `Infrastructure` | Driver domain or service partition |
+| `Root` | The bootstrap authority partition (created first) |
+
+For the config structure used when creating partitions through the `PartitionOps` trait, see `PartitionConfig` in `rvm-partition/src/ops.rs`.
+
+### 4. Communication Edges
+
+Partitions do not communicate through shared memory. They send messages along **communication edges** (`CommEdge`), defined in `rvm-partition/src/comm_edge.rs`:
+
+```rust
+pub struct CommEdge {
+    pub id: CommEdgeId,
+    pub source: PartitionId,
+    pub dest: PartitionId,
+    pub weight: u64,            // accumulated message bytes, decayed per epoch
+    pub last_epoch: u32,
+}
+```
+
+Each `CommEdgeId` is a unique `u64` identifier. Edge weights track how much traffic flows between two partitions. These weights are the raw material for the coherence engine: high-weight edges mean strong coupling; low-weight edges mean the partitions are drifting apart. The coherence engine uses these weights to compute mincut boundaries, drive tier placement, and inform split/merge decisions.
+
+Every IPC send increments the edge weight (see section 5 below). Edge weights decay per epoch to reflect recent communication patterns rather than historical totals.
+
+### 5. IPC (Inter-Partition Communication)
+
+`IpcManager` in `rvm-partition/src/ipc.rs` provides zero-copy message passing between partitions. It is parameterized by two const generics:
+
+- `MAX_EDGES` -- maximum number of concurrent IPC channels
+- `QUEUE_SIZE` -- per-channel message queue capacity (must be a power of two)
+
+**Creating a channel:**
+
+```rust
+let edge_id = ipc_mgr.create_channel(from_partition, to_partition)?;
+```
+
+**Sending a message:**
+
+```rust
+let msg = IpcMessage {
+    sender: caller_id,
+    receiver: target_id,
+    edge_id,
+    payload_len: 128,
+    msg_type: 1,
+    sequence: next_seq,
+    capability_hash: 0xABCD,
+};
+ipc_mgr.send(edge_id, msg, caller_id)?;
+```
+
+The `send()` method enforces two security checks:
+
+1. **Sender identity:** `msg.sender` must match `caller_id` (no spoofing).
+2. **Channel authorization:** the caller must be the source endpoint of the channel.
+
+Both checks return `InsufficientCapability` on failure. A separate `send_unchecked()` exists for kernel-internal paths that have already validated authorization.
+
+Each `MessageQueue` is a fixed-size ring buffer. When the queue is full, `send()` returns `ResourceLimitExceeded`. Messages are delivered in FIFO order.
+
+Every successful send increments the channel's weight counter, which feeds back into the coherence graph for mincut computation. See [Core Concepts](02-core-concepts.md) for how coherence scoring works.
+
+### 6. Split and Merge
+
+Split and merge are novel partition operations. No prior hypervisor offers them. They allow RVM to dynamically restructure its partition topology in response to changing agent communication patterns.
+
+**Split** divides one partition into two. The key function is `scored_region_assignment()` in `rvm-partition/src/split.rs`. Given a memory region's coherence score and the coherence scores of the two candidate partitions, it returns a placement score in `[0, 10000]`:
+
+- **7500** = assign to the left partition (closer match)
+- **2500** = assign to the right partition (closer match)
+- Ties break left
+
+Split is configured through `SplitConfig`, which specifies the minimum coherence threshold required for the split to proceed. Regions are assigned to whichever child partition has the closer coherence score, ensuring that tightly-coupled regions stay together.
+
+**Merge** combines two partitions into one. Before merging, all preconditions must be satisfied. There are two levels of checking:
+
+1. **`merge_preconditions_met(coherence_a, coherence_b)`** -- basic check: both partitions must exceed the merge coherence threshold (default: 7000 basis points = 70%).
+
+2. **`merge_preconditions_full(coherence_a, coherence_b, are_adjacent, combined_cap_count, max_caps_per_partition)`** -- full DC-11 check adding:
+   - The partitions must be **adjacent** in the coherence graph (they share a `CommEdge`)
+   - The combined capability count must not exceed the per-partition maximum
+
+When a precondition fails, `MergePreconditionError` explains exactly what went wrong:
+
+| Error | Meaning |
+|-------|---------|
+| `InsufficientCoherence` | One or both partitions are below the 70% threshold |
+| `NotAdjacent` | The partitions do not share a communication edge |
+| `ResourceLimitExceeded` | The merged partition would have too many capabilities |
+
+Preconditions are checked in priority order: coherence first, then adjacency, then resources. This means a coherence failure is always reported even if adjacency would also fail.
+
+For advanced split/merge scenarios including live migration during split, see [Advanced: Live Split/Merge](13-advanced-exotic.md).
+
+### 7. Device Management
+
+`DeviceLeaseManager` in `rvm-partition/src/device.rs` handles hardware device access. Leases are:
+
+- **Time-bounded** -- each lease has a `granted_epoch` and `expiry_epoch`
+- **Revocable** -- the hypervisor can call `revoke_lease()` at any time
+- **Exclusive** -- a device may only be leased to one partition at a time
+- **Capability-gated** -- the `capability_hash` field records which capability token authorized the grant
+
+The manager is parameterized by `MAX_DEVICES` (registered hardware) and `MAX_LEASES` (concurrent active leases). Key operations:
+
+| Operation | Description |
+|-----------|-------------|
+| `register_device(info)` | Add a hardware device to the pool |
+| `grant_lease(device_id, partition, duration, epoch, cap_hash)` | Grant time-bounded exclusive access |
+| `revoke_lease(lease_id)` | Immediately revoke and release the device |
+| `check_lease(lease_id, current_epoch)` | Verify a lease is still valid; returns `DeviceLeaseExpired` if not |
+| `expire_leases(current_epoch)` | Bulk-expire all leases past their deadline |
+
+`DeviceInfo` describes a registered device:
+
+```rust
+pub struct DeviceInfo {
+    pub id: u32,
+    pub class: DeviceClass,       // Network, Storage, Serial, Timer, Graphics, ...
+    pub mmio_base: u64,
+    pub mmio_size: u64,
+    pub irq: Option<u32>,
+    pub available: bool,
+}
+```
+
+`ActiveLease` tracks a currently held lease:
+
+```rust
+pub struct ActiveLease {
+    pub lease_id: DeviceLeaseId,
+    pub device_id: u32,
+    pub partition_id: PartitionId,
+    pub granted_epoch: u64,
+    pub expiry_epoch: u64,
+    pub capability_hash: u32,
+}
+```
+
+When a lease expires or is revoked, the device returns to the available pool and can be leased to another partition. Double-grants are rejected with `DeviceLeaseConflict`.
+
+---
+
+## Part 2: Scheduling
+
+### 8. The Two-Signal Scheduler
+
+RVM's scheduler computes partition priority from exactly two signals:
+
+```
+priority = deadline_urgency + cut_pressure_boost
+```
+
+- **`deadline_urgency`** (`u16`) -- how close the partition is to missing its deadline. Higher values mean the partition is more urgent. This is the classic real-time scheduling signal.
+
+- **`cut_pressure_boost`** (`CutPressure`, fixed-point) -- a graph-derived signal from the coherence engine. When a partition's cut pressure is high, it means the partition is becoming isolated from its communication neighbors. Boosting its priority helps it run sooner, giving it a chance to re-establish communication and reduce its isolation.
+
+The `compute_priority()` function in `rvm-sched/src/priority.rs` combines them:
+
+```rust
+pub fn compute_priority(deadline_urgency: u16, cut_pressure: CutPressure) -> u32 {
+    let pressure_boost = (cut_pressure.as_fixed() >> 16).min(u16::MAX as u32) as u16;
+    deadline_urgency as u32 + pressure_boost as u32
+}
+```
+
+The result is a `u32` in `[0, 131070]`. Higher values mean higher priority. When the coherence engine is absent (DC-1/DC-6 degraded mode), `cut_pressure` is zero and the scheduler falls back to deadline-only scheduling.
+
+This two-signal design is what makes RVM coherence-native: the scheduler does not just schedule by deadline, it also schedules by graph structure.
+
+### 9. Three Modes
+
+The scheduler operates in one of three modes, defined by `SchedulerMode` in `rvm-sched/src/modes.rs`:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| **Reflex** | Hard real-time. Bounded local execution only. No cross-partition traffic allowed. Target: <10 us context switch. | Latency-critical control loops, interrupt handling |
+| **Flow** | Normal execution with coherence-aware placement. Cross-partition IPC is allowed. The scheduler uses both deadline urgency and cut-pressure boost. | Default mode for most workloads |
+| **Recovery** | Stabilization mode. Used during replay, rollback, and split operations. The scheduler restricts scheduling decisions to ensure deterministic execution during recovery. | Fault recovery, partition reconstruction |
+
+Each per-CPU scheduler tracks its own mode independently. One CPU can be in Reflex mode handling a real-time partition while another CPU is in Flow mode running normal workloads.
+
+### 10. Partition Switch
+
+The partition switch is the hot path. It must be fast. The design constraints are absolute:
+
+- **No allocation.** Zero heap activity.
+- **No graph work.** No coherence computation.
+- **No policy evaluation.** The decision was already made; this just executes it.
+
+The five steps of `partition_switch()` in `rvm-sched/src/switch.rs`:
+
+1. Save current registers into the outgoing `SwitchContext` (on AArch64: MRS sequence)
+2. Write `to.vttbr_el2` to `VTTBR_EL2` (stage-2 page table base + VMID)
+3. TLB invalidate (`TLBI VMALLE1`)
+4. Memory barrier (`DSB ISH` + `ISB`)
+5. Restore registers from the incoming `SwitchContext`
+
+The target is <10 microseconds. Benchmarks measure approximately 6 nanoseconds on host builds (the HAL stub path). On real AArch64 hardware, the TLB invalidation dominates.
+
+`SwitchContext` is the saved register state for a partition:
+
+```rust
+#[repr(C, align(64))]    // cache-line aligned to prevent false sharing
+pub struct SwitchContext {
+    pub vttbr_el2: u64,   // stage-2 page table base + VMID
+    pub elr_el2: u64,     // return address (Exception Link Register)
+    pub spsr_el2: u64,    // saved program status
+    pub sp_el1: u64,      // guest stack pointer
+    pub gp_regs: [u64; 31],  // general-purpose registers x0-x30
+}
+```
+
+Hot fields (`vttbr_el2`, `elr_el2`, `spsr_el2`, `sp_el1`) are placed first so they fit in a single 64-byte cache line. The general-purpose registers are cold-path fields accessed after the initial switch.
+
+Before switching, `validate_for_switch()` checks two safety conditions:
+
+1. The entry point (`elr_el2`) is not zero
+2. The entry point is below the hypervisor address space boundary (`0xFFFF_0000_0000_0000`)
+
+If validation fails, `partition_switch()` returns `Err(InvalidPartitionState)` and no switch occurs.
+
+`SwitchResult` captures the outcome:
+
+```rust
+pub struct SwitchResult {
+    pub from_vmid: u16,    // VMID of the outgoing partition
+    pub to_vmid: u16,      // VMID of the incoming partition
+    pub elapsed_ns: u64,   // switch duration (from HAL timer)
+}
+```
+
+For bare-metal boot details and how `SwitchContext::init()` prepares a partition for first entry, see [Bare Metal](12-bare-metal.md).
+
+### 11. Per-CPU and SMP
+
+**Per-CPU scheduling** is handled by `PerCpuScheduler` in `rvm-sched/src/per_cpu.rs`:
+
+```rust
+#[repr(C, align(64))]    // cache-line aligned per CPU
+pub struct PerCpuScheduler {
+    pub cpu_id: u16,
+    pub current: Option<PartitionId>,
+    pub mode: SchedulerMode,
+    pub idle: bool,
+}
+```
+
+Each physical CPU has its own `PerCpuScheduler` instance. The cache-line alignment (`align(64)`) ensures that per-CPU data does not share cache lines across CPUs (false sharing prevention).
+
+**Multi-core coordination** is handled by `SmpCoordinator` in `rvm-sched/src/smp.rs`, parameterized by `MAX_CPUS`:
+
+| Operation | Description |
+|-----------|-------------|
+| `bring_online(cpu_id)` | Mark a CPU as available for scheduling |
+| `take_offline(cpu_id)` | Remove a CPU (must release partition first) |
+| `assign_partition(cpu_id, partition)` | Bind a partition to a CPU |
+| `release_partition(cpu_id)` | Unbind and return the partition to the idle pool |
+| `find_idle_cpu()` | Find the first online, idle CPU |
+| `partition_affinity(partition)` | Which CPU is running a given partition |
+| `rebalance_hint()` | Suggest `(overloaded_cpu, idle_cpu)` pairs for migration |
+
+`CpuState` tracks each physical CPU:
+
+```rust
+pub struct CpuState {
+    pub cpu_id: u8,
+    pub online: bool,
+    pub current_partition: Option<PartitionId>,
+    pub idle: bool,
+    pub epoch_ticks: u64,
+}
+```
+
+The `epoch_ticks` counter increments each time a partition is assigned to the CPU. The rebalance hint uses this to identify the most heavily loaded CPU and suggest migrating work to an idle one.
+
+V1 uses a cooperative scheduling model. Lock-free work stealing is deferred to post-v1.
+
+### 12. Epoch Tracking
+
+Scheduler epochs are the unit of bulk witness logging. Individual context switches are **not** witnessed (this is a deliberate design choice, DC-10): at thousands of switches per second, per-switch witnessing would be prohibitively expensive.
+
+Instead, `EpochTracker` in `rvm-sched/src/epoch.rs` aggregates switch statistics per epoch:
+
+```rust
+pub struct EpochSummary {
+    pub epoch: u32,           // epoch number
+    pub switch_count: u16,    // total context switches this epoch
+    pub runnable_count: u16,  // partitions that were runnable
+}
+```
+
+Usage:
+
+1. Call `record_switch()` after each context switch (increments the counter)
+2. At the epoch boundary, call `advance(runnable_count)` which:
+   - Returns an `EpochSummary` for the completed epoch
+   - Resets the switch counter to zero
+   - Increments the epoch number
+
+The returned `EpochSummary` is then emitted as a single witness record covering all the switches in that epoch. This gives auditors a complete picture of scheduling activity without the overhead of per-switch witnessing.
+
+For how epoch summaries integrate with the witness trail, see [Witness and Audit](06-witness-audit.md). For how the coherence engine uses epoch data, see [Core Concepts](02-core-concepts.md).
+
+---
+
+## Cross-References
+
+| Topic | Chapter |
+|-------|---------|
+| Capability tables scoped to partitions | [Capabilities and Proofs](05-capabilities-proofs.md) |
+| Witness records emitted by lifecycle transitions | [Witness and Audit](06-witness-audit.md) |
+| Memory regions owned by partitions | [Memory Model](08-memory-model.md) |
+| WASM agents running inside partitions | [WASM Agents](09-wasm-agents.md) |
+| Coherence scoring and mincut computation | [Core Concepts](02-core-concepts.md) |
+| Stage-2 page tables and VMID handling | [Bare Metal](12-bare-metal.md) |
+| Live split/merge advanced scenarios | [Advanced and Exotic](13-advanced-exotic.md) |
+| Security gate and attestation | [Security](10-security.md) |
+| Performance benchmarks for partition switch | [Performance](11-performance.md) |
+| Full API reference for `rvm-partition` and `rvm-sched` | [Crate Reference](04-crate-reference.md) |

--- a/userguide/08-memory-model.md
+++ b/userguide/08-memory-model.md
@@ -1,0 +1,355 @@
+# Memory Model: Four Tiers and Time Travel
+
+RVM does not use demand paging. Every tier transition is explicit, driven by coherence scores and residency rules. Memory lives in one of four tiers at all times, and any historical state can be perfectly reconstructed from a checkpoint plus the witness delta log.
+
+This chapter covers the four-tier model, the buddy allocator, memory regions, address translation, and the reconstruction pipeline.
+
+---
+
+## 1. The Four-Tier Model
+
+```
+                 +-----------------------+
+    Tier 0       |        HOT            |   Per-core SRAM / L1-adjacent
+    (always      |   Always resident     |   Fastest access, smallest capacity
+     resident)   |   during execution    |
+                 +-----------+-----------+
+                             |
+                     explicit promote / demote
+                             |
+                 +-----------+-----------+
+    Tier 1       |        WARM           |   Shared DRAM
+    (resident    |   Resident if         |   Resident when residency rule is met:
+     if rule     |   residency rule met  |     cut_value + recency_score > threshold
+     met)        +-----------+-----------+
+                             |
+                     explicit promote / demote
+                             |
+                 +-----------+-----------+
+    Tier 2       |       DORMANT         |   Compressed checkpoint + delta
+    (compressed) |   Stored as snapshot  |   Reconstructed on demand
+                 |   + witness deltas    |   Not raw bytes -- structured data
+                 +-----------+-----------+
+                             |
+                     explicit promote / demote
+                             |
+                 +-----------+-----------+
+    Tier 3       |        COLD           |   Persistent archival (RVF-backed)
+    (archival)   |   Accessed only       |   Never auto-promoted
+                 |   during recovery     |   Explicit restore only
+                 +-----------------------+
+```
+
+Key properties:
+
+- **All transitions are explicit.** There is no page fault handler that silently promotes memory. The tier manager decides when to move a region, and the move is a witnessed operation.
+- **Coherence drives placement.** High coherence score means the region is actively used by communicating agents -- keep it hot. Low coherence means it can safely go dormant.
+- **Dormant is not deleted.** Tier 2 stores a compressed checkpoint plus a sequence of witness deltas. The original state can be perfectly reconstructed at any time.
+- **Cold is archival.** Tier 3 is for long-term storage on persistent media. It is accessed only during recovery or explicit restore operations. Cold regions are never automatically promoted.
+
+The `Tier` enum in `rvm-memory/src/tier.rs`:
+
+```rust
+pub enum Tier {
+    Hot     = 0,   // per-core SRAM / L1-adjacent
+    Warm    = 1,   // cluster-shared DRAM
+    Dormant = 2,   // compressed checkpoint + delta
+    Cold    = 3,   // persistent archival
+}
+```
+
+## 2. TierManager
+
+The `TierManager` in `rvm-memory/src/tier.rs` governs tier placement. It uses a residency rule:
+
+```
+cut_value + recency_score > eviction_threshold
+```
+
+When the coherence engine is absent (DC-1 degraded mode), `cut_value` defaults to zero and only `recency_score` drives placement.
+
+**`TierThresholds`** configures the transition points. All values are in basis points (0 to 10,000):
+
+```rust
+pub struct TierThresholds {
+    pub hot_to_warm: u16,          // below this -> demote Hot to Warm
+    pub warm_to_dormant: u16,      // below this -> demote Warm to Dormant
+    pub dormant_to_cold: u16,      // below this -> demote Dormant to Cold
+    pub warm_to_hot: u16,          // above this -> promote Warm to Hot
+    pub dormant_to_warm: u16,      // above this -> promote Dormant to Warm
+}
+```
+
+The conservative defaults (`TierThresholds::DEFAULT`) for DC-1 mode:
+
+| Transition | Threshold |
+|------------|-----------|
+| Hot to Warm | 7,000 (70%) |
+| Warm to Dormant | 4,000 (40%) |
+| Dormant to Cold | 1,000 (10%) |
+| Warm to Hot | 8,000 (80%) |
+| Dormant to Warm | 5,000 (50%) |
+
+Notice the hysteresis: promoting Warm to Hot requires 80%, but demoting Hot to Warm triggers at 70%. This prevents oscillation at the boundary.
+
+**`RegionTierState`** tracks the current tier for each memory region, indexed by `OwnedRegionId`. The tier manager maintains this mapping and updates it when a region is promoted or demoted.
+
+## 3. The Buddy Allocator
+
+`BuddyAllocator` in `rvm-memory/src/allocator.rs` handles physical page allocation. It is a classic power-of-two buddy allocator with these design constraints:
+
+- **`#![no_std]` compatible** -- no heap allocation. The entire bitmap is stack-allocated.
+- **`#![forbid(unsafe_code)]`** -- fully safe Rust.
+- **`PAGE_SIZE = 4096`** bytes (4 KiB).
+- **Maximum order: 10** -- the largest single allocation is 2^10 = 1,024 pages = 4 MiB.
+
+The allocator is parameterized by two const generics:
+
+```rust
+pub struct BuddyAllocator<const TOTAL_PAGES: usize, const BITMAP_WORDS: usize>
+```
+
+- `TOTAL_PAGES` -- how many 4 KiB pages the allocator manages (must be a power of two)
+- `BITMAP_WORDS` -- the number of `u64` words in the allocation bitmap. Use `BuddyAllocator::REQUIRED_BITMAP_WORDS` to compute this.
+
+**Creating an allocator:**
+
+```rust
+// Manage 256 pages (1 MiB) starting at physical address 0x1000_0000.
+type Alloc = BuddyAllocator<256, 16>;
+let mut alloc = Alloc::new(PhysAddr::new(0x1000_0000))?;
+```
+
+The base address must be page-aligned. All blocks start as free at the highest usable order.
+
+**Allocating pages:**
+
+```rust
+let addr = alloc.alloc_pages(0)?;  // 1 page (4 KiB)
+let addr = alloc.alloc_pages(2)?;  // 4 pages (16 KiB)
+let addr = alloc.alloc_pages(8)?;  // 256 pages (1 MiB)
+```
+
+If no block of the requested size is free, the allocator splits a larger block. If no larger block exists either, it returns `OutOfMemory`.
+
+**Freeing pages:**
+
+```rust
+alloc.free_pages(addr, 0)?;  // free a 1-page block
+```
+
+Freed blocks are automatically coalesced with their buddy. If both halves of a pair are free, they merge into a single block at the next order up. This continues recursively until no further merging is possible.
+
+The allocator detects double-frees: attempting to free an already-free block returns `InternalError`.
+
+**Free count:**
+
+```rust
+let free = alloc.free_page_count();  // total free pages across all orders
+```
+
+Internally, the allocator uses `trailing_zeros` on bitmap words for fast first-free-block scanning -- O(1) per 64-bit word instead of checking bit by bit. Pre-computed cumulative bit offsets give O(1) level indexing.
+
+## 4. Memory Regions
+
+A `MemoryRegion` in `rvm-memory/src/lib.rs` describes a contiguous mapping from guest physical address space to host physical address space:
+
+```rust
+pub struct MemoryRegion {
+    pub guest_base: GuestPhysAddr,     // guest physical base (page-aligned)
+    pub host_base: PhysAddr,           // host physical base (page-aligned)
+    pub page_count: usize,             // number of 4 KiB pages
+    pub permissions: MemoryPermissions,
+    pub owner: PartitionId,
+}
+```
+
+**Permissions** are defined by `MemoryPermissions`:
+
+| Constant | Read | Write | Execute |
+|----------|------|-------|---------|
+| `READ_ONLY` | yes | no | no |
+| `READ_WRITE` | yes | yes | no |
+| `READ_EXECUTE` | yes | no | yes |
+
+**Validation:** `validate_region()` checks three conditions:
+
+1. Both `guest_base` and `host_base` must be page-aligned (`AlignmentError`)
+2. `page_count` must be non-zero (`ResourceLimitExceeded`)
+3. At least one permission bit must be set (`Unsupported`)
+
+**Overlap detection:** Two functions check for dangerous overlaps:
+
+- **`regions_overlap(a, b)`** -- checks guest-physical overlap within the same partition. Regions in different partitions have separate guest address spaces, so cross-partition guest overlap is not a conflict.
+
+- **`regions_overlap_host(a, b)`** -- checks host-physical overlap across all partitions. This is a **critical security check**: two partitions mapping the same host physical pages would break isolation entirely. One partition could read or write another's memory.
+
+## 5. Region Manager
+
+`RegionManager` in `rvm-memory/src/region.rs` maintains a fixed-capacity table of `OwnedRegion` entries. It extends the basic `MemoryRegion` concept with tier metadata and lifecycle management.
+
+**`OwnedRegion`** adds tier tracking:
+
+```rust
+pub struct OwnedRegion {
+    pub id: OwnedRegionId,
+    pub owner: PartitionId,
+    pub guest_base: GuestPhysAddr,
+    pub host_base: PhysAddr,
+    pub page_count: u32,
+    pub tier: Tier,                    // Hot | Warm | Dormant | Cold
+    pub permissions: MemoryPermissions,
+}
+```
+
+**`RegionConfig`** is the creation descriptor:
+
+```rust
+pub struct RegionConfig {
+    pub id: OwnedRegionId,
+    pub owner: PartitionId,
+    pub guest_base: GuestPhysAddr,
+    pub host_base: PhysAddr,
+    pub page_count: u32,
+    pub tier: Tier,
+    pub permissions: MemoryPermissions,
+}
+```
+
+**Key operations on `RegionManager<MAX>`:**
+
+| Operation | Description |
+|-----------|-------------|
+| `create(config)` | Create a region. Validates alignment, non-zero page count, and rejects overlaps (guest-physical within same partition, host-physical across all partitions). |
+| `create_auto_id(owner, guest, host, pages, tier, perms)` | Same as `create` but auto-assigns a monotonically increasing `OwnedRegionId`. |
+| `destroy(region_id)` | Remove a region and return it. Frees the slot for reuse. |
+| `transfer(region_id, new_owner)` | Move ownership to a different partition. The guest mapping stays the same. Rejects if the new owner has an overlapping region. |
+| `get(region_id)` / `get_mut(region_id)` | Look up a region by ID. |
+| `translate(owner, guest_addr)` | Translate a guest physical address to a host physical address within the given partition. Returns an `AddressMapping` with the host address and permissions. |
+| `count_for_partition(owner)` | Count regions owned by a partition. |
+| `regions_for_partition(owner, out)` | Write matching region IDs into a caller-provided buffer. |
+
+**`AddressMapping`** is the result of address translation:
+
+```rust
+pub struct AddressMapping {
+    pub guest: GuestPhysAddr,
+    pub host: PhysAddr,
+    pub permissions: MemoryPermissions,
+}
+```
+
+The host-physical overlap check in `create()` is the critical isolation enforcement point. It runs across all partitions regardless of ownership. Without it, a malicious partition could map the same physical memory as another partition and read its secrets.
+
+## 6. Memory Time Travel (Reconstruction)
+
+Dormant memory (Tier 2) is not stored as raw bytes. It is stored as a **compressed checkpoint** plus a sequence of **witness deltas**. To restore a dormant region, the reconstruction pipeline:
+
+1. Loads the checkpoint (compressed snapshot at a known-good state)
+2. Applies the witness delta log in sequence order
+3. Validates the final state hash against the expected value
+
+This means any historical state can be perfectly rebuilt on demand -- days or weeks after the region went dormant.
+
+**`CompressedCheckpoint`** in `rvm-memory/src/reconstruction.rs`:
+
+```rust
+pub struct CompressedCheckpoint {
+    pub id: CheckpointId,
+    pub region_id: OwnedRegionId,
+    pub witness_sequence: u64,    // witness log position at checkpoint time
+    pub uncompressed_hash: u64,   // FNV-1a hash for integrity verification
+    pub uncompressed_size: u32,
+    pub compressed_size: u32,
+}
+```
+
+**`WitnessDelta`** represents a single write operation recorded in the witness log:
+
+```rust
+pub struct WitnessDelta {
+    pub sequence: u64,    // position in the witness log
+    pub offset: u32,      // byte offset within the region
+    pub length: u16,      // bytes written
+    pub data_hash: u64,   // FNV-1a hash of the written data
+}
+```
+
+**`ReconstructionPipeline<MAX_DELTAS>`** orchestrates the reconstruction:
+
+1. Buffer the relevant witness deltas (up to `MAX_DELTAS` at a time)
+2. Decompress the checkpoint into a caller-provided buffer
+3. Apply each delta in sequence order
+4. Compute the hash of the final state and verify it
+
+**`ReconstructionResult`** reports what happened:
+
+```rust
+pub struct ReconstructionResult {
+    pub region_id: OwnedRegionId,
+    pub size_bytes: u32,
+    pub deltas_applied: u32,
+    pub final_hash: u64,
+}
+```
+
+The reconstruction pipeline uses no heap allocation. All buffers are caller-provided with fixed sizes. In production, checkpoint compression would use LZ4 or a hardware compression engine; the current implementation uses a byte-level compression stub that is correct but not optimized.
+
+**`create_checkpoint()`** creates a new checkpoint for a region, capturing its current state as a compressed snapshot with integrity hash.
+
+The witness deltas that feed reconstruction come from the same witness trail that records all mutations in the system. For details on how witness records are structured, signed, and chained, see [Witness and Audit](06-witness-audit.md). For advanced reconstruction scenarios including cross-partition state recovery, see [Advanced: Memory Time Travel](13-advanced-exotic.md).
+
+## 7. Address Types
+
+RVM uses strongly-typed address wrappers to prevent accidental mixing of address spaces. All are defined in `rvm-types/src/addr.rs`:
+
+**`GuestPhysAddr`** -- a guest physical address, scoped to a partition. Each partition has its own guest physical address space isolated by stage-2 page tables.
+
+```rust
+pub struct GuestPhysAddr(u64);
+impl GuestPhysAddr {
+    pub const fn new(addr: u64) -> Self;
+    pub const fn as_u64(self) -> u64;
+    pub const fn is_page_aligned(self) -> bool;   // 4 KiB alignment
+}
+```
+
+**`PhysAddr`** -- a host physical address. This is the actual hardware address.
+
+```rust
+pub struct PhysAddr(u64);
+impl PhysAddr {
+    pub const fn new(addr: u64) -> Self;
+    pub const fn as_u64(self) -> u64;
+    pub const fn is_page_aligned(self) -> bool;
+    pub const fn page_align_down(self) -> Self;   // round down to 4 KiB boundary
+}
+```
+
+**`VirtAddr`** -- a host virtual address, used within the hypervisor's own address space.
+
+```rust
+pub struct VirtAddr(u64);
+impl VirtAddr {
+    pub const fn new(addr: u64) -> Self;
+    pub const fn as_u64(self) -> u64;
+}
+```
+
+All three types are `#[repr(transparent)]` wrappers around `u64` with no runtime overhead. The type system prevents you from accidentally passing a guest physical address where a host physical address is expected -- a class of bug that has caused real hypervisor security vulnerabilities.
+
+---
+
+## Cross-References
+
+| Topic | Chapter |
+|-------|---------|
+| How partitions own memory regions | [Partitions and Scheduling](07-partitions-scheduling.md) |
+| Witness records that feed reconstruction deltas | [Witness and Audit](06-witness-audit.md) |
+| WASM agent memory quotas | [WASM Agents](09-wasm-agents.md) |
+| Stage-2 page tables and VTTBR_EL2 | [Bare Metal](12-bare-metal.md) |
+| Coherence-driven tier placement | [Core Concepts](02-core-concepts.md) |
+| Advanced reconstruction scenarios | [Advanced and Exotic](13-advanced-exotic.md) |
+| Security implications of host-physical overlap | [Security](10-security.md) |
+| Benchmark results for buddy allocator | [Performance](11-performance.md) |
+| Full API reference for `rvm-memory` | [Crate Reference](04-crate-reference.md) |

--- a/userguide/09-wasm-agents.md
+++ b/userguide/09-wasm-agents.md
@@ -1,0 +1,353 @@
+# WebAssembly Agents: Running Code in Partitions
+
+RVM partitions can host WebAssembly modules as an alternative to native AArch64 guests. WASM support is optional and compile-time gated: when disabled, all WASM-related code is excluded from the binary entirely.
+
+This chapter covers module loading and validation, the agent lifecycle, host function dispatch, resource quotas, and the migration protocol.
+
+---
+
+## 1. What Is WASM in RVM?
+
+RVM does not include a full WASM runtime with JIT compilation. Instead, it provides the infrastructure for executing WASM modules inside a sandboxed interpreter within a partition. The key properties:
+
+- **Optional feature.** The `rvm-wasm` crate is compiled into the kernel workspace by default, but all its code is behind `#![no_std]` and `#![forbid(unsafe_code)]`. On a bare-metal deployment where WASM is not needed, it can be excluded from the final binary.
+
+- **Sandboxed execution.** WASM modules run within a partition's memory region. They cannot access memory outside their partition. They cannot make system calls. Their only interface to the hypervisor is through a fixed set of host functions.
+
+- **Capability-gated host functions.** Every host function call is checked against the calling agent's capability token before dispatch. An agent without `WRITE` rights cannot call `Send`. An agent without `EXECUTE` rights cannot call `Spawn`. See section 5 for the full mapping.
+
+- **Witness-logged state transitions.** Every agent lifecycle event (spawn, suspend, resume, terminate, migrate) emits a witness record before the mutation commits. See [Witness and Audit](06-witness-audit.md).
+
+- **Size limit.** `MAX_MODULE_SIZE = 1,048,576` bytes (1 MiB). Modules larger than this are rejected at validation time.
+
+## 2. Module Lifecycle
+
+A WASM module within a partition progresses through four states, defined by `WasmModuleState`:
+
+```
+  Loaded  --->  Validated  --->  Running  --->  Terminated
+```
+
+| State | Meaning |
+|-------|---------|
+| `Loaded` | The module bytes have been received but not yet checked |
+| `Validated` | The module has passed structural validation and is ready to execute |
+| `Running` | The module is actively executing instructions |
+| `Terminated` | The module has been shut down and its resources freed |
+
+**`WasmModuleInfo`** tracks metadata for a loaded module:
+
+```rust
+pub struct WasmModuleInfo {
+    pub partition: PartitionId,    // hosting partition
+    pub state: WasmModuleState,
+    pub size_bytes: u32,
+    pub export_count: u16,         // number of exported functions
+    pub import_count: u16,         // number of imported (host) functions
+}
+```
+
+## 3. Module Validation
+
+`validate_module()` in `rvm-wasm/src/lib.rs` performs structural validation on WASM binary data. It checks four things:
+
+**Step 1: Header check.** The first 8 bytes must be the WASM magic number and version:
+
+```
+Bytes 0-3:  0x00 0x61 0x73 0x6D   (\0asm)
+Bytes 4-7:  0x01 0x00 0x00 0x00   (version 1)
+```
+
+**Step 2: Size check.** The total module size must not exceed `MAX_MODULE_SIZE` (1 MiB).
+
+**Step 3: Section validation.** After the 8-byte header, the validator walks through each section:
+
+- Each section has a 1-byte ID followed by an LEB128-encoded `u32` size
+- The section ID must be a valid `WasmSectionId` (0 through 12)
+- The declared size must fit within the remaining module bytes
+
+**Step 4: Ordering and uniqueness.** Non-custom section IDs must appear in strictly increasing order. No non-custom section may appear twice. Custom sections (ID 0) may appear anywhere and may repeat.
+
+The 13 recognized section types (`WasmSectionId`):
+
+| ID | Name | Content |
+|----|------|---------|
+| 0 | Custom | Name + opaque data (can appear multiple times) |
+| 1 | Type | Function signatures |
+| 2 | Import | Imported functions, tables, memories, globals |
+| 3 | Function | Type indices for defined functions |
+| 4 | Table | Table definitions |
+| 5 | Memory | Memory definitions |
+| 6 | Global | Global variable definitions |
+| 7 | Export | Exported functions, tables, memories, globals |
+| 8 | Start | Index of the start function |
+| 9 | Element | Table initialization data |
+| 10 | Code | Function bodies |
+| 11 | Data | Data segment initialization |
+| 12 | DataCount | Number of data segments (bulk memory proposal) |
+
+On success, `validate_module()` returns a `WasmValidationResult`:
+
+```rust
+pub struct WasmValidationResult {
+    pub section_count: u16,
+    pub has_type: bool,
+    pub has_function: bool,
+    pub has_memory: bool,
+    pub has_export: bool,
+    pub has_code: bool,
+    pub total_payload_bytes: u32,
+}
+```
+
+This tells the caller which sections are present without requiring a second pass. LEB128 decoding rejects non-canonical (over-long) encodings: on the 5th byte of a `u32`, only the low 4 bits may be set.
+
+## 4. Agent Lifecycle
+
+WASM agents have a 7-state lifecycle defined in `rvm-wasm/src/agent.rs`, governed by ADR-140:
+
+```
+                    +---------------+
+                    | Initializing  |
+                    +-------+-------+
+                            |
+                   activate |
+                            v
+                    +-------+-------+
+            +------>|    Running    |<------+
+            |       +---+---+---+--+       |
+            |           |   |   |          |
+      resume|  suspend  |   |   | terminate
+            |           v   |   |
+            |   +-------+-+ |   |
+            +---| Suspended | |   |
+                +-------+-+ |   |
+                        |   |   |
+               hibernate|   |   |
+                        v   |   v
+              +---------+-+ | +-+----------+
+              | Hibernated| | | Terminated |
+              +-----+-----+ | +------------+
+                    |        |
+          reconstruct|       | migrate
+                    v        v
+          +---------+--+ +---+-------+
+          |Reconstructing| | Migrating |
+          +-----+------+ +-----+-----+
+                |               |
+       activate |       complete|
+                v               v
+            Running          Running (at dest)
+```
+
+The seven states (`AgentState`):
+
+| State | Meaning |
+|-------|---------|
+| `Initializing` | Agent is being set up (module loading, validation) |
+| `Running` | Agent is actively executing instructions |
+| `Suspended` | Execution is paused; state is preserved in-place |
+| `Migrating` | Agent is being transferred to another partition (see section 6) |
+| `Hibernated` | Agent state has been serialized to cold storage |
+| `Reconstructing` | Agent is being restored from a hibernation snapshot |
+| `Terminated` | Agent has been shut down and resources freed |
+
+**`AgentManager<MAX>`** manages agents within a partition. Key operations:
+
+| Operation | From State | To State | Witness Event |
+|-----------|-----------|----------|---------------|
+| `spawn(config, witness_log)` | -- | Initializing | `TaskSpawn` |
+| `activate(id)` | Initializing or Reconstructing | Running | -- |
+| `suspend(id, witness_log)` | Running | Suspended | `PartitionSuspend` |
+| `resume(id, witness_log)` | Suspended | Running | `PartitionResume` |
+| `terminate(id, witness_log)` | Any non-terminated | Terminated | `TaskTerminate` |
+
+Each agent is identified by an `AgentId` derived from a capability badge (`AgentId::from_badge(badge)`). Duplicate badges are rejected. When an agent is terminated, its slot is freed for reuse -- without this, terminated agents would permanently occupy slots and eventually exhaust the capacity.
+
+**`AgentConfig`** specifies how to spawn an agent:
+
+```rust
+pub struct AgentConfig {
+    pub badge: u32,                // badge value -> AgentId
+    pub partition_id: PartitionId, // hosting partition
+    pub max_memory_pages: u32,     // memory budget
+}
+```
+
+## 5. Host Functions
+
+WASM agents interact with the hypervisor through a fixed set of 8 host functions, defined in `rvm-wasm/src/host_functions.rs`. Every call is capability-checked before dispatch.
+
+**The host function table:**
+
+| Function | ID | Description | Required Rights |
+|----------|----|-------------|----------------|
+| `Send` | 0 | Send a message to another agent or partition | `WRITE` |
+| `Receive` | 1 | Receive a pending message | `READ` |
+| `Alloc` | 2 | Allocate linear memory pages | `WRITE` |
+| `Free` | 3 | Free previously allocated pages | `WRITE` |
+| `Spawn` | 4 | Spawn a child agent in the same partition | `EXECUTE` |
+| `Yield` | 5 | Yield the current execution quantum | `READ` |
+| `GetTime` | 6 | Read the monotonic timer (nanoseconds) | `READ` |
+| `GetId` | 7 | Return the caller's agent identifier | `READ` |
+
+If the agent's capability token does not include the required rights, the call returns `InsufficientCapability` immediately.
+
+**Dispatch flow:**
+
+```rust
+let result = dispatch_host_call(
+    agent_id,       // who is calling
+    function,       // which host function
+    &args,          // up to 3 u64 arguments
+    &cap_token,     // the agent's capability token
+    &mut host_ctx,  // the kernel's HostContext implementation
+);
+```
+
+The `HostContext` trait connects host function dispatch to real kernel subsystems. Implement it on your kernel struct to wire up IPC, memory allocation, and scheduling. A `StubHostContext` is provided for testing.
+
+**`HostCallResult`** is either `Success(u64)` or `Error(RvmError)`:
+
+```rust
+match result {
+    HostCallResult::Success(value) => { /* use value */ }
+    HostCallResult::Error(err) => { /* handle error */ }
+}
+```
+
+The capability check is the first thing that happens in `dispatch_host_call()`. No kernel subsystem is touched until the caller's rights have been verified. This is a defense-in-depth measure: even if a WASM module has a bug that constructs an invalid function call, the capability gate stops it.
+
+## 6. Migration
+
+WASM agents can be migrated between partitions to optimize coherence. The migration protocol has 7 steps, defined in `rvm-wasm/src/migration.rs`:
+
+| Step | State | What Happens |
+|------|-------|-------------|
+| 1 | Serializing | Agent state is serialized to a portable format |
+| 2 | PausingComms | Inter-partition communication is paused |
+| 3 | TransferringRegions | Memory regions are transferred to the destination partition |
+| 4 | UpdatingEdges | Communication edges in the coherence graph are updated |
+| 5 | UpdatingGraph | The coherence graph topology is updated |
+| 6 | Verifying | State integrity is verified at the destination |
+| 7 | Resuming | The agent resumes execution at the destination |
+
+After step 7, the state becomes `Complete`. If any step fails or the total time exceeds the deadline, the state becomes `Aborted`.
+
+**DC-7 timeout:** `MIGRATION_TIMEOUT_NS = 100,000,000` (100 ms). Every call to `advance()` checks the elapsed time. If the migration has been running longer than the deadline, it is automatically aborted with `MigrationTimeout` and a witness record is emitted.
+
+**`MigrationPlan`** describes a planned migration:
+
+```rust
+pub struct MigrationPlan {
+    pub agent_id: AgentId,
+    pub source_partition: PartitionId,
+    pub dest_partition: PartitionId,
+    pub deadline_ns: u64,          // defaults to MIGRATION_TIMEOUT_NS
+}
+```
+
+Migrating a partition to itself is rejected at `begin()` time -- it is a no-op that would corrupt coherence edges.
+
+**`MigrationTracker`** tracks progress:
+
+```rust
+let mut tracker = MigrationTracker::begin(plan, now_ns)?;
+
+// Advance through each step, passing the current timestamp
+loop {
+    match tracker.advance(now_ns, &witness_log) {
+        Ok(MigrationState::Complete) => break,
+        Ok(_) => continue,
+        Err(RvmError::MigrationTimeout) => { /* handle timeout */ }
+        Err(e) => { /* handle other error */ }
+    }
+}
+```
+
+A completion witness record (`PartitionMigrate`) is emitted when the migration reaches the `Complete` state. A timeout witness record (`MigrationTimeout`) is emitted on abort.
+
+## 7. Resource Quotas
+
+`QuotaTracker` in `rvm-wasm/src/quota.rs` enforces per-partition resource budgets. Each partition running WASM agents is subject to four limits:
+
+**`PartitionQuota`** defines the budget:
+
+```rust
+pub struct PartitionQuota {
+    pub max_cpu_us_per_epoch: u64,   // CPU microseconds per scheduler epoch
+    pub max_memory_pages: u32,       // WASM linear memory pages (64 KiB each)
+    pub max_ipc_per_epoch: u32,      // IPC messages per epoch
+    pub max_agents: u16,             // concurrent agents
+}
+```
+
+The defaults:
+
+| Resource | Default Limit |
+|----------|--------------|
+| CPU time per epoch | 10,000 us (10 ms) |
+| Memory pages | 256 (16 MiB) |
+| IPC messages per epoch | 1,024 |
+| Concurrent agents | 32 |
+
+**Atomic check-and-record:** The quota tracker provides three atomic methods that check the budget and record usage in a single step:
+
+- `check_and_record_cpu(partition, us)` -- check and record CPU microseconds
+- `check_and_record_memory(partition, pages)` -- check and record memory pages
+- `check_and_record_ipc(partition)` -- check and record one IPC message
+
+These replace the older `check_quota()` + `record_usage()` two-step pattern, which was vulnerable to TOCTOU (time-of-check-to-time-of-use) races: a concurrent caller could pass the check before either caller recorded its usage. The atomic methods eliminate this race.
+
+If the requested amount would exceed the quota, no usage is recorded and `ResourceLimitExceeded` is returned.
+
+**`ResourceUsage`** tracks current consumption:
+
+```rust
+pub struct ResourceUsage {
+    pub cpu_us: u64,          // CPU microseconds consumed this epoch
+    pub memory_pages: u32,    // pages currently allocated
+    pub ipc_count: u32,       // IPC messages sent this epoch
+    pub agent_count: u16,     // currently active agents
+}
+```
+
+**Epoch reset:** At the start of each scheduler epoch, call `reset_epoch_counters()` to zero out the per-epoch counters (CPU and IPC). Memory usage is persistent across epochs since memory is not reclaimed at epoch boundaries.
+
+**Enforcement:** `enforce_quota(partition)` returns `true` if the partition is over budget on any dimension. When a partition exceeds its budget, the kernel can terminate the lowest-priority agent to bring usage back under control.
+
+## 8. Enabling WASM
+
+The `rvm-wasm` crate is included in the workspace by default. To use it in a custom kernel build, add it as a dependency:
+
+```toml
+[dependencies]
+rvm-wasm = { path = "crates/rvm-wasm" }
+```
+
+For bare-metal builds, the crate works under `#![no_std]`. Enable `alloc` or `std` features for host testing:
+
+```toml
+rvm-wasm = { path = "crates/rvm-wasm", features = ["std"] }
+```
+
+When you do not need WASM support, simply omit `rvm-wasm` from your dependency list. Since the crate is a separate compilation unit, excluding it removes all WASM code from the final binary.
+
+For how feature flags work across the entire crate tree, see [Architecture: Feature Flags](03-architecture.md). For bare-metal deployment considerations when choosing which optional crates to include, see [Bare Metal](12-bare-metal.md).
+
+---
+
+## Cross-References
+
+| Topic | Chapter |
+|-------|---------|
+| Partitions that host WASM agents | [Partitions and Scheduling](07-partitions-scheduling.md) |
+| Capability tokens used for host function gating | [Capabilities and Proofs](05-capabilities-proofs.md) |
+| Witness records emitted by agent lifecycle events | [Witness and Audit](06-witness-audit.md) |
+| Memory regions and tier placement for agent data | [Memory Model](08-memory-model.md) |
+| Security gate and attestation for WASM modules | [Security](10-security.md) |
+| Coherence graph that drives migration decisions | [Core Concepts](02-core-concepts.md) |
+| Architecture and crate dependency graph | [Architecture](03-architecture.md) |
+| Bare-metal deployment with/without WASM | [Bare Metal](12-bare-metal.md) |
+| Benchmark results for WASM validation | [Performance](11-performance.md) |
+| Full API reference for `rvm-wasm` | [Crate Reference](04-crate-reference.md) |

--- a/userguide/10-security.md
+++ b/userguide/10-security.md
@@ -1,0 +1,408 @@
+# Security Architecture: Defense in Depth
+
+RVM's security model is not a layer bolted on top. It is the system's structure. Every hypercall passes through a three-stage gate. Every mutation is proof-gated. Every decision is witnessed. This chapter describes the gate pipeline, the policy evaluation logic, attestation, resource budgets, input validation, and the results of the security audit.
+
+> **Prerequisite reading:** [Capabilities and Proofs](05-capabilities-proofs.md) for the trust model and proof tiers. [Witness and Audit](06-witness-audit.md) for the witness trail.
+
+---
+
+## 1. The Three-Stage Security Gate
+
+Every privileged operation in RVM enters through the **Security Gate** (`rvm_security::gate`). The gate is the single entry point -- there is no bypass. The pipeline has three mandatory stages:
+
+```
+Hypercall
+  |
+  v
+[Stage 1: Capability Check]  -- Does the caller hold the right type and rights?
+  |
+  v
+[Stage 2: Proof Verification] -- Is the proof commitment valid?
+  |
+  v
+[Stage 3: Witness Logging]   -- Record the decision for audit
+  |
+  v
+Operation proceeds (or is denied)
+```
+
+If any stage fails, a `ProofRejected` witness record is emitted and the operation is denied. Even denials are witnessed -- you can audit who tried what and failed.
+
+### `SecurityGate`
+
+The basic gate wraps a `WitnessLog` reference:
+
+```rust
+use rvm_security::gate::{SecurityGate, GateRequest, GateResponse};
+use rvm_witness::WitnessLog;
+
+let log = WitnessLog::<256>::new();
+let gate = SecurityGate::new(&log);
+```
+
+### `GateRequest`
+
+A request to the gate carries everything needed for evaluation:
+
+```rust
+pub struct GateRequest {
+    pub token: CapToken,              // The capability presented by the caller
+    pub required_type: CapType,       // Expected capability type
+    pub required_rights: CapRights,   // Required rights bitmask
+    pub proof_commitment: Option<WitnessHash>, // P2 proof commitment (if needed)
+    pub require_p3: bool,             // Whether P3 deep proof is required
+    pub p3_chain_valid: bool,         // Advisory only -- gate ignores this
+    pub p3_witness_data: Option<P3WitnessChain>, // Actual chain data for P3
+    pub action: ActionKind,           // What operation is being attempted
+    pub target_object_id: u64,        // Object being acted upon
+    pub timestamp_ns: u64,            // Current timestamp
+}
+```
+
+**Important:** The `p3_chain_valid` field is **advisory only**. The gate does not trust it. When `require_p3` is true, the gate calls its own `verify_p3_chain()` function on the `p3_witness_data`. A caller that sets `p3_chain_valid = true` but supplies a broken chain will be rejected. This was a security fix -- see [Audit Finding: P3 bypass](#security-audit-results).
+
+### `GateResponse`
+
+On success, the gate returns the witness sequence number and the proof tier that was satisfied:
+
+```rust
+pub struct GateResponse {
+    pub witness_sequence: u64,  // Sequence number of the emitted witness record
+    pub proof_tier: u8,         // 1 = P1 only, 2 = P2, 3 = P3
+}
+```
+
+### Gate Pipeline in Detail
+
+1. **P1 Capability Check -- Type Match.** The token's `cap_type()` must equal `required_type`. If not: emit `ProofRejected`, return `CapabilityTypeMismatch`.
+
+2. **P1 Capability Check -- Rights Subset.** The token must carry all `required_rights`. If not: emit `ProofRejected`, return `InsufficientRights`.
+
+3. **P2 Policy Validation -- Proof Commitment.** If `proof_commitment` is `Some`, it must not be the zero hash. A zero commitment is rejected as `PolicyViolation`. If no commitment is required (`None`), the gate reports P1-only (tier = 1).
+
+4. **P3 Deep Proof (if required).** If `require_p3` is true, the gate verifies the `P3WitnessChain` by walking its links and confirming that each link's `record_hash` equals the next link's `prev_hash`. Empty or broken chains are rejected as `DerivationChainBroken`.
+
+5. **Witness Emission.** On success, an allowed-action witness record is appended. On failure at any stage, a `ProofRejected` witness is appended first, then the error is returned.
+
+### `SignedSecurityGate`
+
+The `SignedSecurityGate` extends the basic gate with a `WitnessSigner`. It behaves identically except:
+
+- All witness records (both allowed and rejected) are signed via `signed_append`.
+- P3 chain verification also checks auxiliary signatures on each chain link, providing cryptographic tamper evidence beyond hash-chain continuity.
+
+```rust
+use rvm_security::gate::SignedSecurityGate;
+use rvm_witness::default_signer;
+
+let log = WitnessLog::<256>::new();
+let signer = default_signer();
+let gate = SignedSecurityGate::new(&log, &signer);
+
+let response = gate.check_and_execute(&request)?;
+// Emitted witness record has a non-zero aux field (signed)
+```
+
+Links with all-zero signatures are skipped during verification, maintaining backwards compatibility with unsigned chains.
+
+---
+
+## 2. PolicyRequest and Evaluation
+
+For code paths that need a quick capability check without the full gate pipeline (e.g., internal kernel paths that handle their own witness logging), RVM provides a lightweight `PolicyRequest` evaluator.
+
+### PolicyRequest Fields
+
+```rust
+pub struct PolicyRequest<'a> {
+    pub token: &'a CapToken,               // Capability token
+    pub required_type: CapType,            // Expected type
+    pub required_rights: CapRights,        // Required rights
+    pub proof_commitment: Option<&'a WitnessHash>, // Optional proof commitment
+    pub current_epoch: Option<u32>,        // Optional epoch for staleness check
+}
+```
+
+### Evaluation Stages
+
+The `evaluate()` function checks four stages in order:
+
+| Stage | Check | Error on Failure |
+|-------|-------|-----------------|
+| 0 | **Epoch freshness** -- If `current_epoch` is provided, the token's epoch must match | `InsufficientCapability` |
+| 1 | **Capability type** -- Token type must equal `required_type` | `CapabilityTypeMismatch` |
+| 2 | **Rights** -- Token must contain all `required_rights` | `InsufficientCapability` |
+| 3 | **Proof commitment** -- If provided, must not be the zero hash | `ProofInvalid` |
+
+```rust
+use rvm_security::{PolicyRequest, evaluate, enforce, PolicyDecision};
+use rvm_types::{CapToken, CapType, CapRights};
+
+let token = CapToken::new(1, CapType::Partition, CapRights::READ | CapRights::WRITE, 5);
+
+let request = PolicyRequest {
+    token: &token,
+    required_type: CapType::Partition,
+    required_rights: CapRights::READ,
+    proof_commitment: None,
+    current_epoch: Some(5),
+};
+
+// evaluate() returns Allow or Deny
+match evaluate(&request) {
+    PolicyDecision::Allow => { /* proceed */ }
+    PolicyDecision::Deny(err) => { /* handle */ }
+}
+
+// enforce() returns RvmResult<()> for ergonomic use
+enforce(&request)?;
+```
+
+### P2 Policy Rules (Proof Engine)
+
+The `ProofEngine` uses a separate `PolicyEvaluator` (in `rvm_proof::policy`) that evaluates six P2 rules in **constant time** to prevent timing side-channel leakage. Every rule is evaluated regardless of intermediate failures:
+
+| Rule | What It Checks |
+|------|---------------|
+| `OwnershipChain` | Partition ID is within the valid range (0..=4096) |
+| `RegionBounds` | Region base < region limit (no inverted bounds) |
+| `LeaseExpiry` | Current time <= lease expiry time |
+| `DelegationDepth` | Depth <= 8 |
+| `NonceReplay` | Nonce has not been used before (4096-entry ring + watermark) |
+| `TimeWindow` | Current time <= lease expiry (time-bounded operation) |
+
+The nonce replay ring buffer holds 4096 entries (upgraded from 64 after audit) with a monotonic watermark that rejects any nonce at or below the low-water mark, even if it has been evicted from the ring.
+
+---
+
+## 3. Attestation
+
+The attestation subsystem (`rvm_security::attestation`) builds a tamper-evident chain of boot measurements and runtime witness hashes.
+
+### `AttestationChain`
+
+The chain accumulates up to 64 entries, each tagged as either boot (tag=0) or runtime (tag=1):
+
+```rust
+use rvm_security::AttestationChain;
+
+let mut chain = AttestationChain::new();
+chain.add_boot_measurement([0xAA; 32]);     // e.g., kernel image hash
+chain.add_boot_measurement([0xBB; 32]);     // e.g., device tree hash
+chain.add_runtime_witness([0xCC; 32]);      // e.g., witness log digest
+```
+
+Each entry extends the running chain hash. When `crypto-sha256` is enabled, the extension uses `SHA-256(current_chain_hash || measurement)`. Without it, a legacy FNV-1a overlapping-window scheme is used.
+
+### `AttestationReport`
+
+Generate a report summarizing the chain state:
+
+```rust
+let report = chain.generate_attestation_report();
+// report.entry_count, report.chain_root, 
+// report.boot_measurement_count, report.runtime_witness_count
+```
+
+### Verification
+
+Verify a report against an expected chain root:
+
+```rust
+use rvm_security::verify_attestation;
+
+let expected_root = /* computed independently or received from a trusted source */;
+assert!(verify_attestation(&report, &expected_root));
+```
+
+Verification uses constant-time comparison (`subtle::ConstantTimeEq`) to prevent timing side-channel attacks when the chain root is derived from secrets.
+
+For TEE-backed attestation (binding the chain to a hardware measurement), see [Capabilities and Proofs: TEE-Backed Verification](05-capabilities-proofs.md#5-tee-backed-verification-adr-142).
+
+---
+
+## 4. Resource Budgets
+
+Resource budgets prevent a single partition from starving others by exhausting shared resources.
+
+### DMA Budget
+
+The `DmaBudget` tracks DMA bandwidth per epoch:
+
+```rust
+use rvm_security::DmaBudget;
+
+let mut budget = DmaBudget::new(1_000_000); // 1 MB per epoch
+
+budget.check_dma(500_000)?;  // OK, 500 KB remaining
+budget.check_dma(600_000)?;  // Err(ResourceLimitExceeded) -- over budget
+
+budget.reset(); // New epoch: budget restored
+```
+
+The check uses `checked_add` to prevent integer overflow exploits.
+
+### Resource Quota
+
+The `ResourceQuota` combines four limits per partition:
+
+| Resource | Field | Reset per Epoch? |
+|----------|-------|-----------------|
+| CPU time (ns) | `cpu_time_ns` | Yes |
+| Memory (bytes) | `memory_bytes` | **No** (persistent allocation) |
+| IPC rate (messages) | `ipc_rate` | Yes |
+| DMA bandwidth (bytes) | `dma` | Yes |
+
+```rust
+use rvm_security::ResourceQuota;
+
+let mut quota = ResourceQuota::new(
+    1_000_000,    // 1 ms CPU per epoch
+    4096,         // 4 KiB memory
+    100,          // 100 IPC messages per epoch
+    1_000_000,    // 1 MB DMA per epoch
+);
+
+quota.check_cpu_time(500_000)?;  // OK
+quota.check_memory(2048)?;       // OK
+quota.check_ipc()?;              // OK
+quota.dma.check_dma(100_000)?;   // OK
+
+// At epoch boundary:
+quota.reset_epoch(); // Resets CPU, IPC, DMA. Memory is NOT reset.
+```
+
+Memory is not reset at epoch boundaries because it represents persistent allocation. Use `release_memory(bytes)` to return memory explicitly.
+
+---
+
+## 5. Input Validation
+
+The `rvm_security::validation` module provides boundary validation functions used throughout the kernel.
+
+### Partition ID Validation
+
+```rust
+use rvm_security::validation::validate_partition_id;
+
+validate_partition_id(0)?;     // Err(InvalidPartitionState) -- reserved for hypervisor
+validate_partition_id(1)?;     // Ok
+validate_partition_id(4096)?;  // Ok (maximum)
+validate_partition_id(4097)?;  // Err(PartitionLimitExceeded)
+```
+
+### Region Bounds Validation
+
+Validates page alignment (4 KiB), non-zero size, and overflow safety:
+
+```rust
+use rvm_security::validation::validate_region_bounds;
+
+validate_region_bounds(0x1000, 0x1000)?; // Ok: aligned, no overflow
+validate_region_bounds(0x1001, 0x1000)?; // Err(AlignmentError): unaligned address
+validate_region_bounds(0x1000, 0)?;      // Err(AlignmentError): zero size
+validate_region_bounds(u64::MAX - 0xFFF, 0x2000)?; // Err(MemoryOverlap): overflow
+```
+
+### Capability Rights Validation
+
+Ensures requested rights are a subset of held rights:
+
+```rust
+use rvm_security::validation::validate_capability_rights;
+use rvm_types::CapRights;
+
+let held = CapRights::READ | CapRights::WRITE;
+validate_capability_rights(CapRights::READ, held)?;  // Ok
+validate_capability_rights(CapRights::EXECUTE, held)?; // Err(InsufficientCapability)
+```
+
+### Lease Expiry Validation
+
+```rust
+use rvm_security::validation::validate_lease_expiry;
+
+validate_lease_expiry(100, 50)?;  // Ok: current epoch 50 < expiry 100
+validate_lease_expiry(100, 100)?; // Err(DeviceLeaseExpired): expired
+```
+
+---
+
+## 6. Security Audit Results
+
+RVM underwent a comprehensive security audit. 11 findings were identified, 8 have been fixed.
+
+| Severity | Finding | Fix Applied |
+|----------|---------|-------------|
+| **Critical** | P1 timing side channel in capability bitmask comparison | Constant-time bitmask comparison (`rvm_proof::constant_time`) |
+| **High** | Revocation did not propagate through the full derivation subtree | Iterative subtree walk with explicit stack (replaces recursive descent) |
+| **High** | Cross-partition host memory overlap allowed | Global overlap check before region mapping |
+| **Medium** | Generation counter wrap-around at 0 reuses sentinel | Skip generation 0 on wrap (0 is the invalid sentinel) |
+| **Medium** | `next_id` overflow in capability manager | `checked_add` with `TableFull` error on overflow |
+| **Medium** | Recursive revoke could stack overflow on deep trees | Replaced with iterative stack-based walk |
+| **Medium** | Incomplete merge preconditions allowed invalid merges | Full validation of both partitions before merge |
+| **Low** | Terminated WASM agent slots never freed | Set slot to `None` on agent termination |
+| **Medium** | Nonce ring buffer too small (64 entries) | Upgraded to 4096 entries with monotonic watermark |
+| **Medium** | TOCTOU race in quota check-then-record | Atomic `check_and_record` in single lock hold |
+| **Low** | `NullSigner` always returns true | `StrictSigner` as default; `NullSigner` deprecated and gated behind feature flag |
+
+### Remaining Open Items
+
+Three findings from the audit are deferred or accepted:
+
+- **P3 ZK verification** -- Requires TEE hardware integration. Deferred.
+- **u32 generation counter forgery window** -- Requires 2^32 allocate/free cycles on a single slot to exploit. Accepted as residual risk. Widening to u64 would double `CapSlot` size.
+- **FNV-1a hash chain** -- Not cryptographically strong. Mitigated by `HmacWitnessSigner` when `crypto-sha256` is enabled.
+
+---
+
+## 7. Security Best Practices
+
+### Production Configuration
+
+1. **Always use `StrictSigner` or `HmacWitnessSigner` in production.** Never ship with `NullSigner`. The `null-signer` feature flag exists only for testing.
+
+2. **Enable the `crypto-sha256` feature.** This activates HMAC-SHA256 signing for witness records and SHA-256 for attestation chain extension. Without it, you get FNV-1a (fast but not cryptographically strong).
+
+3. **Replace the default signing key.** The compile-time default key `SHA-256(b"rvm-witness-default-key-v1")` is public. In production, derive keys from the TEE hardware measurement using `derive_key_bundle()`.
+
+4. **Use `SignedSecurityGate` instead of `SecurityGate`.** The signed variant signs every witness record (including rejections) and verifies P3 chain signatures.
+
+### Input Validation
+
+5. **Validate all inputs at system boundaries.** Use the `rvm_security::validation` functions before any state mutation. Never trust partition IDs, region bounds, or rights bitmasks from untrusted callers.
+
+6. **Never skip P2 policy evaluation.** Even if P1 passes, P2 catches structural violations (inverted region bounds, nonce replay, expired leases, excessive delegation depth).
+
+### Capability Hygiene
+
+7. **Grant minimum necessary rights.** Follow the principle of least privilege. If a partition only needs to read a region, grant `READ` only.
+
+8. **Use `GRANT_ONCE` for non-transitive delegation.** Prevents authority from propagating beyond the intended recipient.
+
+9. **Use epoch-based revocation for bulk invalidation.** When you need to revoke all capabilities issued before a certain point, increment the epoch. All tokens from prior epochs become stale.
+
+10. **Keep delegation depth shallow.** The 8-level limit exists for a reason. Deep chains are harder to audit and slower to revoke.
+
+### Monitoring
+
+11. **Monitor `ManagerStats`.** Watch `caps_created`, `caps_granted`, `caps_revoked`, and `max_depth_reached` for anomalies.
+
+12. **Periodically verify the witness chain.** Run `verify_chain()` on snapshots to detect tampering.
+
+13. **Set resource quotas.** Every partition should have a `ResourceQuota` with meaningful limits for CPU, memory, IPC, and DMA.
+
+---
+
+## Cross-References
+
+- **Capability types, rights, and delegation** -- The trust model this gate enforces: [Capabilities and Proofs](05-capabilities-proofs.md)
+- **Witness trail format and signing** -- What the gate emits on every decision: [Witness and Audit](06-witness-audit.md)
+- **TEE-backed verification** -- Hardware attestation for stronger signing: [Capabilities and Proofs: TEE](05-capabilities-proofs.md#5-tee-backed-verification-adr-142)
+- **Partition lifecycle security** -- How split, merge, and migration interact with the gate: [Partitions and Scheduling](07-partitions-scheduling.md)
+- **Memory isolation** -- How region capabilities prevent cross-partition access: [Memory Model](08-memory-model.md)
+- **WASM agent sandboxing** -- How agent quotas and capabilities are enforced: [WASM Agents](09-wasm-agents.md)
+- **Performance impact of security checks** -- Latency budgets for P1/P2/P3: [Performance](11-performance.md)
+- **Bare-metal boot security** -- Measured boot and attestation chain initialization: [Bare Metal](12-bare-metal.md)
+- **Crate API surface** -- `rvm-security`, `rvm-proof`, `rvm-cap`: [Crate Reference](04-crate-reference.md)
+- **Glossary** -- Definitions of security gate, attestation, policy decision, DMA budget: [Glossary](15-glossary.md)

--- a/userguide/11-performance.md
+++ b/userguide/11-performance.md
@@ -1,0 +1,306 @@
+# Performance: Benchmarks and Tuning
+
+RVM is designed for predictable, low-latency operation on bare-metal hardware.
+Every hot-path operation has an ADR-specified time budget, and the benchmark
+suite proves that the implementation meets or exceeds those budgets -- often by
+orders of magnitude. This chapter walks through the benchmark suite, explains
+the build profiles that enable peak throughput, and provides tuning guidance.
+
+For the overall architecture that makes this performance possible, see
+[Architecture](03-architecture.md). For the partition switch hot path in
+particular, see [Partitions and Scheduling](07-partitions-scheduling.md).
+
+---
+
+## 1. Benchmark Suite
+
+RVM ships 11 Criterion benchmarks in `benches/benches/rvm_bench.rs`. Each
+benchmark targets a specific hot-path operation called out in the ADR
+documents (ADR-132, ADR-134, ADR-135).
+
+| Benchmark | What It Measures | ADR Target | Measured | Headroom |
+|---|---|---|---|---|
+| `bench_witness_emit` | Single witness record emission into the ring buffer | < 500 ns | ~17 ns | 29x faster |
+| `bench_p1_verify` | P1 capability check (`verify_p1` on a `CapabilityManager`) | < 1 us | < 1 ns | 1000x faster |
+| `bench_p2_verify` | P2 proof engine pipeline (P1 + P2 + witness emission) | < 100 us | ~996 ns | 100x faster |
+| `bench_partition_switch` | Partition context switch (enqueue + dequeue cycle) | < 10 us | ~6 ns | 1600x faster |
+| `bench_coherence_score` | Coherence score computation on a 16-node graph | budgeted | ~84 ns | -- |
+| `bench_mincut` | MinCut on a 16-node chain graph | < 50 us | ~331 ns | 150x faster |
+| `bench_buddy_alloc` | Buddy allocator alloc/free cycle | fast | ~184 ns | -- |
+| `bench_fnv1a_hash` | FNV-1a hash of 64 bytes | fast | ~28 ns | -- |
+| `bench_security_gate` | P1 security gate pass (`check_and_execute`) | fast | ~17 ns | -- |
+| `bench_witness_verify_chain` | Verification of a 64-record witness chain | fast | ~892 ns | -- |
+| `bench_cut_pressure` | Cut pressure computation across 16 nodes | fast | -- | -- |
+
+Every benchmark with an explicit ADR target exceeds its budget by at least one
+order of magnitude. The "fast" targets are internal design goals rather than
+hard ADR requirements.
+
+### Sub-benchmarks
+
+Several top-level benchmarks include sub-benchmarks for bulk and stress
+scenarios:
+
+- `witness_emit_10000` -- 10,000 witness emissions in a single burst.
+- `p1_verify_10000` -- 10,000 consecutive P1 checks on the same capability.
+- `partition_switch_with_pressure` -- 8 partitions with varying cut pressure.
+- `coherence_recompute_all_16node` -- Recompute scores for all 16 nodes at once.
+- `mincut_4node` / `mincut_16node` -- MinCut at two different graph sizes.
+- `buddy_alloc_order0_256` / `buddy_alloc_free_cycle_1000` / `buddy_alloc_mixed_orders` -- Various allocation patterns.
+- `fnv1a_64_bytes_x10000` / `fnv1a_256_bytes` -- Hash throughput at different data sizes.
+- `security_gate_check_p1` / `security_gate_check_p2` -- Gate with and without proof commitment.
+
+---
+
+## 2. Running Benchmarks
+
+**Run the full suite:**
+
+```bash
+cargo bench
+```
+
+**Run only the RVM benchmarks (skip any other workspace members):**
+
+```bash
+cargo bench -p rvm-benches
+```
+
+**Run a single benchmark by name:**
+
+```bash
+cargo bench -- "p1_verify"
+```
+
+Criterion generates HTML reports under `target/criterion/`. Open
+`target/criterion/report/index.html` in a browser to view graphs, regressions,
+and statistical comparisons against previous runs.
+
+**Comparing against a baseline:**
+
+```bash
+cargo bench -- --save-baseline before-change
+# ... make your change ...
+cargo bench -- --baseline before-change
+```
+
+Criterion will report whether each benchmark got faster, slower, or stayed
+within noise.
+
+---
+
+## 3. Build Profiles
+
+The workspace `Cargo.toml` defines three profiles that control compilation
+behavior.
+
+### Release (production and benchmarks)
+
+```toml
+[profile.release]
+opt-level = 3       # Maximum optimization
+lto = "fat"         # Full link-time optimization across all crates
+codegen-units = 1   # Single codegen unit -- slower compile, better code
+strip = true        # Remove debug symbols from the binary
+panic = "abort"     # No unwinding -- smaller binary, faster panics
+```
+
+This profile produces the smallest, fastest binary. It is the default for
+`make build` and `make run`. Fat LTO with a single codegen unit enables the
+compiler to inline across crate boundaries -- critical for operations like
+`verify_p1` where the entire call chain collapses to a few instructions.
+
+### Bench (criterion benchmarks)
+
+```toml
+[profile.bench]
+inherits = "release"
+debug = true         # Keep debug info for profiling (perf, Instruments)
+```
+
+Identical optimization level to release, but retains debug symbols so that
+profilers can map instruction addresses back to source lines.
+
+### Dev (development and testing)
+
+```toml
+[profile.dev]
+opt-level = 0       # No optimization -- fast compile
+debug = true        # Full debug info
+```
+
+Used by `cargo test` and `cargo check`. Compile times are fast but runtime
+performance is not representative. Never benchmark in dev profile.
+
+---
+
+## 4. Hot Path Optimization
+
+The partition switch is the most performance-critical operation in RVM. It
+runs on every scheduling tick, potentially millions of times per second. The
+implementation follows a strict discipline:
+
+**No allocation.** The switch path touches only pre-allocated per-CPU run
+queues. No buddy allocator calls, no ring buffer resizing.
+
+**No graph work.** Coherence scores and cut pressures are computed
+asynchronously during epoch boundaries, not during the switch itself. The
+scheduler reads pre-computed values.
+
+**No policy evaluation.** Security gate checks happen when a partition is
+*created* or when a capability is *exercised*, not on every context switch.
+The switch path only reads the priority value.
+
+**Constant-time priority comparison.** The 2-signal priority
+(`deadline_urgency + cut_pressure_boost`) is computed as a single `u32`
+addition. No loops, no branches beyond the run queue scan.
+
+The result: ~6 ns per switch on a modern x86-64 host, or roughly 1600x under
+the 10 us ADR budget.
+
+For contrast, the P2 proof engine pipeline *intentionally* does more work. It
+chains a P1 capability check, policy evaluation, and witness emission into a
+single call. At ~996 ns, it is still 100x under its 100 us budget, but it is
+not on the per-switch hot path.
+
+---
+
+## 5. Design for Performance
+
+The following architectural decisions contribute to RVM's performance across
+all subsystems. For the full design rationale, see [Core
+Concepts](02-core-concepts.md) and [Architecture](03-architecture.md).
+
+### Constant-time operations
+
+Capability lookup (`verify_p1`) is an array index plus generation check --
+O(1). Witness emission is a ring buffer write -- O(1). Priority computation
+is arithmetic on two integers -- O(1). The only non-constant-time operations
+in the hot path are the coherence graph algorithms (MinCut, score
+recomputation), and those are gated by the adaptive engine to run at reduced
+frequency under load.
+
+### Fixed-point arithmetic
+
+RVM uses no floating-point math anywhere. Coherence scores, cut pressures,
+EMA filter weights, and Phi values are all represented in basis points
+(hundredths of a percent, where 10,000 = 100%). This avoids FPU context
+save/restore during partition switches and guarantees bitwise determinism
+across platforms. See [Glossary: EMA Filter](15-glossary.md).
+
+### Cache-line alignment
+
+Witness records are exactly 64 bytes -- one cache line on most architectures.
+This means each record fits in a single cache-line fetch with no
+false-sharing between adjacent records. The `WitnessRecord` layout is
+documented in [Witness and Audit](06-witness-audit.md).
+
+### `no_std` / no heap
+
+Every RVM crate is `#![no_std]` and `#![forbid(unsafe_code)]` (except
+`rvm-hal`, which needs `unsafe` for hardware access). No crate allocates from
+the heap in its default configuration. All data structures use compile-time
+const generics for capacity:
+
+```rust
+// 256-slot capability manager, 16-node coherence graph
+let cap_mgr = CapabilityManager::<256>::with_defaults();
+let graph = CoherenceGraph::<16, 128>::new();
+let sched = Scheduler::<4, 256>::new();
+```
+
+This eliminates allocator overhead, prevents fragmentation, and makes worst-
+case memory usage fully predictable at compile time.
+
+---
+
+## 6. Tuning Tips
+
+### Feature flags
+
+Each crate exposes feature flags that control optional subsystems. Disabling
+unused features removes dead code and can improve instruction cache behavior.
+
+| Flag | Crate | Effect |
+|---|---|---|
+| `ruvector` | rvm-coherence | Enables RuVector coherence engine backend |
+| `sched` | rvm-coherence | Direct scheduler feedback integration |
+| `crypto-sha256` | rvm-proof, rvm-boot | Uses real SHA-256 instead of FNV-1a |
+| `ed25519` | rvm-proof | Enables Ed25519 witness signatures |
+| `null-signer` | rvm-proof, rvm-witness | Enables NullSigner for testing (never use in production) |
+| `alloc` | all crates | Enables APIs that require an allocator |
+| `std` | all crates | Enables std-dependent features |
+
+For the smallest possible kernel image (Seed hardware profile), disable
+`ruvector`, `alloc`, and `std`.
+
+### Ring buffer capacity
+
+The witness log uses a compile-time ring buffer:
+
+```rust
+let log = WitnessLog::<4096>::new();  // 4096 records = 256 KB
+```
+
+The default capacity is 262,144 records (16 MB). For memory-constrained
+deployments, reduce this. The trade-off is that a smaller ring overwrites
+older records sooner. If you need complete audit trails, drain the ring to
+persistent storage before it wraps. See [Witness and
+Audit](06-witness-audit.md) for the ring buffer semantics.
+
+### EMA alpha
+
+The `EmaFilter` smoothing factor controls how quickly coherence scores react
+to changes. The alpha is expressed in basis points:
+
+| Alpha | Behavior |
+|---|---|
+| 1000 (10%) | Slow, very smooth -- good for stable workloads |
+| 3000 (30%) | Moderate -- recommended default |
+| 5000 (50%) | Responsive -- good for bursty workloads |
+| 8000 (80%) | Very responsive -- tracks rapid changes, more noise |
+
+Higher alpha values make the scheduler react faster to coherence shifts but
+amplify measurement noise. Lower values produce smoother scheduling behavior
+but delay reaction to genuine changes.
+
+### Adaptive coherence engine
+
+The `AdaptiveCoherenceEngine` throttles coherence recomputation under CPU
+pressure:
+
+| CPU Load | Recomputation Frequency |
+|---|---|
+| < 60% | Every epoch |
+| 60 -- 80% | Every 2nd epoch |
+| > 80% | Every 4th epoch |
+
+This is automatic. You do not need to tune it unless you are running on
+hardware where the coherence computation itself is a significant fraction of
+the epoch budget. In that case, the `budget_exceeded_count` field tells you
+how often the system is dropping computations. See
+[Advanced and Exotic](13-advanced-exotic.md) for details on the adaptive
+engine.
+
+### MinCut budget
+
+The `MinCutBridge` accepts a budget parameter (maximum iterations):
+
+```rust
+let mut bridge = MinCutBridge::<16>::new(200);  // up to 200 iterations
+```
+
+A smaller budget means faster (but less accurate) cut computations. For
+production use, start with the default and reduce only if
+`MinCutBudgetExceeded` errors appear in the witness log.
+
+---
+
+## Further Reading
+
+- [Architecture](03-architecture.md) -- crate layer diagram and data flow
+- [Partitions and Scheduling](07-partitions-scheduling.md) -- the switch hot path in detail
+- [Witness and Audit](06-witness-audit.md) -- ring buffer design and chain integrity
+- [Advanced and Exotic](13-advanced-exotic.md) -- adaptive coherence and RuVector integration
+- [Troubleshooting](14-troubleshooting.md) -- what to do when performance is not as expected
+- [Cross-Reference Index](cross-reference.md) -- find every mention of a concept

--- a/userguide/12-bare-metal.md
+++ b/userguide/12-bare-metal.md
@@ -1,0 +1,410 @@
+# Bare-Metal Deployment: Running on Real Hardware
+
+RVM is not a library that runs inside an operating system. It *is* the
+operating system -- a microhypervisor that boots from a reset vector, sets up
+page tables, and takes control of the hardware. This chapter explains how to
+build the bare-metal kernel image, run it on QEMU, understand the boot
+sequence, and prepare for deployment on physical hardware.
+
+For the architecture of the crates that compose the kernel, see
+[Architecture](03-architecture.md). For the seven-phase boot sequence from
+the software perspective, see the `rvm-boot` entry in [Crate
+Reference](04-crate-reference.md).
+
+---
+
+## 1. Prerequisites
+
+You need the following tools installed before building a bare-metal kernel.
+
+**Rust 1.77 or later:**
+
+```bash
+rustup update stable
+rustc --version  # 1.77.0+
+```
+
+**AArch64 bare-metal target:**
+
+```bash
+rustup target add aarch64-unknown-none
+```
+
+This installs the `core` library cross-compiled for AArch64 with no OS. RVM
+does not link against `std` or any C runtime.
+
+**cargo-binutils (for ELF-to-binary conversion):**
+
+```bash
+cargo install cargo-binutils
+rustup component add llvm-tools
+```
+
+This provides `rust-objcopy` (for converting ELF to raw binary) and
+`rust-objdump` (for disassembly).
+
+**QEMU (for emulated boot):**
+
+```bash
+# macOS
+brew install qemu
+
+# Ubuntu / Debian
+sudo apt install qemu-system-aarch64
+
+# Verify
+qemu-system-aarch64 --version
+```
+
+QEMU 8.0 or later is recommended. The `virt` machine type that RVM targets
+is well-tested across QEMU versions.
+
+---
+
+## 2. The Linker Script (`rvm.ld`)
+
+The file `rvm.ld` at the workspace root controls the memory layout of the
+kernel image. It tells the linker where to place each section in physical
+memory.
+
+### Entry point
+
+```text
+ENTRY(_start)
+```
+
+The symbol `_start` is defined in `rvm-hal`'s AArch64 assembly boot stub. It
+is the first instruction the CPU executes after reset.
+
+### Memory map
+
+```text
+MEMORY {
+    RAM (rwx) : ORIGIN = 0x40000000, LENGTH = 128M
+}
+```
+
+QEMU's `virt` machine places RAM at physical address `0x4000_0000`. The
+linker script tells Rust to place all code and data within this 128 MB region.
+On physical hardware, adjust the origin and length to match your board's
+memory map.
+
+### Section layout
+
+| Section | Alignment | Contents |
+|---|---|---|
+| `.text.boot` | Load address (0x4000_0000) | Assembly boot stub: EL2 check, stack setup, BSS clear |
+| `.text` | 4 bytes | All Rust code |
+| `.rodata` | 8 bytes | Read-only data (string literals, const tables) |
+| `.data` | 8 bytes | Initialized mutable data |
+| `.bss` | 16 bytes | Zero-initialized mutable data |
+| Stack | 4 KB page | 64 KB hypervisor stack, growing downward |
+| Page tables | 4 KB page | L1 + 4 L2 page tables (5 x 4 KB = 20 KB) |
+| Heap | 4 KB page | Optional, reserved for future use |
+
+### Exported symbols
+
+The linker script exports symbols that the boot code uses:
+
+| Symbol | Purpose |
+|---|---|
+| `_start` | Entry point (in `.text.boot`) |
+| `__bss_start` | Start of BSS (zeroed during boot) |
+| `__bss_end` | End of BSS |
+| `__stack_top` | Initial stack pointer |
+| `__page_tables` | Start of page table region |
+| `__heap_start` | Start of optional heap region |
+
+---
+
+## 3. Build Steps
+
+The `Makefile` in the workspace root provides the standard build targets.
+
+### Type-check (fast verification)
+
+```bash
+make check
+```
+
+This runs `cargo check --target aarch64-unknown-none -p rvm-hal`. It
+verifies that the HAL crate compiles for the bare-metal target without
+producing a binary. Use this during development for fast feedback.
+
+### Build the kernel ELF
+
+```bash
+make build
+```
+
+This runs:
+
+```bash
+RUSTFLAGS="-C link-arg=-Trvm.ld" cargo build --target aarch64-unknown-none --release -p rvm-kernel
+```
+
+The output is an ELF binary at
+`target/aarch64-unknown-none/release/rvm-kernel`. The release profile applies
+opt-level 3, fat LTO, single codegen unit, symbol stripping, and
+`panic=abort`. See [Performance](11-performance.md) for details on the
+release profile.
+
+### Convert to raw binary
+
+```bash
+make bin
+```
+
+This strips the ELF headers and produces a flat binary at
+`target/aarch64-unknown-none/release/rvm-kernel.bin`. Use this format when
+your bootloader expects a raw image rather than ELF.
+
+### Disassemble
+
+```bash
+make objdump
+```
+
+This runs `rust-objdump -d` on the kernel ELF and prints the first 200 lines
+of disassembly. Useful for verifying that `_start` is at the expected load
+address and inspecting generated code quality.
+
+---
+
+## 4. QEMU Boot
+
+```bash
+make run
+```
+
+This executes:
+
+```bash
+qemu-system-aarch64 \
+    -M virt \
+    -cpu cortex-a72 \
+    -m 128M \
+    -nographic \
+    -kernel target/aarch64-unknown-none/release/rvm-kernel
+```
+
+### QEMU parameters explained
+
+| Flag | Value | Purpose |
+|---|---|---|
+| `-M` | `virt` | ARM virtual platform -- PL011 UART, GICv2, generic timer |
+| `-cpu` | `cortex-a72` | ARMv8-A CPU with EL2 support |
+| `-m` | `128M` | 128 MB of RAM starting at 0x4000_0000 |
+| `-nographic` | -- | UART output goes to the terminal (no GUI window) |
+| `-kernel` | ELF path | QEMU loads the ELF and jumps to its entry point |
+
+Press **Ctrl-A X** to exit QEMU.
+
+### What you should see
+
+On a successful boot, the kernel prints a banner and phase completions to the
+PL011 UART:
+
+```text
+[RVM] Boot phase 0: HAL init ... OK
+[RVM] Boot phase 1: Memory init ... OK
+[RVM] Boot phase 2: Capability init ... OK
+[RVM] Boot phase 3: Witness init ... OK
+[RVM] Boot phase 4: Scheduler init ... OK
+[RVM] Boot phase 5: Root partition ... OK
+[RVM] Boot phase 6: Handoff ... OK
+[RVM] Kernel ready. 7/7 phases complete.
+```
+
+If QEMU hangs at startup, see [Troubleshooting](14-troubleshooting.md).
+
+---
+
+## 5. The Boot Sequence
+
+RVM follows a 7-phase deterministic boot sequence defined in ADR-137. Each
+phase is gated: the next phase cannot begin until the current one completes
+successfully and emits a witness record.
+
+```text
+Phase 0: HAL init         -- timer, MMU stubs, interrupt controller
+Phase 1: Memory init      -- physical page allocator (BuddyAllocator)
+Phase 2: Capability init  -- capability table with root capabilities
+Phase 3: Witness init     -- witness log ring buffer, genesis record
+Phase 4: Scheduler init   -- per-CPU run queues, epoch tracker
+Phase 5: Root partition   -- create partition 0 with full rights
+Phase 6: Handoff          -- transfer control to the root partition
+```
+
+### Phase flow
+
+The `BootSequence` struct in `rvm-boot` tracks which phases have completed.
+It enforces ordering: calling `complete_stage()` for phase N when phase N-1
+has not completed returns an error.
+
+Each phase extends the measured boot hash chain (see section 6 below). The
+`BootContext` struct holds all transient state needed during boot:
+
+```rust
+pub struct BootContext {
+    pub sequence: BootSequence,    // Phase tracker
+    pub measured: MeasuredBootState, // Hash chain
+    pub dtb_ptr: u64,             // Device tree blob pointer
+    pub ram_size: u64,            // Detected RAM
+    pub uart_ready: bool,         // UART available for output
+}
+```
+
+### Phase 0: HAL init
+
+The platform HAL initializes:
+- PL011 UART for debug output
+- ARM generic timer for monotonic time
+- GICv2 interrupt controller
+- Stage-2 MMU stubs (identity mapping for early boot)
+
+### Phase 5: Root partition
+
+The root partition (partition 0) is created with full capability rights
+(`READ | WRITE | EXECUTE | GRANT | REVOKE | PROVE`). It owns all physical
+memory and all device leases. Subsequent partitions are created by the root
+partition delegating subsets of its authority.
+
+### Phase 6: Handoff
+
+The scheduler begins its main loop. Control passes to the root partition's
+first vCPU. From this point forward, RVM is fully operational.
+
+For the full API of each boot phase, see the `rvm-boot` section of [Crate
+Reference](04-crate-reference.md).
+
+---
+
+## 6. Measured Boot
+
+The `MeasuredBootState` struct accumulates a cryptographic hash chain during
+boot for remote attestation.
+
+Before each phase executes, its code hash is extended into a running
+accumulator:
+
+```text
+accumulator[n+1] = SHA-256(accumulator[n] || phase_index || phase_hash)
+```
+
+When the `crypto-sha256` feature is disabled (for minimal builds), the
+fallback uses four overlapping FNV-1a windows to fill the 32-byte
+accumulator.
+
+The final attestation digest proves that exactly these code paths executed in
+exactly this order. A remote verifier can compare the digest against a
+known-good reference to detect tampering.
+
+Key properties:
+
+- **Deterministic.** The same code always produces the same digest.
+- **Order-sensitive.** Swapping two phases produces a different digest.
+- **Tamper-evident.** Changing any input byte changes the final digest.
+- **Per-phase audit.** Individual phase hashes are recorded for replay.
+
+```rust
+let state = MeasuredBootState::new();
+state.extend_measurement(BootStage::ResetVector, &phase_0_hash);
+// ... extend for each phase ...
+let digest = state.get_attestation_digest(); // [u8; 32]
+```
+
+See [Security](10-security.md) for how measured boot integrates with the
+TEE attestation pipeline.
+
+---
+
+## 7. Hardware Profile: Seed
+
+The Seed profile targets microcontroller-class hardware with 64 KB to 1 MB
+of RAM. At this scale, RVM provides:
+
+- Capability-enforced partition isolation
+- Witness trail (reduced ring buffer, e.g., 64 records = 4 KB)
+- Proof-gated mutations (P1 and P2 tiers)
+- Deterministic boot with measured attestation
+
+What Seed omits:
+
+- Coherence engine (no graph computation at this scale)
+- WASM runtime (insufficient memory)
+- Dormant/cold memory tiers (only hot and warm)
+- MinCut and adaptive recomputation
+
+To build for Seed, disable the `ruvector`, `alloc`, and `std` features and
+set a small ring buffer capacity. The kernel footprint can be as small as a
+few kilobytes of code plus the witness ring.
+
+This is unique: no other hypervisor provides capability + proof + witness
+security on devices that typically run bare C with no isolation at all. See
+[Advanced and Exotic](13-advanced-exotic.md) for a deeper discussion.
+
+---
+
+## 8. Hardware Profile: Appliance
+
+The Appliance profile targets systems with 1 to 32 GB of RAM. At this scale,
+RVM enables the full feature set:
+
+- Full coherence engine with MinCut and adaptive recomputation
+- Four-tier memory model (hot, warm, dormant, cold)
+- WASM agent runtime with per-epoch resource quotas
+- Live partition split and merge
+- RuVector integration for spectral graph analysis
+
+This profile is intended for edge computing appliances, automotive ECUs,
+industrial gateways, and multi-agent orchestration platforms.
+
+---
+
+## 9. Cargo Config
+
+The file `.cargo/config.toml` provides default flags for bare-metal builds:
+
+```toml
+[target.aarch64-unknown-none]
+rustflags = ["-C", "link-arg=-Trvm.ld"]
+```
+
+This tells Cargo to pass the linker script automatically whenever building
+for `aarch64-unknown-none`. You do not need to set `RUSTFLAGS` manually
+unless you are overriding the linker script path.
+
+For host-target builds (`cargo test`, `cargo bench`), this config has no
+effect. The linker script is only used when building for the bare-metal
+target.
+
+---
+
+## 10. CI Pipeline
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs four checks on
+every push and pull request:
+
+| Step | Command | Purpose |
+|---|---|---|
+| Host check | `cargo check` | Verify all crates compile on the host |
+| Host tests | `cargo test` | Run the full 648-test suite |
+| Clippy | `cargo clippy -- -D warnings` | Lint enforcement (zero warnings) |
+| Cross-compile | `cargo check --target aarch64-unknown-none -p rvm-hal --no-default-features` | Verify the HAL compiles for bare metal |
+
+The cross-compile step does not *run* the kernel (QEMU is not available in
+CI). It only verifies that the code compiles for the bare-metal target. To
+run the kernel, use `make run` on a machine with QEMU installed.
+
+---
+
+## Further Reading
+
+- [Quick Start](01-quickstart.md) -- five-minute build and boot guide
+- [Architecture](03-architecture.md) -- crate dependency tree and layer responsibilities
+- [Performance](11-performance.md) -- benchmark suite and build profile details
+- [Security](10-security.md) -- TEE integration and measured boot attestation
+- [Advanced and Exotic](13-advanced-exotic.md) -- Seed and Appliance profiles in depth
+- [Troubleshooting](14-troubleshooting.md) -- what to do when QEMU does not boot
+- [Cross-Reference Index](cross-reference.md) -- find every mention of a concept

--- a/userguide/13-advanced-exotic.md
+++ b/userguide/13-advanced-exotic.md
@@ -1,0 +1,411 @@
+# Advanced and Exotic: Novel Capabilities
+
+RVM contains six capabilities with no prior art in existing hypervisors or
+operating systems. Each emerged from the intersection of coherence theory,
+capability security, and bare-metal systems engineering. This chapter explains
+what each capability is, why it matters, and where to find the implementation
+in the codebase.
+
+For the foundational concepts behind these capabilities, start with [Core
+Concepts](02-core-concepts.md). For the API surface, see [Crate
+Reference](04-crate-reference.md).
+
+---
+
+## 1. Kernel-Level Graph Control Loop
+
+**No other operating system uses spectral graph coherence as a first-class
+scheduling signal.**
+
+Traditional hypervisors schedule partitions by deadline, priority, or fair
+share. RVM adds a second signal: *cut pressure*, derived from the coherence
+graph. The coherence engine computes how tightly coupled each partition is to
+its neighbors, and the scheduler uses that signal to prioritize partitions
+that are part of an active communication cluster.
+
+### How it works
+
+1. The `CoherenceGraph` (in `rvm-coherence`) maintains a weighted adjacency
+   structure where nodes are partitions and edges represent communication
+   channels (`CommEdge`). Edge weights are updated as IPC traffic flows.
+
+2. The scoring module (`rvm_coherence::scoring`) computes a `CoherenceScore`
+   for each partition as the ratio of internal weight (self-loops) to total
+   weight (all incident edges). Higher scores mean the partition is more
+   self-contained; lower scores mean it is heavily coupled to neighbors.
+
+3. The `EmaFilter` (in `rvm-coherence`) smooths raw scores using fixed-point
+   exponential moving averages. This prevents scheduling jitter from noisy
+   measurements.
+
+4. The pressure module (`rvm_coherence::pressure`) derives a `CutPressure`
+   signal from the graph structure. High cut pressure means the partition
+   sits on a weak cut boundary -- it might benefit from migration or splitting.
+
+5. The `AdaptiveCoherenceEngine` throttles recomputation frequency based on
+   CPU load: every epoch below 60% load, every 2nd epoch at 60-80%, every
+   4th epoch above 80%.
+
+6. The scheduler (`rvm-sched`) combines two signals into a single priority:
+
+   ```text
+   priority = deadline_urgency + cut_pressure_boost
+   ```
+
+   Partitions with high cut pressure receive a scheduling boost, ensuring
+   that coupled workloads run in close temporal proximity.
+
+### Where to look
+
+| Component | Crate | Module |
+|---|---|---|
+| Graph structure | rvm-coherence | `graph` |
+| Score computation | rvm-coherence | `scoring` |
+| Cut pressure | rvm-coherence | `pressure` |
+| MinCut | rvm-coherence | `mincut` |
+| Adaptive throttle | rvm-coherence | `adaptive` |
+| EMA filter | rvm-coherence | root (`EmaFilter`) |
+| 2-signal priority | rvm-sched | `priority` |
+
+---
+
+## 2. Reconstructable Memory (Time Travel)
+
+**Unlike demand paging, RVM can reconstruct any historical memory state from
+a checkpoint plus the witness trail.**
+
+Traditional hypervisors page memory in and out of physical frames. When a
+page is evicted, its contents are written to swap. When it is needed again,
+the swap image is loaded. There is no concept of *historical* state -- you
+can only access the current version.
+
+RVM's dormant memory tier (Tier 2) stores state differently. Instead of a
+raw swap image, a dormant region consists of:
+
+1. A `CompressedCheckpoint` -- a snapshot of the region at a known-good point.
+2. A sequence of `WitnessDelta` records -- every mutation since the checkpoint.
+
+To restore a dormant region, the `ReconstructionPipeline` (in `rvm-memory`)
+replays the deltas on top of the checkpoint:
+
+```text
+Load checkpoint --> Decompress --> Apply deltas in order --> Validate hash
+```
+
+Because the witness trail records *every* mutation with timestamps, you can
+reconstruct the state of any region at any point in time, not just the latest
+version. This enables forensic queries like "what was the state of region X
+between 14:00 and 14:05?"
+
+### Key types
+
+| Type | Crate | Purpose |
+|---|---|---|
+| `CompressedCheckpoint` | rvm-memory | Snapshot with compression metadata |
+| `WitnessDelta` | rvm-memory | Single mutation record with offset, length, data hash |
+| `ReconstructionPipeline` | rvm-memory | Replay engine |
+| `ReconstructionResult` | rvm-memory | Outcome with integrity verification |
+| `CheckpointId` | rvm-memory | Unique checkpoint reference |
+
+### Design constraints
+
+- No heap allocation: all reconstruction works on caller-provided buffers.
+- Delta integrity: each delta carries an FNV-1a hash of its data payload.
+- The final reconstructed state is validated against an expected hash.
+
+See [Memory Model](08-memory-model.md) for the four-tier architecture and
+tier transition rules.
+
+---
+
+## 3. Proof-Gated Infrastructure
+
+**Every mutation in RVM requires a valid proof. This is not authorization --
+it is mathematical verification.**
+
+In a traditional OS, access control asks "does this process have permission?"
+RVM goes further: it asks "can this process *prove* that this state transition
+is valid?" The proof must be submitted alongside the mutation request, and
+the proof engine verifies it before the mutation proceeds.
+
+The three proof tiers are:
+
+| Tier | Name | Verification | Cost | Use Case |
+|---|---|---|---|---|
+| P1 | Capability Check | Rights bitmap lookup | < 1 ns | Every operation |
+| P2 | Policy Validation | Hash preimage + witness | ~996 ns | State mutations |
+| P3 | Deep Proof | Zero-knowledge (TEE) | Deferred | Privacy-preserving ops |
+
+The `SecurityGate` (in `rvm-security`) enforces the three-stage pipeline:
+
+1. **Capability check** -- Does the caller hold the right `CapToken` with
+   the required `CapRights`?
+2. **Proof verification** -- Does the submitted `Proof` satisfy its
+   `WitnessHash` commitment?
+3. **Witness logging** -- The decision (allow or deny) is recorded in the
+   witness trail before the mutation executes.
+
+This pipeline is wired at the kernel level. There is no way to bypass it --
+not through a syscall, not through a hypercall, not through a device access.
+
+See [Capabilities and Proofs](05-capabilities-proofs.md) for the full proof
+system API and [Security](10-security.md) for the gate pipeline.
+
+---
+
+## 4. Witness-Native OS
+
+**The audit trail is a first-class kernel object, not bolted-on logging.**
+
+Most operating systems add audit logging as an afterthought -- a daemon that
+watches system calls, a kernel tracepoint that can be disabled, or a log file
+that can be deleted. In RVM, the witness trail is part of the kernel's
+fundamental architecture. It cannot be disabled, deleted, or bypassed.
+
+Every witness record is exactly 64 bytes (one cache line) and is emitted at
+~17 ns per record. The record format is:
+
+| Offset | Size | Field |
+|---|---|---|
+| 0 | 8 | `sequence` (monotonic counter) |
+| 8 | 8 | `timestamp_ns` |
+| 16 | 1 | `action_kind` |
+| 17 | 1 | `proof_tier` |
+| 18 | 2 | `flags` |
+| 20 | 4 | `actor_partition_id` |
+| 24 | 4 | `target_object_id` |
+| 28 | 4 | `capability_hash` |
+| 32 | 8 | `payload` |
+| 40 | 8 | `prev_hash` (FNV-1a chain) |
+| 48 | 8 | `record_hash` |
+| 56 | 8 | `aux` (signature or extension) |
+
+The `prev_hash` and `record_hash` fields form a hash chain. Each record's
+`prev_hash` equals the preceding record's `record_hash`. Breaking any link
+is detectable by `verify_chain()`.
+
+The witness is not just an audit log -- it is the *recovery mechanism*. The
+`ReconstructionPipeline` uses witness deltas to rebuild dormant memory. The
+fault rollback system uses witness records to determine the point of failure.
+
+See [Witness and Audit](06-witness-audit.md) for the full witness system.
+
+---
+
+## 5. Live Partition Split and Merge
+
+**No other hypervisor can dynamically re-isolate workloads along graph-
+theoretic cut boundaries.**
+
+Traditional VM migration moves an entire VM from one host to another. RVM
+can split a single partition into two partitions, or merge two partitions
+into one, while the system is running.
+
+### Split
+
+The `scored_region_assignment()` function (in `rvm-partition`) assigns each
+memory region to the "left" or "right" child partition based on coherence
+affinity:
+
+```rust
+pub fn scored_region_assignment(
+    region_coherence: CoherenceScore,
+    left_coherence: CoherenceScore,
+    right_coherence: CoherenceScore,
+) -> u16  // 0..10000: higher = prefer left
+```
+
+Regions are placed with the partition whose coherence profile is closest. The
+MinCut algorithm identifies the optimal split boundary -- the point where
+cutting the graph severs the fewest (weakest) communication edges.
+
+### Merge
+
+The `merge_preconditions_full()` function validates that two partitions can
+be safely merged:
+
+```rust
+pub fn merge_preconditions_full(
+    coherence_a: CoherenceScore,
+    coherence_b: CoherenceScore,
+    are_adjacent: bool,
+    combined_cap_count: usize,
+    max_caps_per_partition: usize,
+) -> Result<(), MergePreconditionError>
+```
+
+Three preconditions must hold:
+
+1. Both partitions must exceed the merge coherence threshold (7000 basis
+   points by default).
+2. The partitions must be adjacent in the coherence graph (they share a
+   `CommEdge`).
+3. The combined capability count must fit within the per-partition limit.
+
+### Why this matters
+
+Split and merge enable dynamic right-sizing of isolation domains. A partition
+that has grown too large and contains loosely coupled workloads can be split
+to improve isolation. Two small partitions that are tightly coupled can be
+merged to reduce IPC overhead.
+
+See [Partitions and Scheduling](07-partitions-scheduling.md) for the
+partition lifecycle and state machine.
+
+---
+
+## 6. Edge Security on 64 KB RAM (Seed Profile)
+
+**Full capability + proof + witness security on microcontroller-class hardware.**
+
+The Seed hardware profile runs RVM on devices with as little as 64 KB of RAM.
+At this scale, most systems run bare C with no memory protection, no process
+isolation, and no audit trail. RVM provides:
+
+- **Capability isolation.** Each partition has a scoped capability table.
+  Code in partition A cannot access partition B's memory or devices without a
+  valid `CapToken`.
+- **Proof-gated mutations.** Even on a 64 KB device, every state change
+  requires a proof (at minimum, a P1 capability check).
+- **Witness trail.** A 64-record ring buffer (4 KB) records every privileged
+  action. The hash chain ensures tamper evidence.
+- **Measured boot.** The attestation digest proves exactly which code is
+  running.
+
+What makes this possible is the `no_std`, zero-heap, const-generic
+architecture. The entire security stack compiles down to a few kilobytes of
+code with fully predictable memory usage.
+
+See [Bare-Metal Deployment](12-bare-metal.md) for build instructions and
+[Security](10-security.md) for the security model.
+
+---
+
+## 7. Fault Rollback Classes
+
+RVM defines four failure classes with escalating severity and recovery
+strategies. Each escalation is recorded in the witness trail.
+
+| Class | Name | Recovery Strategy | Scope |
+|---|---|---|---|
+| F1 | Transient | Agent restart | Single WASM agent within a partition |
+| F2 | Recoverable | Partition reconstruct | Single partition from checkpoint + deltas |
+| F3 | Permanent | Memory rollback | Partition destroyed, memory reclaimed |
+| F4 | Catastrophic | Kernel reboot | System-wide measured re-attestation |
+
+The `FailureClass` enum (in `rvm-types`) maps directly to these levels:
+
+```rust
+pub enum FailureClass {
+    Transient = 0,    // F1
+    Recoverable = 1,  // F2
+    Permanent = 2,    // F3
+    Catastrophic = 3, // F4
+}
+```
+
+### Witnessed escalation
+
+When an F1 recovery fails (agent restart does not resolve the issue), the
+system escalates to F2 and records the escalation in the witness trail. If
+F2 fails (checkpoint is corrupted or deltas are inconsistent), escalation
+continues to F3 and then F4.
+
+Every escalation emits a witness record with the old and new failure class,
+the partition involved, and the reason for escalation. This creates an
+auditable chain from initial fault to final resolution.
+
+### Recovery checkpoint
+
+The `RecoveryCheckpoint` type captures the state needed to restore a
+partition:
+
+```rust
+pub struct RecoveryCheckpoint {
+    pub partition: PartitionId,
+    pub witness_sequence: u64,
+    pub timestamp_ns: u64,
+    pub epoch: u32,
+}
+```
+
+The `ReconstructionReceipt` pairs a checkpoint with metadata about whether
+the partition was hibernated or destroyed, guiding the reconstruction
+pipeline.
+
+---
+
+## 8. Deterministic Edge Orchestration
+
+RVM's three scheduling modes enable coexistence of safety-critical and
+best-effort workloads on the same hardware.
+
+| Mode | Behavior | Use Case |
+|---|---|---|
+| **Reflex** | Hard real-time. Bounded local execution only. No cross-partition IPC. | Safety-critical control loops |
+| **Flow** | Normal execution with coherence-aware placement. | General workloads |
+| **Recovery** | Stabilization. Replay, rollback, split operations. | Post-fault recovery |
+
+### Reflex mode
+
+In Reflex mode, the scheduler guarantees bounded latency by disabling all
+cross-partition traffic. A partition running a safety-critical control loop
+(e.g., motor controller, braking system) executes with deterministic timing.
+This is enforced at the scheduler level -- no coherence recomputation, no
+MinCut, no IPC message delivery.
+
+### Coexistence
+
+On an automotive ECU, a typical deployment might have:
+
+- Partition 1 (Reflex): ADAS control loop -- 1 ms deadline, hard real-time
+- Partition 2 (Flow): Infotainment UI -- best-effort, coherence-scheduled
+- Partition 3 (Flow): Telemetry agent -- periodic data upload
+- Partition 4 (Recovery): OTA update staging area
+
+Each partition is isolated by capabilities. The Reflex partition cannot be
+preempted by Flow partitions. If the infotainment partition crashes, it is
+contained -- it cannot affect the ADAS control loop.
+
+See [Partitions and Scheduling](07-partitions-scheduling.md) for the
+scheduler modes and priority computation.
+
+---
+
+## 9. RuVector Integration
+
+RVM's coherence engine can optionally use the RuVector library for advanced
+graph computations. The integration is behind the `ruvector` feature flag in
+`rvm-coherence`.
+
+| RuVector Module | RVM Use |
+|---|---|
+| `ruvector-mincut` | Production-grade minimum cut algorithms |
+| `ruvector-sparsifier` | Graph sparsification for large partition counts |
+| `ruvector-solver` | Spectral solvers for coherence eigenvalue analysis |
+| `ruvector-coherence` | IIT-inspired Phi computation pipelines |
+
+When the `ruvector` feature is disabled (default), RVM uses its built-in
+`MinCutBridge` (a budgeted Stoer-Wagner heuristic) and the simple
+internal/total weight ratio for scoring. These built-in implementations are
+sufficient for deployments with up to ~16 partitions.
+
+For larger deployments (tens or hundreds of partitions), the RuVector backends
+provide better algorithmic complexity and accuracy. The `RuVectorCoherenceEngine`
+type (in `rvm_coherence::engine`) implements the `CoherenceBackend` trait and
+can be substituted at compile time.
+
+---
+
+## Further Reading
+
+- [Core Concepts](02-core-concepts.md) -- foundational theory behind coherence and capabilities
+- [Capabilities and Proofs](05-capabilities-proofs.md) -- the three-tier proof system
+- [Witness and Audit](06-witness-audit.md) -- witness record format and chain integrity
+- [Partitions and Scheduling](07-partitions-scheduling.md) -- split, merge, and scheduling modes
+- [Memory Model](08-memory-model.md) -- four-tier architecture and reconstruction
+- [Security](10-security.md) -- security gate pipeline and TEE integration
+- [Performance](11-performance.md) -- benchmark results for all subsystems
+- [Bare-Metal Deployment](12-bare-metal.md) -- Seed and Appliance hardware profiles
+- [Glossary](15-glossary.md) -- definitions for all terms used in this chapter
+- [Cross-Reference Index](cross-reference.md) -- find every mention of a concept

--- a/userguide/14-troubleshooting.md
+++ b/userguide/14-troubleshooting.md
@@ -1,0 +1,469 @@
+# Troubleshooting: Common Issues and Solutions
+
+This chapter covers the most frequently encountered problems when building,
+testing, and running RVM, along with their solutions. Each section identifies
+the symptom, explains the cause, and provides a concrete fix.
+
+For build and deployment details, see [Bare-Metal
+Deployment](12-bare-metal.md). For performance-related issues, see
+[Performance](11-performance.md).
+
+---
+
+## 1. Build Fails: Missing Target
+
+**Symptom:**
+
+```text
+error[E0463]: can't find crate for `core`
+  |
+  = note: the `aarch64-unknown-none` target may not be installed
+```
+
+**Cause:** The bare-metal AArch64 target is not installed.
+
+**Fix:**
+
+```bash
+rustup target add aarch64-unknown-none
+```
+
+This downloads the precompiled `core` library for the bare-metal target. You
+only need to do this once per Rust toolchain version.
+
+---
+
+## 2. Build Fails: Wrong Rust Version
+
+**Symptom:**
+
+```text
+error: package `rvm-types v0.1.0` cannot be built because it requires
+       rustc 1.77 or newer
+```
+
+**Cause:** Your Rust compiler is older than the minimum supported version.
+
+**Fix:**
+
+```bash
+rustup update stable
+rustc --version  # verify 1.77.0 or later
+```
+
+All workspace crates declare `rust-version = "1.77"` in `Cargo.toml`. This
+is the minimum version that supports the const generics and language features
+RVM depends on.
+
+---
+
+## 3. Build Fails: Feature Flag Conflicts
+
+**Symptom:**
+
+```text
+error[E0432]: unresolved import `sha2`
+  --> crates/rvm-proof/src/signer.rs:5:5
+```
+
+**Cause:** The `crypto-sha256` feature is enabled but the `sha2` dependency
+is not available, or you are building with conflicting feature combinations.
+
+**Fix:** Check which features are active:
+
+```bash
+cargo tree -p rvm-proof -f "{p} [{f}]"
+```
+
+If you are building for Seed (minimal) profile, disable cryptographic
+features:
+
+```bash
+cargo build -p rvm-proof --no-default-features
+```
+
+If you *want* SHA-256 support, ensure the feature is explicitly enabled:
+
+```bash
+cargo build -p rvm-proof --features crypto-sha256
+```
+
+---
+
+## 4. Tests Fail
+
+**Symptom:** One or more tests fail when running `cargo test`.
+
+**Fix:** Run the full workspace test suite with the correct flags:
+
+```bash
+cargo test --workspace --lib
+```
+
+Common causes of test failures:
+
+- **Running a single crate without workspace features.** Some crates depend
+  on features that are enabled by the workspace `Cargo.toml`. Running
+  `cargo test -p rvm-proof` alone may miss features. Always use `--workspace`
+  for the full test suite.
+
+- **Stale build artifacts.** After switching branches or updating Rust:
+
+  ```bash
+  cargo clean && cargo test --workspace
+  ```
+
+- **Platform-specific failures.** The AArch64 HAL tests only compile when
+  targeting `aarch64-unknown-none`. Host-side tests skip platform-specific
+  code automatically.
+
+---
+
+## 5. QEMU Does Not Boot
+
+**Symptom:** `make run` hangs with no output, or QEMU prints an error and
+exits.
+
+### QEMU not installed
+
+```text
+make: qemu-system-aarch64: No such file or directory
+```
+
+**Fix:** Install QEMU:
+
+```bash
+# macOS
+brew install qemu
+
+# Ubuntu / Debian
+sudo apt install qemu-system-aarch64
+```
+
+### Wrong machine type
+
+```text
+qemu-system-aarch64: -M invalid: unsupported machine type
+```
+
+**Fix:** RVM targets the `virt` machine type. Verify your QEMU supports it:
+
+```bash
+qemu-system-aarch64 -M help | grep virt
+```
+
+### Linker script not found
+
+```text
+rust-lld: error: cannot find linker script rvm.ld
+```
+
+**Fix:** The linker script must be in the workspace root. Verify:
+
+```bash
+ls -la rvm.ld
+```
+
+If you are building from a subdirectory, `cd` to the workspace root first.
+The `.cargo/config.toml` sets `rustflags = ["-C", "link-arg=-Trvm.ld"]`,
+which is relative to the workspace root.
+
+### Kernel hangs at boot
+
+If QEMU starts but produces no UART output, the issue is likely in the
+assembly boot stub or the HAL initialization. Check:
+
+1. The ELF entry point is at `0x4000_0000`:
+   ```bash
+   make objdump | head -20
+   ```
+2. The BSS section is properly zeroed (check `__bss_start` and `__bss_end`
+   symbols).
+3. The stack pointer is correctly set to `__stack_top`.
+
+Press **Ctrl-A X** to exit QEMU.
+
+---
+
+## 6. Capability Errors
+
+### InsufficientCapability
+
+**Symptom:** `Err(InsufficientCapability)` from a capability check.
+
+**Cause:** The `CapToken` does not have the required `CapRights` for the
+operation.
+
+**Fix:** Verify the token's rights include what the operation needs:
+
+```rust
+// Check what rights the token has
+let rights = token.rights();
+
+// Common required rights:
+// - READ for memory access
+// - WRITE for memory mutation
+// - EXECUTE for code execution
+// - GRANT for capability delegation
+// - REVOKE for capability revocation
+// - PROVE for proof submission
+```
+
+### CapabilityTypeMismatch
+
+**Symptom:** `Err(CapabilityTypeMismatch)` when presenting a capability.
+
+**Cause:** The capability's `CapType` does not match the resource type. For
+example, presenting a `CapType::Partition` token when a
+`CapType::Region` token is required.
+
+**Fix:** Create or derive a capability with the correct type. Capability
+types cannot be changed after creation -- you need a new capability.
+
+### Epoch mismatch (StaleCapability)
+
+**Symptom:** `Err(StaleCapability)` or `Err(InsufficientCapability)` when
+the token was previously valid.
+
+**Cause:** The system epoch has advanced since the capability was created.
+Epoch-based revocation invalidates all capabilities from prior epochs.
+
+**Fix:** Obtain a fresh capability from the current epoch. The epoch is
+rotated during bulk revocation events. See [Capabilities and
+Proofs](05-capabilities-proofs.md) for epoch semantics.
+
+---
+
+## 7. Proof Verification Fails
+
+### ProofInvalid
+
+**Symptom:** `Err(ProofInvalid)` from `rvm_proof::verify()`.
+
+**Common causes:**
+
+1. **Empty proof data.** A proof with zero-length data always fails:
+
+   ```rust
+   // This will fail:
+   let proof = Proof::hash_proof(commitment, &[]);
+   ```
+
+2. **Wrong commitment.** The proof's commitment must match the expected
+   commitment exactly. The commitment is computed from the proof data:
+
+   ```rust
+   let data = b"my proof data";
+   let commitment = rvm_proof::compute_data_hash(data);
+   let proof = Proof::hash_proof(commitment, data);
+   // verify(proof, &commitment) -- this matches
+   ```
+
+3. **Witness chain proof with broken links.** For P2 (Witness tier) proofs,
+   each 16-byte link must chain correctly:
+   `link[i].record_hash == link[i+1].prev_hash`.
+
+### ProofTierInsufficient
+
+**Symptom:** `Err(ProofTierInsufficient)` from the proof engine.
+
+**Cause:** The operation requires a higher proof tier than what was submitted.
+For example, a cross-partition operation may require P2 (Witness) but only
+P1 (Hash) was provided.
+
+**Fix:** Submit a proof at the required tier. See the tier table in
+[Capabilities and Proofs](05-capabilities-proofs.md).
+
+---
+
+## 8. Memory Alignment Errors
+
+### AlignmentError
+
+**Symptom:** `Err(AlignmentError)` from memory operations.
+
+**Cause:** A guest or host physical address is not page-aligned. RVM requires
+all memory regions to start on 4 KB page boundaries.
+
+**Fix:** Ensure addresses are multiples of `PAGE_SIZE` (4096):
+
+```rust
+use rvm_memory::PAGE_SIZE;
+
+let addr = PhysAddr::new(0x1000_0000);  // OK: aligned
+let bad  = PhysAddr::new(0x1000_0001);  // Error: not aligned
+
+// Check alignment:
+assert!(addr.is_page_aligned());
+```
+
+---
+
+## 9. Partition Limits
+
+### ResourceLimitExceeded / PartitionLimitExceeded
+
+**Symptom:** `Err(ResourceLimitExceeded)` or `Err(PartitionLimitExceeded)`
+when creating a partition.
+
+**Cause:** RVM supports a maximum of 256 partitions per instance. This limit
+comes from the ARM VMID width (8 bits). The constant
+`MAX_PARTITIONS` in `rvm-types` enforces it.
+
+**Fix:** Either:
+- Destroy unused partitions before creating new ones.
+- Merge tightly coupled partitions to free VMID slots. See [Advanced and
+  Exotic](13-advanced-exotic.md) for merge preconditions.
+
+### DelegationDepthExceeded
+
+**Symptom:** `Err(DelegationDepthExceeded)` when granting a capability.
+
+**Cause:** The capability derivation tree has reached its maximum depth of 8
+levels. A capability that was delegated 8 times cannot be delegated further.
+
+**Fix:** Grant from a capability closer to the root of the derivation tree,
+or use `GRANT_ONCE` for non-transitive delegation.
+
+---
+
+## 10. Witness Chain Broken
+
+### ChainIntegrityError
+
+**Symptom:** `verify_chain()` returns `Err(ChainIntegrityError { .. })`.
+
+**Cause:** The `prev_hash` of record N does not match the `record_hash` of
+record N-1. This indicates either:
+
+1. **Tampering.** Someone or something modified a witness record after
+   emission.
+2. **Ring buffer wrap.** If the ring buffer wrapped and you are reading
+   across the wrap boundary, the chain naturally breaks at the oldest
+   retained record.
+3. **NullSigner in production.** The `NullSigner` does not compute real
+   hashes. It is only for testing.
+
+**Fix:**
+
+- If the break is at the ring buffer wrap point, this is expected behavior.
+  The chain is valid within each contiguous segment.
+- If the break is mid-segment, investigate the surrounding records for
+  anomalies (wrong sequence numbers, impossible timestamps).
+- **Never use `NullSigner` in production.** Use `StrictSigner` or
+  `HmacSha256WitnessSigner` for real deployments. The `NullSigner` is gated
+  behind the `null-signer` feature flag and is deprecated. See [Witness and
+  Audit](06-witness-audit.md) and [Security](10-security.md).
+
+---
+
+## 11. Performance Issues
+
+**Symptom:** Operations are slower than expected benchmarks.
+
+### Check the build profile
+
+The most common cause of poor performance is benchmarking in dev profile:
+
+```bash
+# WRONG: dev profile, no optimization
+cargo test  # tests run in dev profile
+
+# RIGHT: release profile
+cargo bench  # benchmarks run in bench profile (inherits release)
+```
+
+If you need to time something outside of Criterion, build with `--release`:
+
+```bash
+cargo build --release
+```
+
+### Check feature flags
+
+Unused subsystems add code and may affect instruction cache behavior. For
+peak performance on resource-constrained hardware, disable features you do
+not use:
+
+```bash
+cargo build --release --no-default-features --features "crypto-sha256"
+```
+
+### Check ring buffer size
+
+An oversized witness ring buffer wastes memory and can cause cache pressure.
+For the Seed profile, use the smallest ring that avoids `WitnessLogFull`
+errors:
+
+```rust
+let log = WitnessLog::<64>::new();  // 64 records = 4 KB
+```
+
+For Appliance deployments with heavy witness traffic, increase the ring:
+
+```rust
+let log = WitnessLog::<262144>::new();  // 262,144 records = 16 MB
+```
+
+### Check the adaptive engine
+
+If coherence computations are being dropped, the
+`AdaptiveCoherenceEngine::budget_exceeded_count` field will be non-zero. This
+means the CPU is too loaded for the configured MinCut budget. Reduce the
+MinCut budget or accept a less accurate cut computation. See
+[Performance](11-performance.md) for tuning details.
+
+---
+
+## 12. Getting Help
+
+### ADR documents
+
+The `docs/adr/` directory contains the Architecture Decision Records that
+define every aspect of RVM's design. Key ADRs:
+
+| ADR | Topic |
+|---|---|
+| ADR-132 | First-class kernel objects and design constraints |
+| ADR-133 | Hardware abstraction layer |
+| ADR-134 | Witness trail specification |
+| ADR-135 | Capability and proof system |
+| ADR-136 | Four-tier memory model |
+| ADR-137 | Seven-phase boot sequence |
+| ADR-138 | Memory management details |
+| ADR-139 | Coherence engine |
+| ADR-140 | Partition lifecycle |
+| ADR-142 | TEE and cryptographic integration |
+
+### GitHub issues
+
+File issues at the RVM repository. Include:
+
+1. The exact error message or unexpected behavior.
+2. The command you ran (e.g., `cargo test --workspace`).
+3. Your Rust version (`rustc --version`) and OS.
+4. Any feature flags you enabled or disabled.
+
+### This user guide
+
+| I need to... | Read |
+|---|---|
+| Build and boot RVM | [Quick Start](01-quickstart.md) |
+| Understand the architecture | [Architecture](03-architecture.md) |
+| Find a specific API | [Crate Reference](04-crate-reference.md) |
+| Debug capability issues | [Capabilities and Proofs](05-capabilities-proofs.md) |
+| Debug witness issues | [Witness and Audit](06-witness-audit.md) |
+| Debug memory issues | [Memory Model](08-memory-model.md) |
+| Optimize performance | [Performance](11-performance.md) |
+| Find a term definition | [Glossary](15-glossary.md) |
+| Find cross-references | [Cross-Reference Index](cross-reference.md) |
+
+---
+
+## Further Reading
+
+- [Quick Start](01-quickstart.md) -- build, test, and boot in five minutes
+- [Bare-Metal Deployment](12-bare-metal.md) -- QEMU parameters and linker script
+- [Performance](11-performance.md) -- build profiles and tuning
+- [Security](10-security.md) -- signer configuration and NullSigner deprecation
+- [Cross-Reference Index](cross-reference.md) -- find every mention of a concept

--- a/userguide/15-glossary.md
+++ b/userguide/15-glossary.md
@@ -1,0 +1,308 @@
+# Glossary: Terms and Definitions
+
+This glossary defines every key term used in the RVM user guide. Entries are
+alphabetical. Cross-references point to the chapter where the term is
+discussed in depth.
+
+---
+
+**ADR** (Architecture Decision Record) -- A numbered document in `docs/adr/`
+that records a design decision, its context, and its consequences. ADRs are
+the authoritative specification for RVM's behavior. See
+[Architecture](03-architecture.md).
+
+**Agent** -- A WASM module running inside a partition. Agents execute in a
+sandboxed interpreter and interact with the kernel through host functions
+gated by capabilities. See [WASM Agents](09-wasm-agents.md).
+
+**BuddyAllocator** -- A power-of-two physical page allocator used to manage
+the host's physical memory. Allocations and frees are O(log N) in the number
+of orders. Implemented in `rvm-memory::allocator`. See [Memory
+Model](08-memory-model.md) and [Performance](11-performance.md).
+
+**Capability** -- An unforgeable, kernel-managed token that grants specific
+rights over a specific kernel object. Capabilities cannot be fabricated by
+user code; they can only be derived from existing capabilities via
+delegation. See [Capabilities and Proofs](05-capabilities-proofs.md).
+
+**CapRights** -- A bitflag type representing the rights held by a capability:
+`READ`, `WRITE`, `EXECUTE`, `GRANT`, `REVOKE`, `PROVE`. Rights can only be
+attenuated (reduced) during delegation, never amplified. See [Capabilities
+and Proofs](05-capabilities-proofs.md).
+
+**CapToken** -- A lightweight value type that carries a capability's type,
+rights, epoch, and owner. Used in security gate requests and policy
+evaluation. Defined in `rvm-types::capability`. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**CapType** -- The kind of kernel object a capability authorizes access to:
+`Partition`, `Region`, `Device`, `CommEdge`, `Witness`. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**Coherence** -- A measure of how tightly coupled a partition is to its
+communication neighbors. Derived from the weighted communication graph.
+Higher coherence means the partition is more self-contained. See [Core
+Concepts](02-core-concepts.md) and [Architecture](03-architecture.md).
+
+**CoherenceScore** -- A fixed-point value in basis points (0..10,000) that
+quantifies a partition's coherence. Computed as the ratio of internal weight
+to total weight. Defined in `rvm-types::coherence`. See [Partitions and
+Scheduling](07-partitions-scheduling.md).
+
+**CommEdge** -- A weighted, directed edge in the coherence graph representing
+a communication channel between two partitions. Edge weight increases with
+IPC traffic. Defined in `rvm-types::coherence`. See [Partitions and
+Scheduling](07-partitions-scheduling.md).
+
+**CutPressure** -- A graph-derived signal indicating that a partition sits on
+a weak boundary in the coherence graph. High cut pressure suggests the
+partition should be migrated or split. Fixed-point, defined in
+`rvm-types::coherence`. See [Advanced and Exotic](13-advanced-exotic.md).
+
+**DC** (Design Constraint) -- A numbered requirement in the ADR documents
+(e.g., DC-1: "Coherence engine is optional"). DCs constrain the
+implementation. See [Architecture](03-architecture.md).
+
+**Delegation Depth** -- The number of times a capability has been derived
+from its root. Maximum depth is 8 (`MAX_DELEGATION_DEPTH`). Prevents
+unbounded delegation chains. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**Derivation Tree** -- The parent-child hierarchy of capabilities.
+Revoking a parent capability propagates revocation to all descendants.
+Implemented in `rvm-cap::derivation`. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**EMA Filter** (Exponential Moving Average) -- A fixed-point smoothing filter
+applied to coherence scores. Prevents scheduling jitter from noisy sensor
+readings. Alpha is expressed in basis points. Implemented in
+`rvm-coherence::EmaFilter`. See [Performance](11-performance.md).
+
+**Epoch** -- A numbered time interval used for capability revocation and
+scheduler accounting. Capabilities from a prior epoch are stale. Epochs
+advance during bulk revocation events. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**Failure Class (F1--F4)** -- A severity classification for faults. F1
+(Transient): agent restart. F2 (Recoverable): partition reconstruct. F3
+(Permanent): partition destroy. F4 (Catastrophic): kernel reboot. Defined
+in `rvm-types::recovery::FailureClass`. See [Advanced and
+Exotic](13-advanced-exotic.md).
+
+**FNV-1a** -- Fowler-Noll-Vo hash function, variant 1a. Used for witness
+chain hashing and proof commitments. Fast, non-cryptographic. Implemented in
+`rvm-witness::hash`. See [Witness and Audit](06-witness-audit.md).
+
+**GuestPhysAddr** -- A guest physical address within a partition's stage-2
+address space. Must be page-aligned for mapping operations. Defined in
+`rvm-types::addr`. See [Memory Model](08-memory-model.md).
+
+**GRANT_ONCE** -- A capability flag that allows a single delegation. After
+the grant, the capability is consumed and cannot be granted again. Prevents
+transitive delegation. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**HAL** (Hardware Abstraction Layer) -- Platform-agnostic traits for hardware
+access: `Platform`, `MmuOps`, `TimerOps`, `InterruptOps`. Concrete
+implementations exist for AArch64 (QEMU virt). Implemented in `rvm-hal`. See
+[Architecture](03-architecture.md) and [Bare-Metal
+Deployment](12-bare-metal.md).
+
+**Hash Chain** -- A sequence of values where each element includes the hash
+of the previous element. Used in the witness trail (`prev_hash` /
+`record_hash`) and measured boot (`MeasuredBootState`). See [Witness and
+Audit](06-witness-audit.md).
+
+**HMAC-SHA256** -- Hash-based Message Authentication Code using SHA-256. Used
+by `HmacSha256WitnessSigner` for cryptographic witness signatures. Requires
+the `crypto-sha256` feature. See [Security](10-security.md).
+
+**Hot** (Memory Tier 0) -- Per-core SRAM or L1-adjacent memory. Always
+resident during execution. Lowest latency. See [Memory
+Model](08-memory-model.md).
+
+**IIT** (Integrated Information Theory) -- A theoretical framework from
+neuroscience that quantifies consciousness as integrated information (Phi).
+RVM uses IIT-inspired metrics to measure partition coherence. See [Core
+Concepts](02-core-concepts.md).
+
+**IPC** (Inter-Partition Communication) -- Message passing between partitions
+via `IpcManager` and `MessageQueue`. IPC traffic updates CommEdge weights in
+the coherence graph. Implemented in `rvm-partition::ipc`. See [Partitions and
+Scheduling](07-partitions-scheduling.md).
+
+**Kernel Object** -- Any entity managed by the RVM kernel: partitions,
+capabilities, witness records, memory regions, communication edges, device
+leases, coherence scores, cut pressures, and recovery checkpoints. See [Core
+Concepts](02-core-concepts.md).
+
+**Memory Tier** -- One of four storage levels: Hot (0), Warm (1), Dormant
+(2), Cold (3). Tier placement is driven by coherence scores. See [Memory
+Model](08-memory-model.md).
+
+**MinCut** -- The minimum weight set of edges whose removal disconnects two
+parts of the coherence graph. Used to identify optimal partition split
+boundaries. Implemented in `rvm-coherence::mincut` as a budgeted Stoer-Wagner
+heuristic. See [Advanced and Exotic](13-advanced-exotic.md).
+
+**Monotonic Attenuation** -- The principle that capability rights can only
+decrease (never increase) through delegation. A child capability always has
+equal or fewer rights than its parent. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+**no_std** -- A Rust attribute indicating that a crate does not link against
+the standard library. All RVM crates are `#![no_std]` to support bare-metal
+deployment. See [Architecture](03-architecture.md).
+
+**NullSigner** -- A test-only witness signer that accepts all records without
+cryptographic verification. Deprecated. Gated behind the `null-signer`
+feature flag. Never use in production. See [Security](10-security.md) and
+[Troubleshooting](14-troubleshooting.md).
+
+**Partition** -- The fundamental isolation and scheduling unit in RVM. Not a
+VM: no emulated hardware, no guest BIOS, no virtual device model. A container
+for a capability table, communication edges, coherence metrics, and CPU
+affinity. See [Partitions and Scheduling](07-partitions-scheduling.md).
+
+**PartitionId** -- A 32-bit identifier for a partition. Unique within an RVM
+instance. Defined in `rvm-types::ids`. See [Partitions and
+Scheduling](07-partitions-scheduling.md).
+
+**PhiValue** -- A fixed-point value representing integrated information (Phi)
+derived from IIT. Inputs to the coherence scoring pipeline. Defined in
+`rvm-types::coherence`. See [Core Concepts](02-core-concepts.md).
+
+**PhysAddr** -- A host physical address. Must be page-aligned for memory
+region operations. Defined in `rvm-types::addr`. See [Memory
+Model](08-memory-model.md).
+
+**Proof** -- A data payload submitted alongside a state-transition request.
+Verified by the proof engine before the mutation proceeds. Contains a tier,
+commitment hash, and raw data (up to 64 bytes). Defined in `rvm-proof`. See
+[Capabilities and Proofs](05-capabilities-proofs.md).
+
+**ProofTier** -- The tier of proof required for an operation: `Hash` (P1),
+`Witness` (P2), `Zk` (P3). Higher tiers provide stronger guarantees at
+higher cost. See [Capabilities and Proofs](05-capabilities-proofs.md).
+
+**QEMU** -- An open-source machine emulator. RVM uses the `virt` machine
+type with `cortex-a72` CPU for development and testing. See [Bare-Metal
+Deployment](12-bare-metal.md).
+
+**Quota** -- A per-partition resource budget enforced per epoch. Covers CPU
+time, memory pages, IPC messages, and WASM instruction counts. Implemented
+in `rvm-wasm::quota`. See [WASM Agents](09-wasm-agents.md).
+
+**Recovery Checkpoint** -- A snapshot of partition state at a known-good
+point. Used for F2 (recoverable) fault recovery. Contains the partition ID,
+witness sequence number, timestamp, and epoch. Defined in
+`rvm-types::recovery`. See [Advanced and Exotic](13-advanced-exotic.md).
+
+**Reflex Mode** -- A scheduling mode for hard real-time workloads. Disables
+cross-partition IPC and coherence recomputation. Guarantees bounded latency.
+See [Partitions and Scheduling](07-partitions-scheduling.md) and [Advanced
+and Exotic](13-advanced-exotic.md).
+
+**Ring Buffer** -- A fixed-size circular buffer used by `WitnessLog` to store
+witness records. When full, new records overwrite the oldest. Capacity is a
+compile-time const generic. See [Witness and Audit](06-witness-audit.md).
+
+**Root Partition** -- Partition 0, created during boot phase 5. Holds full
+capability rights over all resources. All other partitions are created by
+the root partition delegating subsets of its authority. See [Bare-Metal
+Deployment](12-bare-metal.md).
+
+**RVM** (RuVix Virtual Machine) -- The coherence-native bare-metal
+microhypervisor. 13 crates, 648 tests, 11 benchmarks.
+
+**RuVector** -- An optional library providing production-grade graph
+algorithms: MinCut, sparsification, spectral solvers, and IIT-inspired
+coherence computation. Behind the `ruvector` feature flag. See [Advanced and
+Exotic](13-advanced-exotic.md).
+
+**Scheduler** -- The coherence-aware scheduler in `rvm-sched`. Uses a
+2-signal priority: `deadline_urgency + cut_pressure_boost`. Supports three
+modes: Reflex, Flow, Recovery. See [Partitions and
+Scheduling](07-partitions-scheduling.md).
+
+**SecurityGate** -- The unified security policy enforcement point. Every
+hypercall passes through the gate: capability check, proof verification,
+witness logging. Implemented in `rvm-security::gate`. See
+[Security](10-security.md).
+
+**Seed Profile** -- A hardware deployment profile targeting 64 KB to 1 MB
+RAM. Provides capability + proof + witness security on microcontroller-class
+hardware. See [Bare-Metal Deployment](12-bare-metal.md) and [Advanced and
+Exotic](13-advanced-exotic.md).
+
+**SensorReading** -- A raw data point fed into the coherence pipeline.
+Contains a partition ID, timestamp, and Phi value. Defined in
+`rvm-coherence`. See [Architecture](03-architecture.md).
+
+**Split** -- A partition operation that divides one partition into two along a
+graph-theoretic cut boundary. Regions are assigned using
+`scored_region_assignment()`. See [Advanced and
+Exotic](13-advanced-exotic.md).
+
+**StrictSigner** -- The production witness signer. Rejects any record that
+fails integrity checks. Use this (or `HmacSha256WitnessSigner`) in all
+non-test deployments. Implemented in `rvm-witness::signer`. See
+[Security](10-security.md).
+
+**SwitchContext** -- The minimal state saved and restored during a partition
+context switch. The switch path is the hottest path in RVM (~6 ns). See
+[Partitions and Scheduling](07-partitions-scheduling.md) and
+[Performance](11-performance.md).
+
+**TEE** (Trusted Execution Environment) -- Hardware-backed isolated execution.
+RVM's `rvm-proof` crate defines `TeeQuoteProvider` and `TeeQuoteVerifier`
+traits for attestation. Software implementations are provided for testing.
+See [Security](10-security.md).
+
+**Tier** -- See *Memory Tier*.
+
+**VMID** (Virtual Machine Identifier) -- An 8-bit ARM hardware identifier
+used for stage-2 address translation. Limits RVM to 256 partitions. See
+[Partitions and Scheduling](07-partitions-scheduling.md).
+
+**WASM** (WebAssembly) -- A portable bytecode format. RVM partitions can
+optionally host WASM modules as agents. Validated and executed in a sandboxed
+interpreter. Implemented in `rvm-wasm`. See [WASM
+Agents](09-wasm-agents.md).
+
+**Warm** (Memory Tier 1) -- Shared DRAM. Resident if residency rules are
+met. Medium latency. See [Memory Model](08-memory-model.md).
+
+**Witness** -- See *WitnessRecord*.
+
+**WitnessEmitter** -- The API for emitting witness records into the witness
+log. Provides typed methods for each action kind (e.g.,
+`emit_partition_create`). Implemented in `rvm-witness::emit`. See [Witness
+and Audit](06-witness-audit.md).
+
+**WitnessHash** -- A 32-byte hash value used for proof commitments and
+attestation digests. Defined in `rvm-types::witness`. See [Witness and
+Audit](06-witness-audit.md).
+
+**WitnessLog** -- A fixed-size ring buffer of `WitnessRecord` entries.
+Capacity is a compile-time const generic. The default is 262,144 records
+(16 MB). Implemented in `rvm-witness::log`. See [Witness and
+Audit](06-witness-audit.md).
+
+**WitnessRecord** -- A 64-byte audit record emitted by every privileged
+action. Contains sequence number, timestamp, action kind, proof tier, actor
+partition, target object, capability hash, payload, and hash chain links.
+Cache-line aligned. See [Witness and Audit](06-witness-audit.md).
+
+**ZK** (Zero-Knowledge) -- A proof system where the verifier learns nothing
+beyond the validity of the statement. RVM's P3 (Zk) proof tier is defined
+but deferred to post-v1, pending TEE integration. See [Capabilities and
+Proofs](05-capabilities-proofs.md).
+
+---
+
+## Further Reading
+
+- [Core Concepts](02-core-concepts.md) -- narrative explanations of the key ideas
+- [Crate Reference](04-crate-reference.md) -- API-level documentation for each crate
+- [Cross-Reference Index](cross-reference.md) -- find every chapter where a term appears

--- a/userguide/README.md
+++ b/userguide/README.md
@@ -1,0 +1,103 @@
+# RVM User Guide -- The Virtual Machine for the Agentic Age
+
+Traditional hypervisors were designed for static server workloads: long-running VMs with predictable resource needs. AI agents are different -- they spawn in milliseconds, communicate in dense shifting graphs, share context across trust boundaries, and die without warning. RVM replaces VMs with **coherence domains**: lightweight, graph-structured partitions whose isolation, scheduling, and memory placement are driven by how agents actually communicate. When two agents start talking more, RVM moves them closer. When trust drops, RVM splits them apart. Every mutation is proof-gated. Every action is witnessed. The system understands its own structure.
+
+---
+
+## How to Use This Guide
+
+Choose a path based on your goals:
+
+| Path | Start Here | You Will Learn |
+|------|-----------|----------------|
+| **Quick Start** | [01 -- Quick Start](01-quickstart.md) | Clone, build, boot in QEMU, and run your first partition in 5 minutes |
+| **Deep Dive** | [02 -- Core Concepts](02-core-concepts.md) then [03 -- Architecture](03-architecture.md) | How RVM thinks, why it exists, and how the pieces fit together |
+| **Reference** | [04 -- Crate Reference](04-crate-reference.md) then [15 -- Glossary](15-glossary.md) | API surface, type catalog, and precise definitions |
+
+Every chapter ends with cross-reference links to related sections. If you prefer to navigate by topic rather than chapter order, use the [Cross-Reference Index](cross-reference.md).
+
+---
+
+## Table of Contents
+
+| # | Chapter | Description |
+|---|---------|-------------|
+| -- | **[README](README.md)** | This page: guide overview, paths, prerequisites |
+| 01 | [Quick Start](01-quickstart.md) | Clone, build, boot in QEMU, and explore the API in 5 minutes |
+| 02 | [Core Concepts](02-core-concepts.md) | Partitions, capabilities, witnesses, proofs, coherence, and memory tiers explained in plain language |
+| 03 | [Architecture](03-architecture.md) | Crate layering, dependency graph, four-layer stack, and first-class kernel objects |
+| 04 | [Crate Reference](04-crate-reference.md) | Per-crate API surface: public types, traits, constants, and feature flags |
+| 05 | [Capabilities and Proofs](05-capabilities-proofs.md) | The three-tier proof system (P1/P2/P3), capability derivation trees, and delegation rules |
+| 06 | [Witness and Audit](06-witness-audit.md) | 64-byte witness records, hash chains, HMAC signing, replay, and forensic queries |
+| 07 | [Partitions and Scheduling](07-partitions-scheduling.md) | Partition lifecycle, split/merge semantics, 2-signal scheduler, and scheduling modes |
+| 08 | [Memory Model](08-memory-model.md) | Four-tier memory (Hot/Warm/Dormant/Cold), buddy allocator, reconstruction pipeline |
+| 09 | [WASM Agents](09-wasm-agents.md) | WebAssembly guest runtime, 7-state agent lifecycle, HostContext trait |
+| 10 | [Security](10-security.md) | Unified security gate, attestation chains, DMA budgets, and threat model |
+| 11 | [Performance](11-performance.md) | Benchmark results, criterion setup, profiling, and optimization strategies |
+| 12 | [Bare Metal](12-bare-metal.md) | AArch64 boot, EL2 entry, PL011 UART, GICv2, stage-2 page tables, linker script |
+| 13 | [Advanced and Exotic](13-advanced-exotic.md) | Seed profile (64 KB), Appliance deployment, Chip targets, RuVector integration |
+| 14 | [Troubleshooting](14-troubleshooting.md) | Common build errors, QEMU issues, debugging tips, and FAQ |
+| 15 | [Glossary](15-glossary.md) | Precise definitions for every RVM-specific term |
+| -- | [Cross-Reference Index](cross-reference.md) | Topic-to-chapter mapping for quick navigation |
+
+---
+
+## Key Concepts at a Glance
+
+> **Six ideas that make RVM different from every other hypervisor.**
+
+- **Coherence Domains** -- Partitions are not VMs. They have no emulated hardware. A partition is a graph-structured container whose boundaries shift dynamically based on agent communication patterns. See [Core Concepts](02-core-concepts.md).
+
+- **Capabilities** -- Every access right is represented by an unforgeable kernel-resident token with 7 possible rights (READ, WRITE, GRANT, REVOKE, EXECUTE, PROVE, GRANT_ONCE). Rights can only be attenuated, never amplified. Delegation depth is bounded at 8 levels. See [Capabilities and Proofs](05-capabilities-proofs.md).
+
+- **Witness Trail** -- Every privileged action emits a fixed 64-byte, hash-chained audit record before the mutation commits. If witness emission fails, the mutation does not proceed. The entire history is tamper-evident and deterministically replayable. See [Witness and Audit](06-witness-audit.md).
+
+- **Proof Gates** -- No state mutation happens without a valid proof token. Three tiers trade off speed for assurance: P1 capability check (<1 us), P2 policy validation (<100 us), P3 deep derivation chain / deferred ZK. See [Capabilities and Proofs](05-capabilities-proofs.md).
+
+- **Memory Tiers** -- Memory lives in four explicit tiers (Hot, Warm, Dormant, Cold) instead of a demand-paging black box. Dormant memory is stored as a checkpoint plus delta-compressed witness trail and can be reconstructed days later. See [Memory Model](08-memory-model.md).
+
+- **Partitions** -- The unit of scheduling, isolation, migration, and fault containment. Partitions can split along graph-theoretic mincut boundaries when coupling drops, and merge when coherence rises. Every lifecycle transition is witnessed. See [Partitions and Scheduling](07-partitions-scheduling.md).
+
+---
+
+## Cross-Reference Index
+
+For a topic-based lookup across all chapters, see the [Cross-Reference Index](cross-reference.md).
+
+---
+
+## MCP Documentation Tools
+
+The `mcp/` directory contains tooling for programmatic documentation access via the Model Context Protocol. See [mcp/](mcp/) for available tools and integration instructions.
+
+---
+
+## Prerequisites
+
+Before building or running RVM, make sure you have the following installed:
+
+| Requirement | Minimum Version | Purpose |
+|-------------|----------------|---------|
+| **Rust** | 1.77+ | Compiler toolchain (`rustup` recommended) |
+| **AArch64 target** | -- | `rustup target add aarch64-unknown-none` |
+| **cargo-binutils** | -- | `cargo install cargo-binutils` + `rustup component add llvm-tools` |
+| **QEMU** | 8.0+ | `qemu-system-aarch64` for bare-metal emulation |
+
+Optional but recommended:
+
+| Tool | Purpose |
+|------|---------|
+| `criterion` | Already a dev-dependency; used by `cargo bench` |
+| `proptest` | Already a dev-dependency; used in property-based tests |
+| `rust-analyzer` | IDE support for navigating `no_std` crate graph |
+
+All RVM crates are `#![no_std]` and `#![forbid(unsafe_code)]` by default. No C toolchain, no Linux headers, no external libraries are required for host builds or tests.
+
+---
+
+## Quick Links
+
+- **Repository**: <https://github.com/ruvnet/rvm>
+- **License**: MIT OR Apache-2.0
+- **ADR References**: ADR-132 through ADR-142
+- **Start building**: [Quick Start](01-quickstart.md)

--- a/userguide/cross-reference.md
+++ b/userguide/cross-reference.md
@@ -1,0 +1,199 @@
+# Cross-Reference Index
+
+This index maps every major concept, API type, and task to the chapters where
+it is covered. Use it to navigate between related topics and to find the
+authoritative discussion of any subject.
+
+---
+
+## Concept Index
+
+Each row lists the primary chapter (where the concept is defined and
+explained in depth) and every other chapter that references it.
+
+| Concept | Primary Chapter | Also Mentioned In |
+|---|---|---|
+| Capabilities | [05-capabilities-proofs.md](05-capabilities-proofs.md) | [02-core-concepts.md](02-core-concepts.md), [04-crate-reference.md](04-crate-reference.md), [07-partitions-scheduling.md](07-partitions-scheduling.md), [10-security.md](10-security.md), [13-advanced-exotic.md](13-advanced-exotic.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| Witness Trail | [06-witness-audit.md](06-witness-audit.md) | [02-core-concepts.md](02-core-concepts.md), [04-crate-reference.md](04-crate-reference.md), [08-memory-model.md](08-memory-model.md), [10-security.md](10-security.md), [11-performance.md](11-performance.md), [13-advanced-exotic.md](13-advanced-exotic.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| Proof System (P1/P2/P3) | [05-capabilities-proofs.md](05-capabilities-proofs.md) | [02-core-concepts.md](02-core-concepts.md), [04-crate-reference.md](04-crate-reference.md), [10-security.md](10-security.md), [11-performance.md](11-performance.md), [13-advanced-exotic.md](13-advanced-exotic.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| Partitions | [07-partitions-scheduling.md](07-partitions-scheduling.md) | [02-core-concepts.md](02-core-concepts.md), [03-architecture.md](03-architecture.md), [04-crate-reference.md](04-crate-reference.md), [05-capabilities-proofs.md](05-capabilities-proofs.md), [08-memory-model.md](08-memory-model.md), [12-bare-metal.md](12-bare-metal.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Coherence Engine | [03-architecture.md](03-architecture.md) | [02-core-concepts.md](02-core-concepts.md), [04-crate-reference.md](04-crate-reference.md), [07-partitions-scheduling.md](07-partitions-scheduling.md), [11-performance.md](11-performance.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Scheduler (2-signal) | [07-partitions-scheduling.md](07-partitions-scheduling.md) | [03-architecture.md](03-architecture.md), [04-crate-reference.md](04-crate-reference.md), [11-performance.md](11-performance.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Memory Model (4-tier) | [08-memory-model.md](08-memory-model.md) | [02-core-concepts.md](02-core-concepts.md), [04-crate-reference.md](04-crate-reference.md), [12-bare-metal.md](12-bare-metal.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Security Gate | [10-security.md](10-security.md) | [04-crate-reference.md](04-crate-reference.md), [05-capabilities-proofs.md](05-capabilities-proofs.md), [11-performance.md](11-performance.md), [13-advanced-exotic.md](13-advanced-exotic.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| Boot Sequence (7-phase) | [12-bare-metal.md](12-bare-metal.md) | [03-architecture.md](03-architecture.md), [04-crate-reference.md](04-crate-reference.md), [10-security.md](10-security.md), [15-glossary.md](15-glossary.md) |
+| Measured Boot | [12-bare-metal.md](12-bare-metal.md) | [10-security.md](10-security.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| WASM Agents | [09-wasm-agents.md](09-wasm-agents.md) | [02-core-concepts.md](02-core-concepts.md), [04-crate-reference.md](04-crate-reference.md), [12-bare-metal.md](12-bare-metal.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Split / Merge | [13-advanced-exotic.md](13-advanced-exotic.md) | [07-partitions-scheduling.md](07-partitions-scheduling.md), [04-crate-reference.md](04-crate-reference.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| MinCut | [13-advanced-exotic.md](13-advanced-exotic.md) | [04-crate-reference.md](04-crate-reference.md), [11-performance.md](11-performance.md), [15-glossary.md](15-glossary.md) |
+| CutPressure | [13-advanced-exotic.md](13-advanced-exotic.md) | [07-partitions-scheduling.md](07-partitions-scheduling.md), [11-performance.md](11-performance.md), [15-glossary.md](15-glossary.md) |
+| EMA Filter | [11-performance.md](11-performance.md) | [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Buddy Allocator | [08-memory-model.md](08-memory-model.md) | [04-crate-reference.md](04-crate-reference.md), [11-performance.md](11-performance.md), [12-bare-metal.md](12-bare-metal.md), [15-glossary.md](15-glossary.md) |
+| Reconstruction Pipeline | [08-memory-model.md](08-memory-model.md) | [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Failure Classes (F1--F4) | [13-advanced-exotic.md](13-advanced-exotic.md) | [02-core-concepts.md](02-core-concepts.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| Delegation / Derivation Tree | [05-capabilities-proofs.md](05-capabilities-proofs.md) | [04-crate-reference.md](04-crate-reference.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| TEE / Attestation | [10-security.md](10-security.md) | [04-crate-reference.md](04-crate-reference.md), [05-capabilities-proofs.md](05-capabilities-proofs.md), [12-bare-metal.md](12-bare-metal.md), [15-glossary.md](15-glossary.md) |
+| IPC | [07-partitions-scheduling.md](07-partitions-scheduling.md) | [04-crate-reference.md](04-crate-reference.md), [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Scheduling Modes (Reflex/Flow/Recovery) | [07-partitions-scheduling.md](07-partitions-scheduling.md) | [13-advanced-exotic.md](13-advanced-exotic.md), [15-glossary.md](15-glossary.md) |
+| Epoch-Based Revocation | [05-capabilities-proofs.md](05-capabilities-proofs.md) | [07-partitions-scheduling.md](07-partitions-scheduling.md), [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| RuVector | [13-advanced-exotic.md](13-advanced-exotic.md) | [11-performance.md](11-performance.md), [15-glossary.md](15-glossary.md) |
+| Seed / Appliance Profiles | [12-bare-metal.md](12-bare-metal.md) | [13-advanced-exotic.md](13-advanced-exotic.md), [11-performance.md](11-performance.md), [15-glossary.md](15-glossary.md) |
+| Benchmarks | [11-performance.md](11-performance.md) | [01-quickstart.md](01-quickstart.md), [04-crate-reference.md](04-crate-reference.md) |
+| Build Profiles | [11-performance.md](11-performance.md) | [01-quickstart.md](01-quickstart.md), [12-bare-metal.md](12-bare-metal.md), [14-troubleshooting.md](14-troubleshooting.md) |
+| Linker Script (rvm.ld) | [12-bare-metal.md](12-bare-metal.md) | [01-quickstart.md](01-quickstart.md), [14-troubleshooting.md](14-troubleshooting.md) |
+| FNV-1a | [06-witness-audit.md](06-witness-audit.md) | [11-performance.md](11-performance.md), [15-glossary.md](15-glossary.md) |
+| NullSigner (deprecated) | [10-security.md](10-security.md) | [14-troubleshooting.md](14-troubleshooting.md), [15-glossary.md](15-glossary.md) |
+| Device Leases | [04-crate-reference.md](04-crate-reference.md) | [02-core-concepts.md](02-core-concepts.md), [07-partitions-scheduling.md](07-partitions-scheduling.md), [15-glossary.md](15-glossary.md) |
+
+---
+
+## API Quick Finder
+
+This table maps key public types and functions to the crate where they are
+defined and the chapter that explains their usage.
+
+| Type / Function | Crate | Chapter |
+|---|---|---|
+| `CapToken` | rvm-types | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `CapRights` | rvm-types | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `CapType` | rvm-types | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `Capability` | rvm-types | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `CapabilityManager` | rvm-cap | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `CapabilityTable` | rvm-cap | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `DerivationTree` | rvm-cap | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `GrantPolicy` | rvm-cap | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `ProofVerifier` | rvm-cap | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `verify_p1()` | rvm-cap | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `Proof` | rvm-proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `ProofTier` | rvm-proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `ProofEngine` | rvm-proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `ProofContextBuilder` | rvm-proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `verify()` | rvm-proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `compute_data_hash()` | rvm-proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| `WitnessSigner` (proof) | rvm-proof | [10-security.md](10-security.md) |
+| `HmacSha256WitnessSigner` | rvm-proof | [10-security.md](10-security.md) |
+| `TeeQuoteProvider` | rvm-proof | [10-security.md](10-security.md) |
+| `TeeQuoteVerifier` | rvm-proof | [10-security.md](10-security.md) |
+| `SoftwareTeeProvider` | rvm-proof | [10-security.md](10-security.md) |
+| `WitnessRecord` | rvm-types | [06-witness-audit.md](06-witness-audit.md) |
+| `WitnessHash` | rvm-types | [06-witness-audit.md](06-witness-audit.md) |
+| `ActionKind` | rvm-types | [06-witness-audit.md](06-witness-audit.md) |
+| `WitnessLog` | rvm-witness | [06-witness-audit.md](06-witness-audit.md) |
+| `WitnessEmitter` | rvm-witness | [06-witness-audit.md](06-witness-audit.md) |
+| `verify_chain()` | rvm-witness | [06-witness-audit.md](06-witness-audit.md) |
+| `fnv1a_64()` | rvm-witness | [06-witness-audit.md](06-witness-audit.md) |
+| `StrictSigner` | rvm-witness | [10-security.md](10-security.md) |
+| `NullSigner` | rvm-witness | [10-security.md](10-security.md) |
+| `PartitionId` | rvm-types | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `PartitionState` | rvm-partition | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `PartitionManager` | rvm-partition | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `Partition` | rvm-partition | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `scored_region_assignment()` | rvm-partition | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `merge_preconditions_full()` | rvm-partition | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `IpcManager` | rvm-partition | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `MessageQueue` | rvm-partition | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `Scheduler` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `PerCpuScheduler` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `SwitchContext` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `SwitchResult` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `SchedulerMode` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `EpochTracker` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `SmpCoordinator` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `compute_priority()` | rvm-sched | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `CoherenceGraph` | rvm-coherence | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `CoherenceScore` | rvm-types | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `CutPressure` | rvm-types | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `EmaFilter` | rvm-coherence | [11-performance.md](11-performance.md) |
+| `AdaptiveCoherenceEngine` | rvm-coherence | [11-performance.md](11-performance.md) |
+| `MinCutBridge` | rvm-coherence | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `compute_coherence_score()` | rvm-coherence | [11-performance.md](11-performance.md) |
+| `compute_cut_pressure()` | rvm-coherence | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `DefaultCoherenceEngine` | rvm-coherence | [03-architecture.md](03-architecture.md) |
+| `BuddyAllocator` | rvm-memory | [08-memory-model.md](08-memory-model.md) |
+| `RegionManager` | rvm-memory | [08-memory-model.md](08-memory-model.md) |
+| `TierManager` | rvm-memory | [08-memory-model.md](08-memory-model.md) |
+| `ReconstructionPipeline` | rvm-memory | [08-memory-model.md](08-memory-model.md) |
+| `CompressedCheckpoint` | rvm-memory | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `WitnessDelta` | rvm-memory | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `MemoryRegion` | rvm-memory | [08-memory-model.md](08-memory-model.md) |
+| `MemoryTier` | rvm-types | [08-memory-model.md](08-memory-model.md) |
+| `SecurityGate` | rvm-security | [10-security.md](10-security.md) |
+| `GateRequest` | rvm-security | [10-security.md](10-security.md) |
+| `GateResponse` | rvm-security | [10-security.md](10-security.md) |
+| `PolicyDecision` | rvm-security | [10-security.md](10-security.md) |
+| `AttestationChain` | rvm-security | [10-security.md](10-security.md) |
+| `DmaBudget` | rvm-security | [10-security.md](10-security.md) |
+| `BootSequence` | rvm-boot | [12-bare-metal.md](12-bare-metal.md) |
+| `BootPhase` | rvm-boot | [12-bare-metal.md](12-bare-metal.md) |
+| `BootTracker` | rvm-boot | [12-bare-metal.md](12-bare-metal.md) |
+| `MeasuredBootState` | rvm-boot | [12-bare-metal.md](12-bare-metal.md) |
+| `BootContext` | rvm-boot | [12-bare-metal.md](12-bare-metal.md) |
+| `run_boot_sequence()` | rvm-boot | [12-bare-metal.md](12-bare-metal.md) |
+| `Platform` (trait) | rvm-hal | [03-architecture.md](03-architecture.md) |
+| `MmuOps` (trait) | rvm-hal | [03-architecture.md](03-architecture.md) |
+| `TimerOps` (trait) | rvm-hal | [03-architecture.md](03-architecture.md) |
+| `InterruptOps` (trait) | rvm-hal | [03-architecture.md](03-architecture.md) |
+| `validate_module()` | rvm-wasm | [09-wasm-agents.md](09-wasm-agents.md) |
+| `WasmModuleInfo` | rvm-wasm | [09-wasm-agents.md](09-wasm-agents.md) |
+| `FailureClass` | rvm-types | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `RecoveryCheckpoint` | rvm-types | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| `PhiValue` | rvm-types | [02-core-concepts.md](02-core-concepts.md) |
+| `RvmError` | rvm-types | [14-troubleshooting.md](14-troubleshooting.md) |
+| `CommEdge` | rvm-types | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| `DeviceLease` | rvm-types | [04-crate-reference.md](04-crate-reference.md) |
+
+---
+
+## "I Want To..." Task Index
+
+| I Want To... | Read |
+|---|---|
+| Build and run RVM for the first time | [01-quickstart.md](01-quickstart.md) |
+| Understand RVM's key ideas before diving into code | [02-core-concepts.md](02-core-concepts.md) |
+| See how the 13 crates fit together | [03-architecture.md](03-architecture.md) |
+| Find the API for a specific crate | [04-crate-reference.md](04-crate-reference.md) |
+| Add capability checks to an operation | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| Submit and verify a proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
+| Emit and query witness records | [06-witness-audit.md](06-witness-audit.md) |
+| Debug a broken witness chain | [06-witness-audit.md](06-witness-audit.md), [14-troubleshooting.md](14-troubleshooting.md) |
+| Understand how partitions are scheduled | [07-partitions-scheduling.md](07-partitions-scheduling.md) |
+| Learn about the four memory tiers | [08-memory-model.md](08-memory-model.md) |
+| Run WASM agents inside partitions | [09-wasm-agents.md](09-wasm-agents.md) |
+| Harden a deployment for production | [10-security.md](10-security.md) |
+| Run benchmarks and tune performance | [11-performance.md](11-performance.md) |
+| Boot RVM on QEMU or real hardware | [12-bare-metal.md](12-bare-metal.md) |
+| Understand what makes RVM novel | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| Split or merge partitions at runtime | [13-advanced-exotic.md](13-advanced-exotic.md) |
+| Fix a build or runtime error | [14-troubleshooting.md](14-troubleshooting.md) |
+| Look up a term I do not recognize | [15-glossary.md](15-glossary.md) |
+| Find every chapter that covers a concept | [cross-reference.md](cross-reference.md) (this page) |
+| Deploy on a 64 KB microcontroller | [12-bare-metal.md](12-bare-metal.md), [13-advanced-exotic.md](13-advanced-exotic.md) |
+| Set up CI for an RVM fork | [12-bare-metal.md](12-bare-metal.md) |
+| Choose the right witness signer for production | [10-security.md](10-security.md) |
+| Reconstruct dormant memory from checkpoints | [08-memory-model.md](08-memory-model.md), [13-advanced-exotic.md](13-advanced-exotic.md) |
+
+---
+
+## Chapter List
+
+For convenience, here is the complete table of contents for the user guide.
+
+| # | Title | Focus |
+|---|---|---|
+| -- | [README.md](README.md) | User guide overview and navigation |
+| 01 | [Quick Start](01-quickstart.md) | Five-minute build, test, boot |
+| 02 | [Core Concepts](02-core-concepts.md) | Foundational theory and design philosophy |
+| 03 | [Architecture](03-architecture.md) | Crate layers, data flow, boot sequence |
+| 04 | [Crate Reference](04-crate-reference.md) | Per-crate API documentation |
+| 05 | [Capabilities and Proofs](05-capabilities-proofs.md) | Three-tier proof system |
+| 06 | [Witness and Audit](06-witness-audit.md) | Witness trail, hash chain, record format |
+| 07 | [Partitions and Scheduling](07-partitions-scheduling.md) | Partition lifecycle, scheduler, IPC |
+| 08 | [Memory Model](08-memory-model.md) | Four-tier memory, buddy allocator, reconstruction |
+| 09 | [WASM Agents](09-wasm-agents.md) | WebAssembly runtime, quotas, migration |
+| 10 | [Security](10-security.md) | Security gate, TEE, signers, attestation |
+| 11 | [Performance](11-performance.md) | Benchmarks, build profiles, tuning |
+| 12 | [Bare-Metal Deployment](12-bare-metal.md) | QEMU boot, linker script, hardware profiles |
+| 13 | [Advanced and Exotic](13-advanced-exotic.md) | Six novel capabilities, fault classes, RuVector |
+| 14 | [Troubleshooting](14-troubleshooting.md) | Common errors and solutions |
+| 15 | [Glossary](15-glossary.md) | Alphabetical term definitions |
+| -- | [Cross-Reference Index](cross-reference.md) | This page |

--- a/userguide/mcp/README.md
+++ b/userguide/mcp/README.md
@@ -1,0 +1,205 @@
+# rvm-docs-mcp
+
+MCP server and CLI tool for searching, navigating, and querying the RVM user guide documentation.
+
+Provides six tools for fast, structured access to the RVM documentation set -- from keyword search to task-oriented reading paths.
+
+## Installation
+
+```bash
+cd userguide/mcp
+npm install
+npm run build
+```
+
+## Adding to Claude Code
+
+Register the MCP server so Claude Code can use the documentation tools:
+
+```bash
+claude mcp add rvm-docs -- node /absolute/path/to/userguide/mcp/dist/index.js
+```
+
+Once registered, the six `docs_*` tools are available in any Claude Code session.
+
+## CLI Usage
+
+The CLI provides the same functionality as the MCP tools, with colored terminal output.
+
+```bash
+# Run via npm
+npm run cli -- search "capability"
+
+# Or after npm link / global install
+rvm-docs search "capability"
+```
+
+### Commands
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `search <query>` | `s` | Full-text search across all documentation files |
+| `nav [chapter]` | `n` | Show table of contents or a specific chapter |
+| `xref <concept>` | `x` | Find cross-references for a concept across all files |
+| `glossary <term>` | `g` | Look up a term in the glossary |
+| `api <symbol>` | `a` | Find API documentation for a type, trait, or function |
+| `howto <task>` | `h` | Task-oriented search with recommended reading paths |
+
+### Examples
+
+```bash
+# Search all docs for a keyword
+rvm-docs search "capability"
+rvm-docs search "proof gate" --max-results 5
+
+# Show table of contents
+rvm-docs nav
+
+# Show a specific chapter by number, name, or filename
+rvm-docs nav 05
+rvm-docs nav security
+rvm-docs nav 10-security.md
+
+# Cross-references for a concept
+rvm-docs xref "witness"
+rvm-docs xref "coherence domain"
+
+# Glossary lookup
+rvm-docs glossary "partition"
+rvm-docs glossary "proof gate"
+
+# API documentation
+rvm-docs api "CapToken"
+rvm-docs api "WitnessRecord"
+rvm-docs api "ProofLevel"
+
+# Task-oriented search
+rvm-docs howto "build rvm"
+rvm-docs howto "run wasm agent"
+rvm-docs howto "benchmark performance"
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--max-results <n>` | Maximum search results (default: 10, applies to `search`) |
+| `--help`, `-h` | Show help message |
+
+## MCP Tools Reference
+
+### docs_search
+
+Search across all documentation files by keyword or phrase.
+
+**Input:**
+```json
+{ "query": "capability delegation", "max_results": 5 }
+```
+
+**Output:** Matching paragraphs with file path, line number, and surrounding context. Results are ranked: exact phrase match > all terms present > any term present.
+
+---
+
+### docs_navigate
+
+Get the table of contents or a specific chapter's content.
+
+**Input:**
+```json
+{ "chapter": "05" }
+```
+
+Omit `chapter` to get the full table of contents from README.md. The chapter parameter accepts a number (`"05"`), partial name (`"security"`), or full filename (`"10-security.md"`).
+
+**Output:** Chapter content as markdown, or the TOC table.
+
+---
+
+### docs_xref
+
+Find all cross-references for a concept across the documentation set.
+
+**Input:**
+```json
+{ "concept": "witness" }
+```
+
+**Output:** Grouped by file, showing headings (likely primary definitions), link references, and mention counts. Files with heading-level references are listed first.
+
+---
+
+### docs_glossary
+
+Look up a term in the glossary.
+
+**Input:**
+```json
+{ "term": "coherence domain" }
+```
+
+**Output:** The glossary definition from 15-glossary.md (if present), plus definition-like references from other chapters (headings, bold terms).
+
+---
+
+### docs_api
+
+Find documentation for an RVM type, trait, function, or constant.
+
+**Input:**
+```json
+{ "symbol": "CapToken" }
+```
+
+**Output:** Matching API signatures, code blocks, and surrounding documentation from the crate reference and detailed chapters. Prioritizes code blocks containing the symbol.
+
+---
+
+### docs_howto
+
+Task-oriented documentation search. Describe what you want to do and get a recommended reading path.
+
+**Input:**
+```json
+{ "task": "run wasm agent" }
+```
+
+**Output:** Matched guide(s) with description and ordered list of recommended chapters. Falls back to full-text search if no specific guide matches.
+
+**Built-in task mappings include:** build rvm, boot qemu, create partition, use capabilities, write proofs, audit witness, manage memory, run wasm agent, secure rvm, benchmark performance, bare metal boot, troubleshoot debug, understand architecture, api reference, and more.
+
+## Architecture
+
+The package has two entry points sharing the same core logic:
+
+```
+src/
+  index.ts   -- MCP server (stdio transport) + exported tool functions
+  cli.ts     -- CLI wrapper with colored terminal output
+```
+
+Documentation files are read from the parent directory (`../`) relative to the package root. Files are cached in memory on startup for fast repeated queries. Missing files are skipped silently, so the tools work with partial documentation sets.
+
+## Documentation Files
+
+The tools operate on these files from the userguide directory:
+
+| File | Topic |
+|------|-------|
+| README.md | Guide overview, paths, prerequisites |
+| 01-quickstart.md | Clone, build, boot in QEMU |
+| 02-core-concepts.md | Partitions, capabilities, witnesses, proofs |
+| 03-architecture.md | Crate layering, dependency graph, four-layer stack |
+| 04-crate-reference.md | Per-crate API surface |
+| 05-capabilities-proofs.md | Three-tier proof system, capability delegation |
+| 06-witness-audit.md | Witness records, hash chains, replay |
+| 07-partitions-scheduling.md | Partition lifecycle, split/merge, scheduler |
+| 08-memory-model.md | Four-tier memory, buddy allocator |
+| 09-wasm-agents.md | WebAssembly guest runtime |
+| 10-security.md | Security gate, attestation, threat model |
+| 11-performance.md | Benchmarks, profiling, optimization |
+| 12-bare-metal.md | AArch64 boot, EL2, UART, GICv2 |
+| 13-advanced-exotic.md | Seed profiles, appliance, chip targets |
+| 14-troubleshooting.md | Build errors, QEMU issues, FAQ |
+| 15-glossary.md | Term definitions |
+| cross-reference.md | Topic-to-chapter index |

--- a/userguide/mcp/dist/cli.d.ts
+++ b/userguide/mcp/dist/cli.d.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+export {};
+//# sourceMappingURL=cli.d.ts.map

--- a/userguide/mcp/dist/cli.js
+++ b/userguide/mcp/dist/cli.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import * as path from "node:path";
+import { loadDocs, docsSearch, docsNavigate, docsXref, docsGlossary, docsApi, docsHowto, } from "./index.js";
+// ---------------------------------------------------------------------------
+// Terminal colors (ANSI escape codes, no dependencies)
+// ---------------------------------------------------------------------------
+const isColorSupported = process.stdout.isTTY && !process.env["NO_COLOR"];
+const c = {
+    reset: isColorSupported ? "\x1b[0m" : "",
+    bold: isColorSupported ? "\x1b[1m" : "",
+    dim: isColorSupported ? "\x1b[2m" : "",
+    red: isColorSupported ? "\x1b[31m" : "",
+    green: isColorSupported ? "\x1b[32m" : "",
+    yellow: isColorSupported ? "\x1b[33m" : "",
+    blue: isColorSupported ? "\x1b[34m" : "",
+    magenta: isColorSupported ? "\x1b[35m" : "",
+    cyan: isColorSupported ? "\x1b[36m" : "",
+    white: isColorSupported ? "\x1b[37m" : "",
+};
+function colorize(text) {
+    return text
+        // Headings
+        .replace(/^(#{1,4}\s.+)$/gm, `${c.bold}${c.cyan}$1${c.reset}`)
+        // Bold text
+        .replace(/\*\*(.+?)\*\*/g, `${c.bold}$1${c.reset}`)
+        // Code blocks - just dim the fences
+        .replace(/^```\w*$/gm, `${c.dim}$&${c.reset}`)
+        // Inline code
+        .replace(/`([^`]+)`/g, `${c.yellow}\`$1\`${c.reset}`)
+        // Links
+        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, `${c.blue}$1${c.reset} ${c.dim}($2)${c.reset}`)
+        // List markers
+        .replace(/^(\s*[-*])\s/gm, `${c.green}$1${c.reset} `)
+        // Line numbers in results
+        .replace(/\(line (\d+)\)/g, `${c.dim}(line $1)${c.reset}`);
+}
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+function printUsage() {
+    console.log(`
+${c.bold}${c.cyan}rvm-docs${c.reset} -- RVM Documentation Search and Navigation
+
+${c.bold}USAGE:${c.reset}
+  rvm-docs <command> [arguments]
+
+${c.bold}COMMANDS:${c.reset}
+  ${c.green}search${c.reset} <query>          Search all documentation files
+  ${c.green}nav${c.reset} [chapter]           Show table of contents or chapter content
+  ${c.green}xref${c.reset} <concept>          Find cross-references for a concept
+  ${c.green}glossary${c.reset} <term>         Look up a glossary term
+  ${c.green}api${c.reset} <symbol>            Find API documentation for a type/function
+  ${c.green}howto${c.reset} <task>            Task-oriented search ("I want to...")
+
+${c.bold}EXAMPLES:${c.reset}
+  rvm-docs search "capability"
+  rvm-docs search "proof gate" --max-results 5
+  rvm-docs nav
+  rvm-docs nav 05
+  rvm-docs nav security
+  rvm-docs xref "witness"
+  rvm-docs glossary "partition"
+  rvm-docs api "CapToken"
+  rvm-docs howto "build rvm"
+  rvm-docs howto "run wasm agent"
+
+${c.bold}OPTIONS:${c.reset}
+  --max-results <n>    Maximum number of search results (default: 10)
+  --help, -h           Show this help message
+`);
+}
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+    const args = argv.slice(2); // skip node and script path
+    if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+        printUsage();
+        process.exit(0);
+    }
+    const command = args[0];
+    let maxResults = 10;
+    // Collect positional args and flags
+    const positionalParts = [];
+    for (let i = 1; i < args.length; i++) {
+        if (args[i] === "--max-results" && i + 1 < args.length) {
+            maxResults = parseInt(args[i + 1], 10) || 10;
+            i++; // skip value
+        }
+        else if (!args[i].startsWith("--")) {
+            positionalParts.push(args[i]);
+        }
+    }
+    return {
+        command,
+        positional: positionalParts.join(" "),
+        maxResults,
+    };
+}
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+    const { command, positional, maxResults } = parseArgs(process.argv);
+    // Resolve docs directory: two levels up from src/ (mcp/src -> mcp -> userguide)
+    const docsDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+    const docs = loadDocs(docsDir);
+    if (docs.length === 0) {
+        console.error(`${c.red}Error:${c.reset} No documentation files found in ${docsDir}`);
+        console.error("Make sure you are running from within the rvm-docs-mcp package.");
+        process.exit(1);
+    }
+    console.error(`${c.dim}Loaded ${docs.length} doc(s) from ${docsDir}${c.reset}\n`);
+    let output;
+    switch (command) {
+        case "search":
+        case "s":
+            if (!positional) {
+                console.error(`${c.red}Error:${c.reset} search requires a query argument.`);
+                process.exit(1);
+            }
+            output = docsSearch(docs, positional, maxResults);
+            break;
+        case "nav":
+        case "navigate":
+        case "n":
+            output = docsNavigate(docs, positional || undefined);
+            break;
+        case "xref":
+        case "x":
+            if (!positional) {
+                console.error(`${c.red}Error:${c.reset} xref requires a concept argument.`);
+                process.exit(1);
+            }
+            output = docsXref(docs, positional);
+            break;
+        case "glossary":
+        case "g":
+            if (!positional) {
+                console.error(`${c.red}Error:${c.reset} glossary requires a term argument.`);
+                process.exit(1);
+            }
+            output = docsGlossary(docs, positional);
+            break;
+        case "api":
+        case "a":
+            if (!positional) {
+                console.error(`${c.red}Error:${c.reset} api requires a symbol argument.`);
+                process.exit(1);
+            }
+            output = docsApi(docs, positional);
+            break;
+        case "howto":
+        case "h":
+            if (!positional) {
+                console.error(`${c.red}Error:${c.reset} howto requires a task description.`);
+                process.exit(1);
+            }
+            output = docsHowto(docs, positional);
+            break;
+        default:
+            console.error(`${c.red}Unknown command:${c.reset} ${command}`);
+            printUsage();
+            process.exit(1);
+    }
+    console.log(colorize(output));
+}
+main();
+//# sourceMappingURL=cli.js.map

--- a/userguide/mcp/dist/index.d.ts
+++ b/userguide/mcp/dist/index.d.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+interface DocEntry {
+    filename: string;
+    filepath: string;
+    content: string;
+    lines: string[];
+}
+export declare function loadDocs(docsDir?: string): DocEntry[];
+export declare function docsSearch(docs: DocEntry[], query: string, maxResults?: number): string;
+export declare function docsNavigate(docs: DocEntry[], chapter?: string): string;
+export declare function docsXref(docs: DocEntry[], concept: string): string;
+export declare function docsGlossary(docs: DocEntry[], term: string): string;
+export declare function docsApi(docs: DocEntry[], symbol: string): string;
+export declare function docsHowto(docs: DocEntry[], task: string): string;
+export {};
+//# sourceMappingURL=index.d.ts.map

--- a/userguide/mcp/dist/index.js
+++ b/userguide/mcp/dist/index.js
@@ -1,0 +1,647 @@
+#!/usr/bin/env node
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema, } from "@modelcontextprotocol/sdk/types.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+// ---------------------------------------------------------------------------
+// Documentation file list (order matters for TOC)
+// ---------------------------------------------------------------------------
+const DOC_FILES = [
+    "README.md",
+    "01-quickstart.md",
+    "02-core-concepts.md",
+    "03-architecture.md",
+    "04-crate-reference.md",
+    "05-capabilities-proofs.md",
+    "06-witness-audit.md",
+    "07-partitions-scheduling.md",
+    "08-memory-model.md",
+    "09-wasm-agents.md",
+    "10-security.md",
+    "11-performance.md",
+    "12-bare-metal.md",
+    "13-advanced-exotic.md",
+    "14-troubleshooting.md",
+    "15-glossary.md",
+    "cross-reference.md",
+];
+// ---------------------------------------------------------------------------
+// Task-to-chapter mapping for howto tool
+// ---------------------------------------------------------------------------
+const HOWTO_MAP = {
+    "build rvm": {
+        chapters: ["01-quickstart.md"],
+        description: "Clone, compile, and run the full test suite.",
+    },
+    "boot qemu": {
+        chapters: ["01-quickstart.md", "12-bare-metal.md"],
+        description: "Boot RVM on QEMU aarch64 virtual machine.",
+    },
+    "create partition": {
+        chapters: ["02-core-concepts.md", "07-partitions-scheduling.md"],
+        description: "Understand and create coherence-domain partitions.",
+    },
+    "split merge partition": {
+        chapters: ["07-partitions-scheduling.md"],
+        description: "Split partitions along mincut boundaries or merge on rising coherence.",
+    },
+    "use capabilities": {
+        chapters: ["05-capabilities-proofs.md", "02-core-concepts.md"],
+        description: "Create, delegate, and attenuate capability tokens.",
+    },
+    "write proofs": {
+        chapters: ["05-capabilities-proofs.md"],
+        description: "Understand P1/P2/P3 proof tiers and proof gates.",
+    },
+    "audit witness": {
+        chapters: ["06-witness-audit.md"],
+        description: "Query witness trails, verify hash chains, replay events.",
+    },
+    "manage memory": {
+        chapters: ["08-memory-model.md"],
+        description: "Work with Hot/Warm/Dormant/Cold memory tiers and buddy allocator.",
+    },
+    "run wasm agent": {
+        chapters: ["09-wasm-agents.md"],
+        description: "Deploy and manage WebAssembly guest agents.",
+    },
+    "secure rvm": {
+        chapters: ["10-security.md", "05-capabilities-proofs.md"],
+        description: "Understand threat model, attestation chains, DMA budgets.",
+    },
+    "benchmark performance": {
+        chapters: ["11-performance.md", "01-quickstart.md"],
+        description: "Run criterion benchmarks and interpret results.",
+    },
+    "bare metal boot": {
+        chapters: ["12-bare-metal.md"],
+        description: "AArch64 EL2 entry, PL011 UART, GICv2, stage-2 page tables.",
+    },
+    "advanced exotic": {
+        chapters: ["13-advanced-exotic.md"],
+        description: "Seed profiles, appliance deployment, chip targets, RuVector.",
+    },
+    "troubleshoot debug": {
+        chapters: ["14-troubleshooting.md"],
+        description: "Fix common build errors, QEMU issues, debugging tips.",
+    },
+    "understand architecture": {
+        chapters: ["03-architecture.md", "02-core-concepts.md"],
+        description: "Crate layering, dependency graph, four-layer stack.",
+    },
+    "api reference": {
+        chapters: ["04-crate-reference.md", "15-glossary.md"],
+        description: "Per-crate API surface, public types, traits, constants.",
+    },
+    "cross reference": {
+        chapters: ["cross-reference.md"],
+        description: "Topic-to-chapter mapping for quick navigation.",
+    },
+    "scheduling": {
+        chapters: ["07-partitions-scheduling.md"],
+        description: "2-signal scheduler and scheduling modes.",
+    },
+};
+let docCache = [];
+function getDocsDir() {
+    return path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+}
+export function loadDocs(docsDir) {
+    const dir = docsDir ?? getDocsDir();
+    const entries = [];
+    for (const filename of DOC_FILES) {
+        const filepath = path.join(dir, filename);
+        try {
+            const content = fs.readFileSync(filepath, "utf-8");
+            entries.push({
+                filename,
+                filepath,
+                content,
+                lines: content.split("\n"),
+            });
+        }
+        catch {
+            // File may not exist yet -- skip silently
+        }
+    }
+    return entries;
+}
+// ---------------------------------------------------------------------------
+// Tool implementations (exported for CLI reuse)
+// ---------------------------------------------------------------------------
+export function docsSearch(docs, query, maxResults = 10) {
+    const lowerQuery = query.toLowerCase();
+    const terms = lowerQuery.split(/\s+/).filter(Boolean);
+    const matches = [];
+    for (const doc of docs) {
+        for (let i = 0; i < doc.lines.length; i++) {
+            const line = doc.lines[i];
+            const lowerLine = line.toLowerCase();
+            // Score: exact phrase match > all terms present > any term present
+            let score = 0;
+            if (lowerLine.includes(lowerQuery)) {
+                score = 3;
+            }
+            else if (terms.every((t) => lowerLine.includes(t))) {
+                score = 2;
+            }
+            else if (terms.some((t) => lowerLine.includes(t))) {
+                score = 1;
+            }
+            if (score > 0) {
+                // Gather context: 1 line before and 1 line after
+                const start = Math.max(0, i - 1);
+                const end = Math.min(doc.lines.length - 1, i + 1);
+                const contextLines = [];
+                for (let j = start; j <= end; j++) {
+                    contextLines.push(doc.lines[j]);
+                }
+                matches.push({
+                    filename: doc.filename,
+                    lineNum: i + 1,
+                    context: contextLines.join("\n"),
+                    score,
+                });
+            }
+        }
+    }
+    // Deduplicate overlapping context windows
+    const deduped = [];
+    const seen = new Set();
+    matches.sort((a, b) => b.score - a.score || a.lineNum - b.lineNum);
+    for (const m of matches) {
+        const key = `${m.filename}:${m.lineNum}`;
+        if (!seen.has(key)) {
+            deduped.push(m);
+            seen.add(key);
+            // Mark nearby lines as seen to reduce noise
+            seen.add(`${m.filename}:${m.lineNum - 1}`);
+            seen.add(`${m.filename}:${m.lineNum + 1}`);
+        }
+    }
+    const results = deduped.slice(0, maxResults);
+    if (results.length === 0) {
+        return `No results found for "${query}".`;
+    }
+    const parts = [`## Search Results for "${query}"\n`];
+    parts.push(`Found ${results.length} result(s):\n`);
+    for (const r of results) {
+        parts.push(`### ${r.filename} (line ${r.lineNum})\n`);
+        parts.push("```");
+        parts.push(r.context);
+        parts.push("```\n");
+    }
+    return parts.join("\n");
+}
+export function docsNavigate(docs, chapter) {
+    if (!chapter) {
+        // Return the TOC from README.md
+        const readme = docs.find((d) => d.filename === "README.md");
+        if (!readme) {
+            return "README.md not found. Available files:\n" +
+                docs.map((d) => `- ${d.filename}`).join("\n");
+        }
+        // Extract the Table of Contents section
+        const tocStart = readme.content.indexOf("## Table of Contents");
+        if (tocStart === -1) {
+            return readme.content;
+        }
+        const afterToc = readme.content.indexOf("\n---", tocStart + 1);
+        const tocSection = afterToc === -1
+            ? readme.content.slice(tocStart)
+            : readme.content.slice(tocStart, afterToc);
+        return tocSection.trim();
+    }
+    // Find the matching chapter
+    const normalized = chapter.replace(/^0+/, "").toLowerCase();
+    const match = docs.find((d) => {
+        const name = d.filename.toLowerCase();
+        // Match by number prefix, partial name, or full filename
+        return (name === chapter.toLowerCase() ||
+            name === `${chapter.toLowerCase()}.md` ||
+            name.startsWith(`${chapter.padStart(2, "0")}-`) ||
+            name.includes(normalized));
+    });
+    if (!match) {
+        const available = docs.map((d) => `- ${d.filename}`).join("\n");
+        return `Chapter "${chapter}" not found.\n\nAvailable chapters:\n${available}`;
+    }
+    return `# ${match.filename}\n\n${match.content}`;
+}
+export function docsXref(docs, concept) {
+    const lowerConcept = concept.toLowerCase();
+    const refs = [];
+    for (const doc of docs) {
+        for (let i = 0; i < doc.lines.length; i++) {
+            const line = doc.lines[i];
+            const lowerLine = line.toLowerCase();
+            if (lowerLine.includes(lowerConcept)) {
+                refs.push({
+                    filename: doc.filename,
+                    lineNum: i + 1,
+                    line: line.trim(),
+                    isHeading: line.startsWith("#"),
+                    isLink: /\[.*\]\(.*\.md.*\)/.test(line),
+                });
+            }
+        }
+    }
+    if (refs.length === 0) {
+        return `No cross-references found for "${concept}".`;
+    }
+    // Group by file
+    const byFile = new Map();
+    for (const ref of refs) {
+        const existing = byFile.get(ref.filename) ?? [];
+        existing.push(ref);
+        byFile.set(ref.filename, existing);
+    }
+    const parts = [`## Cross-References for "${concept}"\n`];
+    parts.push(`Found references in ${byFile.size} file(s):\n`);
+    // Sort: files with headings first (likely primary definition)
+    const sorted = [...byFile.entries()].sort((a, b) => {
+        const aHasHeading = a[1].some((r) => r.isHeading) ? 0 : 1;
+        const bHasHeading = b[1].some((r) => r.isHeading) ? 0 : 1;
+        return aHasHeading - bHasHeading;
+    });
+    for (const [filename, fileRefs] of sorted) {
+        const headingRefs = fileRefs.filter((r) => r.isHeading);
+        const linkRefs = fileRefs.filter((r) => r.isLink && !r.isHeading);
+        const otherRefs = fileRefs.filter((r) => !r.isHeading && !r.isLink);
+        parts.push(`### ${filename}`);
+        if (headingRefs.length > 0) {
+            parts.push("\n**Headings:**");
+            for (const r of headingRefs) {
+                parts.push(`- Line ${r.lineNum}: ${r.line}`);
+            }
+        }
+        if (linkRefs.length > 0) {
+            parts.push("\n**Links:**");
+            for (const r of linkRefs.slice(0, 5)) {
+                parts.push(`- Line ${r.lineNum}: ${r.line}`);
+            }
+        }
+        if (otherRefs.length > 0) {
+            parts.push(`\n**Mentions:** ${otherRefs.length} occurrence(s)`);
+            for (const r of otherRefs.slice(0, 3)) {
+                parts.push(`- Line ${r.lineNum}: ${r.line.slice(0, 120)}${r.line.length > 120 ? "..." : ""}`);
+            }
+        }
+        parts.push("");
+    }
+    return parts.join("\n");
+}
+export function docsGlossary(docs, term) {
+    const glossary = docs.find((d) => d.filename === "15-glossary.md");
+    // If no dedicated glossary file, search all docs for definition-like patterns
+    const lowerTerm = term.toLowerCase();
+    const results = [];
+    if (glossary) {
+        // Search the glossary file first
+        const lines = glossary.lines;
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (line.toLowerCase().includes(lowerTerm)) {
+                // Grab context: heading + body until next heading or blank section
+                let start = i;
+                // Walk back to find the term's heading
+                while (start > 0 && !lines[start].startsWith("#") && !lines[start].startsWith("**")) {
+                    start--;
+                }
+                let end = i + 1;
+                // Walk forward to find the end of the definition
+                while (end < lines.length &&
+                    !lines[end].startsWith("#") &&
+                    !(lines[end].startsWith("**") && end > i + 1)) {
+                    end++;
+                }
+                const block = lines.slice(start, end).join("\n").trim();
+                if (block.length > 0) {
+                    results.push(`### From 15-glossary.md (line ${start + 1})\n\n${block}`);
+                    break; // Take the first glossary match
+                }
+            }
+        }
+    }
+    // Also search other docs for definitions
+    for (const doc of docs) {
+        if (doc.filename === "15-glossary.md")
+            continue;
+        for (let i = 0; i < doc.lines.length; i++) {
+            const line = doc.lines[i];
+            const lowerLine = line.toLowerCase();
+            // Look for heading-level definitions or bold definitions
+            if (lowerLine.includes(lowerTerm) &&
+                (line.startsWith("#") || line.startsWith("**") || line.startsWith("- **"))) {
+                const end = Math.min(i + 4, doc.lines.length);
+                const block = doc.lines.slice(i, end).join("\n").trim();
+                results.push(`### From ${doc.filename} (line ${i + 1})\n\n${block}`);
+                if (results.length >= 5)
+                    break;
+            }
+        }
+        if (results.length >= 5)
+            break;
+    }
+    if (results.length === 0) {
+        return `No glossary entry found for "${term}". Try docs_search for a broader search.`;
+    }
+    return `## Glossary: "${term}"\n\n${results.join("\n\n---\n\n")}`;
+}
+export function docsApi(docs, symbol) {
+    const lowerSymbol = symbol.toLowerCase();
+    const matches = [];
+    for (const doc of docs) {
+        let inCodeBlock = false;
+        let codeBlockStart = -1;
+        for (let i = 0; i < doc.lines.length; i++) {
+            const line = doc.lines[i];
+            if (line.startsWith("```")) {
+                if (inCodeBlock) {
+                    // End of code block -- check if the block contains the symbol
+                    const blockContent = doc.lines.slice(codeBlockStart, i + 1).join("\n");
+                    if (blockContent.toLowerCase().includes(lowerSymbol)) {
+                        // Include heading context before the code block
+                        let headingLine = codeBlockStart;
+                        while (headingLine > 0 && !doc.lines[headingLine].startsWith("#")) {
+                            headingLine--;
+                        }
+                        const contextStart = Math.max(headingLine, codeBlockStart - 3);
+                        const fullBlock = doc.lines.slice(contextStart, i + 1).join("\n");
+                        matches.push({
+                            filename: doc.filename,
+                            lineNum: codeBlockStart + 1,
+                            block: fullBlock,
+                            isCodeBlock: true,
+                            score: 3,
+                        });
+                    }
+                    inCodeBlock = false;
+                }
+                else {
+                    inCodeBlock = true;
+                    codeBlockStart = i;
+                }
+                continue;
+            }
+            if (!inCodeBlock && line.toLowerCase().includes(lowerSymbol)) {
+                // Check for struct/type/trait/fn definitions or heading-level API docs
+                const isApiLine = line.startsWith("#") ||
+                    line.includes("pub struct") ||
+                    line.includes("pub enum") ||
+                    line.includes("pub trait") ||
+                    line.includes("pub fn") ||
+                    line.includes("pub type") ||
+                    line.includes("pub const") ||
+                    line.startsWith("| `") ||
+                    line.startsWith("- `");
+                if (isApiLine) {
+                    const start = Math.max(0, i - 1);
+                    const end = Math.min(doc.lines.length, i + 6);
+                    const block = doc.lines.slice(start, end).join("\n");
+                    matches.push({
+                        filename: doc.filename,
+                        lineNum: i + 1,
+                        block,
+                        isCodeBlock: false,
+                        score: line.startsWith("#") ? 2 : 1,
+                    });
+                }
+            }
+        }
+    }
+    if (matches.length === 0) {
+        return `No API documentation found for "${symbol}". Try docs_search for a broader search.`;
+    }
+    matches.sort((a, b) => b.score - a.score);
+    const top = matches.slice(0, 8);
+    const parts = [`## API Documentation for "${symbol}"\n`];
+    parts.push(`Found ${matches.length} match(es), showing top ${top.length}:\n`);
+    for (const m of top) {
+        parts.push(`### ${m.filename} (line ${m.lineNum})\n`);
+        parts.push(m.block);
+        parts.push("\n");
+    }
+    return parts.join("\n");
+}
+export function docsHowto(docs, task) {
+    const lowerTask = task.toLowerCase();
+    const taskTerms = lowerTask.split(/\s+/).filter(Boolean);
+    const matches = [];
+    for (const [key, entry] of Object.entries(HOWTO_MAP)) {
+        const lowerKey = key.toLowerCase();
+        const lowerDesc = entry.description.toLowerCase();
+        const combined = `${lowerKey} ${lowerDesc}`;
+        let score = 0;
+        if (combined.includes(lowerTask)) {
+            score = 3;
+        }
+        else {
+            const matchedTerms = taskTerms.filter((t) => combined.includes(t));
+            score = matchedTerms.length;
+        }
+        if (score > 0) {
+            matches.push({ key, entry, score });
+        }
+    }
+    matches.sort((a, b) => b.score - a.score);
+    if (matches.length === 0) {
+        // Fall back to search
+        const searchResult = docsSearch(docs, task, 5);
+        return `## How To: "${task}"\n\nNo specific guide found. Here are search results:\n\n${searchResult}`;
+    }
+    const parts = [`## How To: "${task}"\n`];
+    parts.push(`Found ${matches.length} relevant guide(s):\n`);
+    for (const m of matches.slice(0, 5)) {
+        parts.push(`### ${m.key}`);
+        parts.push(`${m.entry.description}\n`);
+        parts.push("**Recommended reading:**");
+        for (const ch of m.entry.chapters) {
+            const doc = docs.find((d) => d.filename === ch);
+            const title = doc
+                ? (doc.lines.find((l) => l.startsWith("# "))?.replace(/^#\s+/, "") ?? ch)
+                : ch;
+            parts.push(`- [${title}](${ch})`);
+        }
+        parts.push("");
+    }
+    return parts.join("\n");
+}
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+const server = new Server({
+    name: "rvm-docs",
+    version: "1.0.0",
+}, {
+    capabilities: {
+        tools: {},
+    },
+});
+// List tools
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+        {
+            name: "docs_search",
+            description: "Search across all RVM documentation files by keyword or phrase. Returns matching paragraphs with file paths and line numbers.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    query: {
+                        type: "string",
+                        description: "The search query (keyword or phrase)",
+                    },
+                    max_results: {
+                        type: "number",
+                        description: "Maximum number of results to return (default: 10)",
+                    },
+                },
+                required: ["query"],
+            },
+        },
+        {
+            name: "docs_navigate",
+            description: "Get the table of contents or a specific chapter's content. If chapter is omitted, returns the full TOC.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    chapter: {
+                        type: "string",
+                        description: 'Chapter identifier: number (e.g. "05"), partial name (e.g. "security"), or full filename (e.g. "10-security.md")',
+                    },
+                },
+            },
+        },
+        {
+            name: "docs_xref",
+            description: "Find all cross-references for a concept across all documentation files. Returns the primary chapter and all files that reference it.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    concept: {
+                        type: "string",
+                        description: "The concept to find cross-references for (e.g. \"witness\", \"partition\", \"capability\")",
+                    },
+                },
+                required: ["concept"],
+            },
+        },
+        {
+            name: "docs_glossary",
+            description: "Look up a term in the RVM glossary. Returns the definition and cross-references to related documentation.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    term: {
+                        type: "string",
+                        description: "The glossary term to look up (e.g. \"coherence domain\", \"proof gate\")",
+                    },
+                },
+                required: ["term"],
+            },
+        },
+        {
+            name: "docs_api",
+            description: "Find documentation for an RVM type, trait, function, or constant. Searches crate-reference and detailed chapters for API signatures and code examples.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    symbol: {
+                        type: "string",
+                        description: "The API symbol to search for (e.g. \"CapToken\", \"WitnessRecord\", \"ProofLevel\")",
+                    },
+                },
+                required: ["symbol"],
+            },
+        },
+        {
+            name: "docs_howto",
+            description: 'Task-oriented documentation search. Describe what you want to do and get a recommended reading path. Example: "boot qemu", "create partition", "run wasm agent".',
+            inputSchema: {
+                type: "object",
+                properties: {
+                    task: {
+                        type: "string",
+                        description: "What you want to accomplish (e.g. \"build rvm\", \"use capabilities\", \"benchmark performance\")",
+                    },
+                },
+                required: ["task"],
+            },
+        },
+    ],
+}));
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    // Ensure docs are loaded
+    if (docCache.length === 0) {
+        docCache = loadDocs();
+    }
+    switch (name) {
+        case "docs_search": {
+            const query = args.query;
+            const maxResults = args.max_results ?? 10;
+            return {
+                content: [{ type: "text", text: docsSearch(docCache, query, maxResults) }],
+            };
+        }
+        case "docs_navigate": {
+            const chapter = args.chapter;
+            return {
+                content: [{ type: "text", text: docsNavigate(docCache, chapter) }],
+            };
+        }
+        case "docs_xref": {
+            const concept = args.concept;
+            return {
+                content: [{ type: "text", text: docsXref(docCache, concept) }],
+            };
+        }
+        case "docs_glossary": {
+            const term = args.term;
+            return {
+                content: [{ type: "text", text: docsGlossary(docCache, term) }],
+            };
+        }
+        case "docs_api": {
+            const symbol = args.symbol;
+            return {
+                content: [{ type: "text", text: docsApi(docCache, symbol) }],
+            };
+        }
+        case "docs_howto": {
+            const task = args.task;
+            return {
+                content: [{ type: "text", text: docsHowto(docCache, task) }],
+            };
+        }
+        default:
+            return {
+                content: [{ type: "text", text: `Unknown tool: ${name}` }],
+                isError: true,
+            };
+    }
+});
+// ---------------------------------------------------------------------------
+// Start server (only when run directly, not when imported by CLI)
+// ---------------------------------------------------------------------------
+async function main() {
+    docCache = loadDocs();
+    const fileCount = docCache.length;
+    const totalLines = docCache.reduce((sum, d) => sum + d.lines.length, 0);
+    console.error(`rvm-docs MCP server started. Loaded ${fileCount} doc(s), ${totalLines} lines.`);
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+// Only start the MCP server when this module is the entry point
+const isDirectRun = process.argv[1] &&
+    (process.argv[1].endsWith("/index.js") ||
+        process.argv[1].endsWith("\\index.js"));
+if (isDirectRun) {
+    main().catch((err) => {
+        console.error("Fatal error:", err);
+        process.exit(1);
+    });
+}
+//# sourceMappingURL=index.js.map

--- a/userguide/mcp/package-lock.json
+++ b/userguide/mcp/package-lock.json
@@ -1,0 +1,1176 @@
+{
+  "name": "rvm-docs-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rvm-docs-mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "bin": {
+        "rvm-docs": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/userguide/mcp/package.json
+++ b/userguide/mcp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rvm-docs-mcp",
+  "version": "1.0.0",
+  "description": "MCP server and CLI for RVM documentation search, navigation, and cross-reference",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "rvm-docs": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "cli": "node dist/cli.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/userguide/mcp/src/cli.ts
+++ b/userguide/mcp/src/cli.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+
+import * as path from "node:path";
+import {
+  loadDocs,
+  docsSearch,
+  docsNavigate,
+  docsXref,
+  docsGlossary,
+  docsApi,
+  docsHowto,
+} from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Terminal colors (ANSI escape codes, no dependencies)
+// ---------------------------------------------------------------------------
+
+const isColorSupported =
+  process.stdout.isTTY && !process.env["NO_COLOR"];
+
+const c = {
+  reset: isColorSupported ? "\x1b[0m" : "",
+  bold: isColorSupported ? "\x1b[1m" : "",
+  dim: isColorSupported ? "\x1b[2m" : "",
+  red: isColorSupported ? "\x1b[31m" : "",
+  green: isColorSupported ? "\x1b[32m" : "",
+  yellow: isColorSupported ? "\x1b[33m" : "",
+  blue: isColorSupported ? "\x1b[34m" : "",
+  magenta: isColorSupported ? "\x1b[35m" : "",
+  cyan: isColorSupported ? "\x1b[36m" : "",
+  white: isColorSupported ? "\x1b[37m" : "",
+};
+
+function colorize(text: string): string {
+  return text
+    // Headings
+    .replace(/^(#{1,4}\s.+)$/gm, `${c.bold}${c.cyan}$1${c.reset}`)
+    // Bold text
+    .replace(/\*\*(.+?)\*\*/g, `${c.bold}$1${c.reset}`)
+    // Code blocks - just dim the fences
+    .replace(/^```\w*$/gm, `${c.dim}$&${c.reset}`)
+    // Inline code
+    .replace(/`([^`]+)`/g, `${c.yellow}\`$1\`${c.reset}`)
+    // Links
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, `${c.blue}$1${c.reset} ${c.dim}($2)${c.reset}`)
+    // List markers
+    .replace(/^(\s*[-*])\s/gm, `${c.green}$1${c.reset} `)
+    // Line numbers in results
+    .replace(/\(line (\d+)\)/g, `${c.dim}(line $1)${c.reset}`);
+}
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+function printUsage(): void {
+  console.log(`
+${c.bold}${c.cyan}rvm-docs${c.reset} -- RVM Documentation Search and Navigation
+
+${c.bold}USAGE:${c.reset}
+  rvm-docs <command> [arguments]
+
+${c.bold}COMMANDS:${c.reset}
+  ${c.green}search${c.reset} <query>          Search all documentation files
+  ${c.green}nav${c.reset} [chapter]           Show table of contents or chapter content
+  ${c.green}xref${c.reset} <concept>          Find cross-references for a concept
+  ${c.green}glossary${c.reset} <term>         Look up a glossary term
+  ${c.green}api${c.reset} <symbol>            Find API documentation for a type/function
+  ${c.green}howto${c.reset} <task>            Task-oriented search ("I want to...")
+
+${c.bold}EXAMPLES:${c.reset}
+  rvm-docs search "capability"
+  rvm-docs search "proof gate" --max-results 5
+  rvm-docs nav
+  rvm-docs nav 05
+  rvm-docs nav security
+  rvm-docs xref "witness"
+  rvm-docs glossary "partition"
+  rvm-docs api "CapToken"
+  rvm-docs howto "build rvm"
+  rvm-docs howto "run wasm agent"
+
+${c.bold}OPTIONS:${c.reset}
+  --max-results <n>    Maximum number of search results (default: 10)
+  --help, -h           Show this help message
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): {
+  command: string;
+  positional: string;
+  maxResults: number;
+} {
+  const args = argv.slice(2); // skip node and script path
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const command = args[0]!;
+  let maxResults = 10;
+
+  // Collect positional args and flags
+  const positionalParts: string[] = [];
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === "--max-results" && i + 1 < args.length) {
+      maxResults = parseInt(args[i + 1]!, 10) || 10;
+      i++; // skip value
+    } else if (!args[i]!.startsWith("--")) {
+      positionalParts.push(args[i]!);
+    }
+  }
+
+  return {
+    command,
+    positional: positionalParts.join(" "),
+    maxResults,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const { command, positional, maxResults } = parseArgs(process.argv);
+
+  // Resolve docs directory: two levels up from src/ (mcp/src -> mcp -> userguide)
+  const docsDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+  const docs = loadDocs(docsDir);
+
+  if (docs.length === 0) {
+    console.error(
+      `${c.red}Error:${c.reset} No documentation files found in ${docsDir}`,
+    );
+    console.error("Make sure you are running from within the rvm-docs-mcp package.");
+    process.exit(1);
+  }
+
+  console.error(
+    `${c.dim}Loaded ${docs.length} doc(s) from ${docsDir}${c.reset}\n`,
+  );
+
+  let output: string;
+
+  switch (command) {
+    case "search":
+    case "s":
+      if (!positional) {
+        console.error(`${c.red}Error:${c.reset} search requires a query argument.`);
+        process.exit(1);
+      }
+      output = docsSearch(docs, positional, maxResults);
+      break;
+
+    case "nav":
+    case "navigate":
+    case "n":
+      output = docsNavigate(docs, positional || undefined);
+      break;
+
+    case "xref":
+    case "x":
+      if (!positional) {
+        console.error(`${c.red}Error:${c.reset} xref requires a concept argument.`);
+        process.exit(1);
+      }
+      output = docsXref(docs, positional);
+      break;
+
+    case "glossary":
+    case "g":
+      if (!positional) {
+        console.error(`${c.red}Error:${c.reset} glossary requires a term argument.`);
+        process.exit(1);
+      }
+      output = docsGlossary(docs, positional);
+      break;
+
+    case "api":
+    case "a":
+      if (!positional) {
+        console.error(`${c.red}Error:${c.reset} api requires a symbol argument.`);
+        process.exit(1);
+      }
+      output = docsApi(docs, positional);
+      break;
+
+    case "howto":
+    case "h":
+      if (!positional) {
+        console.error(`${c.red}Error:${c.reset} howto requires a task description.`);
+        process.exit(1);
+      }
+      output = docsHowto(docs, positional);
+      break;
+
+    default:
+      console.error(`${c.red}Unknown command:${c.reset} ${command}`);
+      printUsage();
+      process.exit(1);
+  }
+
+  console.log(colorize(output));
+}
+
+main();

--- a/userguide/mcp/src/index.ts
+++ b/userguide/mcp/src/index.ts
@@ -1,0 +1,804 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Documentation file list (order matters for TOC)
+// ---------------------------------------------------------------------------
+
+const DOC_FILES = [
+  "README.md",
+  "01-quickstart.md",
+  "02-core-concepts.md",
+  "03-architecture.md",
+  "04-crate-reference.md",
+  "05-capabilities-proofs.md",
+  "06-witness-audit.md",
+  "07-partitions-scheduling.md",
+  "08-memory-model.md",
+  "09-wasm-agents.md",
+  "10-security.md",
+  "11-performance.md",
+  "12-bare-metal.md",
+  "13-advanced-exotic.md",
+  "14-troubleshooting.md",
+  "15-glossary.md",
+  "cross-reference.md",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Task-to-chapter mapping for howto tool
+// ---------------------------------------------------------------------------
+
+const HOWTO_MAP: Record<string, { chapters: string[]; description: string }> = {
+  "build rvm": {
+    chapters: ["01-quickstart.md"],
+    description: "Clone, compile, and run the full test suite.",
+  },
+  "boot qemu": {
+    chapters: ["01-quickstart.md", "12-bare-metal.md"],
+    description: "Boot RVM on QEMU aarch64 virtual machine.",
+  },
+  "create partition": {
+    chapters: ["02-core-concepts.md", "07-partitions-scheduling.md"],
+    description: "Understand and create coherence-domain partitions.",
+  },
+  "split merge partition": {
+    chapters: ["07-partitions-scheduling.md"],
+    description: "Split partitions along mincut boundaries or merge on rising coherence.",
+  },
+  "use capabilities": {
+    chapters: ["05-capabilities-proofs.md", "02-core-concepts.md"],
+    description: "Create, delegate, and attenuate capability tokens.",
+  },
+  "write proofs": {
+    chapters: ["05-capabilities-proofs.md"],
+    description: "Understand P1/P2/P3 proof tiers and proof gates.",
+  },
+  "audit witness": {
+    chapters: ["06-witness-audit.md"],
+    description: "Query witness trails, verify hash chains, replay events.",
+  },
+  "manage memory": {
+    chapters: ["08-memory-model.md"],
+    description: "Work with Hot/Warm/Dormant/Cold memory tiers and buddy allocator.",
+  },
+  "run wasm agent": {
+    chapters: ["09-wasm-agents.md"],
+    description: "Deploy and manage WebAssembly guest agents.",
+  },
+  "secure rvm": {
+    chapters: ["10-security.md", "05-capabilities-proofs.md"],
+    description: "Understand threat model, attestation chains, DMA budgets.",
+  },
+  "benchmark performance": {
+    chapters: ["11-performance.md", "01-quickstart.md"],
+    description: "Run criterion benchmarks and interpret results.",
+  },
+  "bare metal boot": {
+    chapters: ["12-bare-metal.md"],
+    description: "AArch64 EL2 entry, PL011 UART, GICv2, stage-2 page tables.",
+  },
+  "advanced exotic": {
+    chapters: ["13-advanced-exotic.md"],
+    description: "Seed profiles, appliance deployment, chip targets, RuVector.",
+  },
+  "troubleshoot debug": {
+    chapters: ["14-troubleshooting.md"],
+    description: "Fix common build errors, QEMU issues, debugging tips.",
+  },
+  "understand architecture": {
+    chapters: ["03-architecture.md", "02-core-concepts.md"],
+    description: "Crate layering, dependency graph, four-layer stack.",
+  },
+  "api reference": {
+    chapters: ["04-crate-reference.md", "15-glossary.md"],
+    description: "Per-crate API surface, public types, traits, constants.",
+  },
+  "cross reference": {
+    chapters: ["cross-reference.md"],
+    description: "Topic-to-chapter mapping for quick navigation.",
+  },
+  "scheduling": {
+    chapters: ["07-partitions-scheduling.md"],
+    description: "2-signal scheduler and scheduling modes.",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Document cache
+// ---------------------------------------------------------------------------
+
+interface DocEntry {
+  filename: string;
+  filepath: string;
+  content: string;
+  lines: string[];
+}
+
+let docCache: DocEntry[] = [];
+
+function getDocsDir(): string {
+  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+}
+
+export function loadDocs(docsDir?: string): DocEntry[] {
+  const dir = docsDir ?? getDocsDir();
+  const entries: DocEntry[] = [];
+
+  for (const filename of DOC_FILES) {
+    const filepath = path.join(dir, filename);
+    try {
+      const content = fs.readFileSync(filepath, "utf-8");
+      entries.push({
+        filename,
+        filepath,
+        content,
+        lines: content.split("\n"),
+      });
+    } catch {
+      // File may not exist yet -- skip silently
+    }
+  }
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Tool implementations (exported for CLI reuse)
+// ---------------------------------------------------------------------------
+
+export function docsSearch(
+  docs: DocEntry[],
+  query: string,
+  maxResults: number = 10,
+): string {
+  const lowerQuery = query.toLowerCase();
+  const terms = lowerQuery.split(/\s+/).filter(Boolean);
+
+  interface Match {
+    filename: string;
+    lineNum: number;
+    context: string;
+    score: number;
+  }
+
+  const matches: Match[] = [];
+
+  for (const doc of docs) {
+    for (let i = 0; i < doc.lines.length; i++) {
+      const line = doc.lines[i];
+      const lowerLine = line.toLowerCase();
+
+      // Score: exact phrase match > all terms present > any term present
+      let score = 0;
+      if (lowerLine.includes(lowerQuery)) {
+        score = 3;
+      } else if (terms.every((t) => lowerLine.includes(t))) {
+        score = 2;
+      } else if (terms.some((t) => lowerLine.includes(t))) {
+        score = 1;
+      }
+
+      if (score > 0) {
+        // Gather context: 1 line before and 1 line after
+        const start = Math.max(0, i - 1);
+        const end = Math.min(doc.lines.length - 1, i + 1);
+        const contextLines: string[] = [];
+        for (let j = start; j <= end; j++) {
+          contextLines.push(doc.lines[j]);
+        }
+
+        matches.push({
+          filename: doc.filename,
+          lineNum: i + 1,
+          context: contextLines.join("\n"),
+          score,
+        });
+      }
+    }
+  }
+
+  // Deduplicate overlapping context windows
+  const deduped: Match[] = [];
+  const seen = new Set<string>();
+
+  matches.sort((a, b) => b.score - a.score || a.lineNum - b.lineNum);
+
+  for (const m of matches) {
+    const key = `${m.filename}:${m.lineNum}`;
+    if (!seen.has(key)) {
+      deduped.push(m);
+      seen.add(key);
+      // Mark nearby lines as seen to reduce noise
+      seen.add(`${m.filename}:${m.lineNum - 1}`);
+      seen.add(`${m.filename}:${m.lineNum + 1}`);
+    }
+  }
+
+  const results = deduped.slice(0, maxResults);
+
+  if (results.length === 0) {
+    return `No results found for "${query}".`;
+  }
+
+  const parts: string[] = [`## Search Results for "${query}"\n`];
+  parts.push(`Found ${results.length} result(s):\n`);
+
+  for (const r of results) {
+    parts.push(`### ${r.filename} (line ${r.lineNum})\n`);
+    parts.push("```");
+    parts.push(r.context);
+    parts.push("```\n");
+  }
+
+  return parts.join("\n");
+}
+
+export function docsNavigate(docs: DocEntry[], chapter?: string): string {
+  if (!chapter) {
+    // Return the TOC from README.md
+    const readme = docs.find((d) => d.filename === "README.md");
+    if (!readme) {
+      return "README.md not found. Available files:\n" +
+        docs.map((d) => `- ${d.filename}`).join("\n");
+    }
+
+    // Extract the Table of Contents section
+    const tocStart = readme.content.indexOf("## Table of Contents");
+    if (tocStart === -1) {
+      return readme.content;
+    }
+    const afterToc = readme.content.indexOf("\n---", tocStart + 1);
+    const tocSection = afterToc === -1
+      ? readme.content.slice(tocStart)
+      : readme.content.slice(tocStart, afterToc);
+
+    return tocSection.trim();
+  }
+
+  // Find the matching chapter
+  const normalized = chapter.replace(/^0+/, "").toLowerCase();
+  const match = docs.find((d) => {
+    const name = d.filename.toLowerCase();
+    // Match by number prefix, partial name, or full filename
+    return (
+      name === chapter.toLowerCase() ||
+      name === `${chapter.toLowerCase()}.md` ||
+      name.startsWith(`${chapter.padStart(2, "0")}-`) ||
+      name.includes(normalized)
+    );
+  });
+
+  if (!match) {
+    const available = docs.map((d) => `- ${d.filename}`).join("\n");
+    return `Chapter "${chapter}" not found.\n\nAvailable chapters:\n${available}`;
+  }
+
+  return `# ${match.filename}\n\n${match.content}`;
+}
+
+export function docsXref(docs: DocEntry[], concept: string): string {
+  const lowerConcept = concept.toLowerCase();
+
+  interface Ref {
+    filename: string;
+    lineNum: number;
+    line: string;
+    isHeading: boolean;
+    isLink: boolean;
+  }
+
+  const refs: Ref[] = [];
+
+  for (const doc of docs) {
+    for (let i = 0; i < doc.lines.length; i++) {
+      const line = doc.lines[i];
+      const lowerLine = line.toLowerCase();
+
+      if (lowerLine.includes(lowerConcept)) {
+        refs.push({
+          filename: doc.filename,
+          lineNum: i + 1,
+          line: line.trim(),
+          isHeading: line.startsWith("#"),
+          isLink: /\[.*\]\(.*\.md.*\)/.test(line),
+        });
+      }
+    }
+  }
+
+  if (refs.length === 0) {
+    return `No cross-references found for "${concept}".`;
+  }
+
+  // Group by file
+  const byFile = new Map<string, Ref[]>();
+  for (const ref of refs) {
+    const existing = byFile.get(ref.filename) ?? [];
+    existing.push(ref);
+    byFile.set(ref.filename, existing);
+  }
+
+  const parts: string[] = [`## Cross-References for "${concept}"\n`];
+  parts.push(`Found references in ${byFile.size} file(s):\n`);
+
+  // Sort: files with headings first (likely primary definition)
+  const sorted = [...byFile.entries()].sort((a, b) => {
+    const aHasHeading = a[1].some((r) => r.isHeading) ? 0 : 1;
+    const bHasHeading = b[1].some((r) => r.isHeading) ? 0 : 1;
+    return aHasHeading - bHasHeading;
+  });
+
+  for (const [filename, fileRefs] of sorted) {
+    const headingRefs = fileRefs.filter((r) => r.isHeading);
+    const linkRefs = fileRefs.filter((r) => r.isLink && !r.isHeading);
+    const otherRefs = fileRefs.filter((r) => !r.isHeading && !r.isLink);
+
+    parts.push(`### ${filename}`);
+
+    if (headingRefs.length > 0) {
+      parts.push("\n**Headings:**");
+      for (const r of headingRefs) {
+        parts.push(`- Line ${r.lineNum}: ${r.line}`);
+      }
+    }
+
+    if (linkRefs.length > 0) {
+      parts.push("\n**Links:**");
+      for (const r of linkRefs.slice(0, 5)) {
+        parts.push(`- Line ${r.lineNum}: ${r.line}`);
+      }
+    }
+
+    if (otherRefs.length > 0) {
+      parts.push(`\n**Mentions:** ${otherRefs.length} occurrence(s)`);
+      for (const r of otherRefs.slice(0, 3)) {
+        parts.push(`- Line ${r.lineNum}: ${r.line.slice(0, 120)}${r.line.length > 120 ? "..." : ""}`);
+      }
+    }
+
+    parts.push("");
+  }
+
+  return parts.join("\n");
+}
+
+export function docsGlossary(docs: DocEntry[], term: string): string {
+  const glossary = docs.find(
+    (d) => d.filename === "15-glossary.md",
+  );
+
+  // If no dedicated glossary file, search all docs for definition-like patterns
+  const lowerTerm = term.toLowerCase();
+  const results: string[] = [];
+
+  if (glossary) {
+    // Search the glossary file first
+    const lines = glossary.lines;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.toLowerCase().includes(lowerTerm)) {
+        // Grab context: heading + body until next heading or blank section
+        let start = i;
+        // Walk back to find the term's heading
+        while (start > 0 && !lines[start].startsWith("#") && !lines[start].startsWith("**")) {
+          start--;
+        }
+        let end = i + 1;
+        // Walk forward to find the end of the definition
+        while (
+          end < lines.length &&
+          !lines[end].startsWith("#") &&
+          !(lines[end].startsWith("**") && end > i + 1)
+        ) {
+          end++;
+        }
+        const block = lines.slice(start, end).join("\n").trim();
+        if (block.length > 0) {
+          results.push(`### From 15-glossary.md (line ${start + 1})\n\n${block}`);
+          break; // Take the first glossary match
+        }
+      }
+    }
+  }
+
+  // Also search other docs for definitions
+  for (const doc of docs) {
+    if (doc.filename === "15-glossary.md") continue;
+
+    for (let i = 0; i < doc.lines.length; i++) {
+      const line = doc.lines[i];
+      const lowerLine = line.toLowerCase();
+
+      // Look for heading-level definitions or bold definitions
+      if (
+        lowerLine.includes(lowerTerm) &&
+        (line.startsWith("#") || line.startsWith("**") || line.startsWith("- **"))
+      ) {
+        const end = Math.min(i + 4, doc.lines.length);
+        const block = doc.lines.slice(i, end).join("\n").trim();
+        results.push(`### From ${doc.filename} (line ${i + 1})\n\n${block}`);
+
+        if (results.length >= 5) break;
+      }
+    }
+
+    if (results.length >= 5) break;
+  }
+
+  if (results.length === 0) {
+    return `No glossary entry found for "${term}". Try docs_search for a broader search.`;
+  }
+
+  return `## Glossary: "${term}"\n\n${results.join("\n\n---\n\n")}`;
+}
+
+export function docsApi(docs: DocEntry[], symbol: string): string {
+  const lowerSymbol = symbol.toLowerCase();
+
+  interface ApiMatch {
+    filename: string;
+    lineNum: number;
+    block: string;
+    isCodeBlock: boolean;
+    score: number;
+  }
+
+  const matches: ApiMatch[] = [];
+
+  for (const doc of docs) {
+    let inCodeBlock = false;
+    let codeBlockStart = -1;
+
+    for (let i = 0; i < doc.lines.length; i++) {
+      const line = doc.lines[i];
+
+      if (line.startsWith("```")) {
+        if (inCodeBlock) {
+          // End of code block -- check if the block contains the symbol
+          const blockContent = doc.lines.slice(codeBlockStart, i + 1).join("\n");
+          if (blockContent.toLowerCase().includes(lowerSymbol)) {
+            // Include heading context before the code block
+            let headingLine = codeBlockStart;
+            while (headingLine > 0 && !doc.lines[headingLine].startsWith("#")) {
+              headingLine--;
+            }
+            const contextStart = Math.max(headingLine, codeBlockStart - 3);
+            const fullBlock = doc.lines.slice(contextStart, i + 1).join("\n");
+            matches.push({
+              filename: doc.filename,
+              lineNum: codeBlockStart + 1,
+              block: fullBlock,
+              isCodeBlock: true,
+              score: 3,
+            });
+          }
+          inCodeBlock = false;
+        } else {
+          inCodeBlock = true;
+          codeBlockStart = i;
+        }
+        continue;
+      }
+
+      if (!inCodeBlock && line.toLowerCase().includes(lowerSymbol)) {
+        // Check for struct/type/trait/fn definitions or heading-level API docs
+        const isApiLine =
+          line.startsWith("#") ||
+          line.includes("pub struct") ||
+          line.includes("pub enum") ||
+          line.includes("pub trait") ||
+          line.includes("pub fn") ||
+          line.includes("pub type") ||
+          line.includes("pub const") ||
+          line.startsWith("| `") ||
+          line.startsWith("- `");
+
+        if (isApiLine) {
+          const start = Math.max(0, i - 1);
+          const end = Math.min(doc.lines.length, i + 6);
+          const block = doc.lines.slice(start, end).join("\n");
+          matches.push({
+            filename: doc.filename,
+            lineNum: i + 1,
+            block,
+            isCodeBlock: false,
+            score: line.startsWith("#") ? 2 : 1,
+          });
+        }
+      }
+    }
+  }
+
+  if (matches.length === 0) {
+    return `No API documentation found for "${symbol}". Try docs_search for a broader search.`;
+  }
+
+  matches.sort((a, b) => b.score - a.score);
+  const top = matches.slice(0, 8);
+
+  const parts: string[] = [`## API Documentation for "${symbol}"\n`];
+  parts.push(`Found ${matches.length} match(es), showing top ${top.length}:\n`);
+
+  for (const m of top) {
+    parts.push(`### ${m.filename} (line ${m.lineNum})\n`);
+    parts.push(m.block);
+    parts.push("\n");
+  }
+
+  return parts.join("\n");
+}
+
+export function docsHowto(docs: DocEntry[], task: string): string {
+  const lowerTask = task.toLowerCase();
+  const taskTerms = lowerTask.split(/\s+/).filter(Boolean);
+
+  interface HowtoMatch {
+    key: string;
+    entry: { chapters: string[]; description: string };
+    score: number;
+  }
+
+  const matches: HowtoMatch[] = [];
+
+  for (const [key, entry] of Object.entries(HOWTO_MAP)) {
+    const lowerKey = key.toLowerCase();
+    const lowerDesc = entry.description.toLowerCase();
+    const combined = `${lowerKey} ${lowerDesc}`;
+
+    let score = 0;
+    if (combined.includes(lowerTask)) {
+      score = 3;
+    } else {
+      const matchedTerms = taskTerms.filter((t) => combined.includes(t));
+      score = matchedTerms.length;
+    }
+
+    if (score > 0) {
+      matches.push({ key, entry, score });
+    }
+  }
+
+  matches.sort((a, b) => b.score - a.score);
+
+  if (matches.length === 0) {
+    // Fall back to search
+    const searchResult = docsSearch(docs, task, 5);
+    return `## How To: "${task}"\n\nNo specific guide found. Here are search results:\n\n${searchResult}`;
+  }
+
+  const parts: string[] = [`## How To: "${task}"\n`];
+  parts.push(`Found ${matches.length} relevant guide(s):\n`);
+
+  for (const m of matches.slice(0, 5)) {
+    parts.push(`### ${m.key}`);
+    parts.push(`${m.entry.description}\n`);
+    parts.push("**Recommended reading:**");
+    for (const ch of m.entry.chapters) {
+      const doc = docs.find((d) => d.filename === ch);
+      const title = doc
+        ? (doc.lines.find((l) => l.startsWith("# "))?.replace(/^#\s+/, "") ?? ch)
+        : ch;
+      parts.push(`- [${title}](${ch})`);
+    }
+    parts.push("");
+  }
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+
+const server = new Server(
+  {
+    name: "rvm-docs",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  },
+);
+
+// List tools
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "docs_search",
+      description:
+        "Search across all RVM documentation files by keyword or phrase. Returns matching paragraphs with file paths and line numbers.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          query: {
+            type: "string",
+            description: "The search query (keyword or phrase)",
+          },
+          max_results: {
+            type: "number",
+            description: "Maximum number of results to return (default: 10)",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "docs_navigate",
+      description:
+        "Get the table of contents or a specific chapter's content. If chapter is omitted, returns the full TOC.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          chapter: {
+            type: "string",
+            description:
+              'Chapter identifier: number (e.g. "05"), partial name (e.g. "security"), or full filename (e.g. "10-security.md")',
+          },
+        },
+      },
+    },
+    {
+      name: "docs_xref",
+      description:
+        "Find all cross-references for a concept across all documentation files. Returns the primary chapter and all files that reference it.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          concept: {
+            type: "string",
+            description: "The concept to find cross-references for (e.g. \"witness\", \"partition\", \"capability\")",
+          },
+        },
+        required: ["concept"],
+      },
+    },
+    {
+      name: "docs_glossary",
+      description:
+        "Look up a term in the RVM glossary. Returns the definition and cross-references to related documentation.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          term: {
+            type: "string",
+            description: "The glossary term to look up (e.g. \"coherence domain\", \"proof gate\")",
+          },
+        },
+        required: ["term"],
+      },
+    },
+    {
+      name: "docs_api",
+      description:
+        "Find documentation for an RVM type, trait, function, or constant. Searches crate-reference and detailed chapters for API signatures and code examples.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          symbol: {
+            type: "string",
+            description: "The API symbol to search for (e.g. \"CapToken\", \"WitnessRecord\", \"ProofLevel\")",
+          },
+        },
+        required: ["symbol"],
+      },
+    },
+    {
+      name: "docs_howto",
+      description:
+        'Task-oriented documentation search. Describe what you want to do and get a recommended reading path. Example: "boot qemu", "create partition", "run wasm agent".',
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          task: {
+            type: "string",
+            description: "What you want to accomplish (e.g. \"build rvm\", \"use capabilities\", \"benchmark performance\")",
+          },
+        },
+        required: ["task"],
+      },
+    },
+  ],
+}));
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  // Ensure docs are loaded
+  if (docCache.length === 0) {
+    docCache = loadDocs();
+  }
+
+  switch (name) {
+    case "docs_search": {
+      const query = (args as { query: string; max_results?: number }).query;
+      const maxResults = (args as { max_results?: number }).max_results ?? 10;
+      return {
+        content: [{ type: "text" as const, text: docsSearch(docCache, query, maxResults) }],
+      };
+    }
+
+    case "docs_navigate": {
+      const chapter = (args as { chapter?: string }).chapter;
+      return {
+        content: [{ type: "text" as const, text: docsNavigate(docCache, chapter) }],
+      };
+    }
+
+    case "docs_xref": {
+      const concept = (args as { concept: string }).concept;
+      return {
+        content: [{ type: "text" as const, text: docsXref(docCache, concept) }],
+      };
+    }
+
+    case "docs_glossary": {
+      const term = (args as { term: string }).term;
+      return {
+        content: [{ type: "text" as const, text: docsGlossary(docCache, term) }],
+      };
+    }
+
+    case "docs_api": {
+      const symbol = (args as { symbol: string }).symbol;
+      return {
+        content: [{ type: "text" as const, text: docsApi(docCache, symbol) }],
+      };
+    }
+
+    case "docs_howto": {
+      const task = (args as { task: string }).task;
+      return {
+        content: [{ type: "text" as const, text: docsHowto(docCache, task) }],
+      };
+    }
+
+    default:
+      return {
+        content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+        isError: true,
+      };
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Start server (only when run directly, not when imported by CLI)
+// ---------------------------------------------------------------------------
+
+async function main() {
+  docCache = loadDocs();
+
+  const fileCount = docCache.length;
+  const totalLines = docCache.reduce((sum, d) => sum + d.lines.length, 0);
+
+  console.error(
+    `rvm-docs MCP server started. Loaded ${fileCount} doc(s), ${totalLines} lines.`,
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// Only start the MCP server when this module is the entry point
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith("/index.js") ||
+   process.argv[1].endsWith("\\index.js"));
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/userguide/mcp/tsconfig.json
+++ b/userguide/mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Complete 17-chapter user guide (7,087 lines) covering all 13 RVM crates
- MCP documentation server with 6 tools for AI-assisted search/navigation
- Standalone CLI with colored output and shorthand aliases
- README updated with collapsed tutorial and MCP capabilities sections

Closes #2, closes #3

## What's Included

### User Guide (`userguide/`)
17 interconnected chapters from quick start through exotic capabilities:
- Core concepts, architecture, crate reference
- Deep dives: capabilities, proofs, witnesses, security, memory, WASM
- Performance benchmarks, bare-metal deployment, troubleshooting
- 60+ term glossary and comprehensive cross-reference index

### MCP Tools (`userguide/mcp/`)
- `docs_search` — Full-text search across all docs
- `docs_navigate` — TOC browsing and chapter reading
- `docs_xref` — Cross-reference finder
- `docs_glossary` — Term lookup
- `docs_api` — API symbol documentation
- `docs_howto` — Task-oriented guide

### README Updates
- Collapsed tutorial section with quick start commands
- Full user guide table of contents
- MCP tools section with installation and usage

## Test plan

- [x] `cargo test --workspace --lib` — 797 tests pass, 0 failures
- [x] MCP CLI `search` — returns ranked results across 17 docs
- [x] MCP CLI `nav` — displays TOC and individual chapters
- [x] MCP CLI `glossary` — looks up terms with cross-references
- [x] MCP CLI `howto` — returns task-oriented reading paths
- [x] MCP CLI `api` — finds API symbol documentation
- [x] MCP CLI `xref` — finds concept cross-references
- [x] TypeScript builds cleanly (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)