### PR TITLE
fix(security): RUSTSEC-2024-0436 audit config + 6 npm CVEs in mcp docs server

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,18 @@
+# cargo-audit configuration for the RVM workspace.
+# See: https://github.com/rustsec/rustsec/tree/main/cargo-audit
+
+[advisories]
+# RUSTSEC-2024-0436: `paste` crate is unmaintained.
+# This is a *transitive* warning from a deeply nested optional dependency:
+#   rvm-gpu (optional cuda-rust-wasm feature) -> wgpu -> wgpu-hal -> metal -> paste
+# The workspace itself does not depend on `paste` and the GPU feature is
+# disabled by default (no `webgpu`/`metal` feature flag in any default build).
+# The `paste` crate has no known security vulnerability -- only maintenance
+# concerns. Suppressed until cuda-rust-wasm or wgpu ships a compatible release
+# that removes the metal -> paste dependency.
+ignore = ["RUSTSEC-2024-0436"]
+informational_warnings = ["unmaintained", "unsound", "notice"]
+
+[output]
+show_tree = true
+quiet = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvm-benches"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "rvm-cap",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-boot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-hal",
  "rvm-memory",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-cap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-types",
  "spin",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-coherence"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-partition",
  "rvm-sched",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-gpu"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cuda-rust-wasm",
  "rvm-types",
@@ -1823,14 +1823,14 @@ dependencies = [
 
 [[package]]
 name = "rvm-hal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-types",
 ]
 
 [[package]]
 name = "rvm-kernel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-boot",
  "rvm-cap",
@@ -1849,14 +1849,14 @@ dependencies = [
 
 [[package]]
 name = "rvm-memory"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-types",
 ]
 
 [[package]]
 name = "rvm-partition"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-cap",
  "rvm-types",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-proof"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ed25519-dalek",
  "hmac",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-sched"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-partition",
  "rvm-types",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-security"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-types",
  "rvm-witness",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-tests"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-boot",
  "rvm-cap",
@@ -1920,14 +1920,14 @@ dependencies = [
 
 [[package]]
 name = "rvm-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "rvm-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rvm-cap",
  "rvm-partition",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "rvm-witness"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hmac",
  "rvm-types",

--- a/userguide/mcp/package-lock.json
+++ b/userguide/mcp/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -424,12 +424,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -448,9 +448,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -636,9 +636,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Security & Quality Fixes

### Rust — cargo-audit

**RUSTSEC-2024-0436** (`paste` 1.0.15 — unmaintained, warning-level)

Added `.cargo/audit.toml` to document and suppress this advisory with full justification. The `paste` crate has **no CVE score** (unmaintained warning only). It enters the dependency graph only through the optional `rvm-gpu` webgpu/metal feature:

```
rvm-gpu (cuda-rust-wasm, off by default)
  → wgpu → wgpu-hal → metal (macOS only) → paste
```

No fix is available without an upstream `cuda-rust-wasm` or `wgpu` release removing the `metal → paste` dependency. The ignore entry in `.cargo/audit.toml` includes a full prose justification so future maintainers understand the rationale.

**Rust gate results:**
- `cargo audit` — clean (exit 0, 0 vulnerabilities, warning suppressed with justification)
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — 882 tests, 0 failures

---

### Node / npm — `userguide/mcp/` docs MCP server

`npm audit fix` resolved **6 CVEs** in transitive dependencies of `@modelcontextprotocol/sdk`:

| Package | Severity | Advisory | Fix |
|---|---|---|---|
| `fast-uri` <= 3.1.1 | HIGH | GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc — path traversal + host confusion via percent-encoded segments | bumped to 3.1.2 |
| `hono` <= 4.12.17 | MODERATE | Multiple: cookie injection, path traversal in toSSG(), middleware bypass, JWT NumericDate, cache leakage, bodyLimit bypass, JSX HTML injection | bumped to 4.12.22 |
| `@hono/node-server` < 1.19.13 | MODERATE | GHSA-92pp-h63x-v22m — middleware bypass via repeated slashes in serveStatic | bumped to 1.19.14 |
| `ip-address` <= 10.1.0 | MODERATE | GHSA-v2v4-37r5-5v8g — XSS in Address6 HTML-emitting methods | bumped to 10.2.0 |
| `express-rate-limit` 8.0.1-8.5.0 | MODERATE | Vulnerable ip-address transitive dep | bumped to 8.5.2 |
| `qs` 6.11.1-6.15.1 | MODERATE | GHSA-q8mj-m7cp-5q26 — DoS via null entries in comma-format arrays | bumped to 6.15.2 |

`npm audit` now reports **0 vulnerabilities**.

---

## Test plan

- [x] `cargo audit` — clean (0 vulnerabilities, exit 0)
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean (exit 0)
- [x] `cargo test --workspace` — 882 tests, 0 failures
- [x] `npm audit` in `userguide/mcp/` — 0 vulnerabilities