### PR TITLE
docs: fix stale crate and test counts across 4 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Capability-based isolation, proof-gated execution, and witness attestation on mi
 
 | # | Criterion | Target |
 |---|-----------|--------|
-| 1 | All 13 crates compile with `#![no_std]` and `#![forbid(unsafe_code)]` | Enforced |
+| 1 | All 14 crates compile with `#![no_std]` and `#![forbid(unsafe_code)]` | Enforced |
 | 2 | Cold boot to first witness | < 250ms on Appliance hardware |
 | 3 | Hot partition switch | < 10 microseconds |
 | 4 | Witness record is exactly 64 bytes, cache-line aligned | Compile-time asserted |
@@ -612,7 +612,7 @@ The [`userguide/`](userguide/) directory contains 17 chapters covering every sub
 | [01 Quick Start](userguide/01-quickstart.md) | Build, test, and boot in 5 minutes |
 | [02 Core Concepts](userguide/02-core-concepts.md) | Partitions, capabilities, witnesses, proofs, coherence |
 | [03 Architecture](userguide/03-architecture.md) | Layer diagram, data flow, boot sequence, feature flags |
-| [04 Crate Reference](userguide/04-crate-reference.md) | All 13 crates with types, APIs, and dependencies |
+| [04 Crate Reference](userguide/04-crate-reference.md) | All 14 crates with types, APIs, and dependencies |
 | [05 Capabilities & Proofs](userguide/05-capabilities-proofs.md) | 7 rights, delegation trees, 3 proof tiers, TEE |
 | [06 Witness & Audit](userguide/06-witness-audit.md) | 64-byte records, hash chains, signing, querying |
 | [07 Partitions & Scheduling](userguide/07-partitions-scheduling.md) | Lifecycle, IPC, split/merge, 2-signal scheduler |

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,4 +33,4 @@ cargo test -p rvm-tests
 
 ## Workspace Dependencies
 
-All 13 RVM crates (rvm-types through rvm-kernel).
+All 14 RVM crates (rvm-types through rvm-kernel).

--- a/userguide/15-glossary.md
+++ b/userguide/15-glossary.md
@@ -213,7 +213,7 @@ the root partition delegating subsets of its authority. See [Bare-Metal
 Deployment](12-bare-metal.md).
 
 **RVM** (RuVix Virtual Machine) -- The coherence-native bare-metal
-microhypervisor. 13 crates, 648 tests, 11 benchmarks.
+microhypervisor. 14 crates, 945 tests, 11 benchmarks.
 
 **RuVector** -- An optional library providing production-grade graph
 algorithms: MinCut, sparsification, spectral solvers, and IIT-inspired

--- a/userguide/cross-reference.md
+++ b/userguide/cross-reference.md
@@ -150,7 +150,7 @@ defined and the chapter that explains their usage.
 |---|---|
 | Build and run RVM for the first time | [01-quickstart.md](01-quickstart.md) |
 | Understand RVM's key ideas before diving into code | [02-core-concepts.md](02-core-concepts.md) |
-| See how the 13 crates fit together | [03-architecture.md](03-architecture.md) |
+| See how the 14 crates fit together | [03-architecture.md](03-architecture.md) |
 | Find the API for a specific crate | [04-crate-reference.md](04-crate-reference.md) |
 | Add capability checks to an operation | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
 | Submit and verify a proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |


### PR DESCRIPTION
## Summary
Fix stale numeric references that were not updated when the crate and test counts grew:

| File | Old | New |
|------|-----|-----|
| `userguide/15-glossary.md` | "13 crates, 648 tests" | "14 crates, 945 tests" |
| `README.md` (success criteria) | "All 13 crates" | "All 14 crates" |
| `README.md` (quick links) | "All 13 crates" | "All 14 crates" |
| `userguide/cross-reference.md` | "13 crates" | "14 crates" |

## Test plan
- [x] Grepped for all remaining "13 crates" references — none found in checked files
- [x] Verified project has 14 crates and 945 tests per README badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)