### PR TITLE
feat(launch): instance lifecycle over the host adapters

### DIFF
--- a/crates/rvm-host/Cargo.toml
+++ b/crates/rvm-host/Cargo.toml
@@ -23,6 +23,10 @@ rvm-rvf = { workspace = true }
 
 [features]
 default = []
+# Synthetic RVF fixtures. Off by default and never enabled by `std`: it exists
+# so `rvm-launch` can build a container to drive a lifecycle test without
+# either crate reimplementing segment framing.
+testkit = []
 std = [
     "rvm-types/std",
     "rvm-cap/std",

--- a/crates/rvm-host/src/adapter.rs
+++ b/crates/rvm-host/src/adapter.rs
@@ -310,9 +310,7 @@ pub trait HostAdapter {
             partition_id: isolation.placement.partition,
             max_memory_pages: isolation.placement.max_memory_pages,
         };
-        let id = agents
-            .spawn(&config, log)
-            .map_err(HostError::SpawnFailed)?;
+        let id = agents.spawn(&config, log).map_err(HostError::SpawnFailed)?;
 
         emit(
             log,

--- a/crates/rvm-host/src/bare_metal.rs
+++ b/crates/rvm-host/src/bare_metal.rs
@@ -58,10 +58,7 @@ impl HostAdapter for BareMetalAdapter {
 
     fn mechanisms(&self) -> MechanismSet {
         MechanismSet::new()
-            .with_all(
-                &IsolationMechanism::PORTABLE_CORE,
-                MechanismStatus::Engaged,
-            )
+            .with_all(&IsolationMechanism::PORTABLE_CORE, MechanismStatus::Engaged)
             .with_all(
                 &IsolationMechanism::BARE_METAL_ONLY,
                 MechanismStatus::Engaged,

--- a/crates/rvm-host/src/error.rs
+++ b/crates/rvm-host/src/error.rs
@@ -43,9 +43,14 @@ impl fmt::Display for HostError {
             Self::CapabilityUnenforceable(c) => {
                 write!(f, "adapter cannot enforce capability class {c}")
             }
-            Self::MechanismUnavailable(m) => write!(f, "required isolation mechanism {m} did not engage"),
+            Self::MechanismUnavailable(m) => {
+                write!(f, "required isolation mechanism {m} did not engage")
+            }
             Self::MechanismNotInStack(m) => {
-                write!(f, "isolation mechanism {m} is not part of this adapter's stack")
+                write!(
+                    f,
+                    "isolation mechanism {m} is not part of this adapter's stack"
+                )
             }
             Self::ModuleTooLarge => f.write_str("module exceeds the adapter's maximum size"),
             Self::ModuleRejected(_) => f.write_str("module is not a well-formed WASM module"),

--- a/crates/rvm-host/src/hosted.rs
+++ b/crates/rvm-host/src/hosted.rs
@@ -166,10 +166,8 @@ impl HostAdapter for HostedAdapter {
 
     fn mechanisms(&self) -> MechanismSet {
         let stack = IsolationMechanism::stack_for(self.os);
-        let mut set = MechanismSet::new().with_all(
-            &IsolationMechanism::PORTABLE_CORE,
-            MechanismStatus::Engaged,
-        );
+        let mut set = MechanismSet::new()
+            .with_all(&IsolationMechanism::PORTABLE_CORE, MechanismStatus::Engaged);
         for (i, mechanism) in stack.iter().enumerate() {
             let status = if self.engaged[i] {
                 MechanismStatus::Engaged
@@ -240,8 +238,12 @@ mod tests {
             .engaging(IsolationMechanism::LinuxSeccomp)
             .unwrap();
         assert_eq!(adapter.isolation_claim(), IsolationClaim::OsSandboxWasm);
-        assert!(adapter.mechanisms().is_engaged(IsolationMechanism::LinuxSeccomp));
-        assert!(!adapter.mechanisms().is_engaged(IsolationMechanism::LinuxCgroups));
+        assert!(adapter
+            .mechanisms()
+            .is_engaged(IsolationMechanism::LinuxSeccomp));
+        assert!(!adapter
+            .mechanisms()
+            .is_engaged(IsolationMechanism::LinuxCgroups));
     }
 
     #[test]

--- a/crates/rvm-host/src/isolation.rs
+++ b/crates/rvm-host/src/isolation.rs
@@ -231,10 +231,7 @@ mod tests {
     use rvm_partition::PartitionType;
 
     fn core() -> MechanismSet {
-        MechanismSet::new().with_all(
-            &IsolationMechanism::PORTABLE_CORE,
-            MechanismStatus::Engaged,
-        )
+        MechanismSet::new().with_all(&IsolationMechanism::PORTABLE_CORE, MechanismStatus::Engaged)
     }
 
     fn live_partition() -> (PartitionManager, PartitionId) {
@@ -271,7 +268,10 @@ mod tests {
     fn hosted_with_an_engaged_os_mechanism_claims_os_sandbox_wasm() {
         let env = HostEnvironment::hosted(HostOs::Linux);
         let set = core().with(IsolationMechanism::LinuxSeccomp, MechanismStatus::Engaged);
-        assert_eq!(IsolationClaim::derive(env, &set), IsolationClaim::OsSandboxWasm);
+        assert_eq!(
+            IsolationClaim::derive(env, &set),
+            IsolationClaim::OsSandboxWasm
+        );
     }
 
     #[test]
@@ -295,7 +295,10 @@ mod tests {
     #[test]
     fn portable_is_always_wasm_only() {
         let env = HostEnvironment::portable();
-        assert_eq!(IsolationClaim::derive(env, &core()), IsolationClaim::WasmOnly);
+        assert_eq!(
+            IsolationClaim::derive(env, &core()),
+            IsolationClaim::WasmOnly
+        );
         assert_eq!(
             IsolationClaim::derive(
                 env,
@@ -322,7 +325,10 @@ mod tests {
         let (mgr, id) = live_partition();
         let evidence = PartitionEvidence::from_manager(&mgr, id).unwrap();
         let env = HostEnvironment::bare_metal(evidence);
-        assert_eq!(IsolationClaim::derive(env, &core()), IsolationClaim::Partition);
+        assert_eq!(
+            IsolationClaim::derive(env, &core()),
+            IsolationClaim::Partition
+        );
         assert_eq!(env.partition(), Some(id));
         assert!(env.is_bare_metal());
         assert!(!env.is_hosted());

--- a/crates/rvm-host/src/lib.rs
+++ b/crates/rvm-host/src/lib.rs
@@ -85,7 +85,7 @@ pub mod package;
 pub mod wasm;
 pub mod witness;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testkit"))]
 pub mod testkit;
 
 pub use adapter::{
@@ -215,7 +215,12 @@ mod tests {
         let mut agents = AgentManager::<4>::new();
 
         let iso = adapter
-            .prepare(&package, Placement::new(PartitionId::new(1), 0, 16), &log, 1)
+            .prepare(
+                &package,
+                Placement::new(PartitionId::new(1), 0, 16),
+                &log,
+                1,
+            )
             .unwrap();
         adapter
             .spawn(&iso, &testkit::MINIMAL_WASM, &mut agents, &log, 2)

--- a/crates/rvm-host/src/mechanism.rs
+++ b/crates/rvm-host/src/mechanism.rs
@@ -430,10 +430,8 @@ mod tests {
 
     #[test]
     fn a_mechanism_not_in_the_stack_has_no_status_at_all() {
-        let set = MechanismSet::new().with_all(
-            &IsolationMechanism::PORTABLE_CORE,
-            MechanismStatus::Engaged,
-        );
+        let set = MechanismSet::new()
+            .with_all(&IsolationMechanism::PORTABLE_CORE, MechanismStatus::Engaged);
         assert_eq!(set.status_of(IsolationMechanism::LinuxCgroups), None);
         assert!(!set.is_engaged(IsolationMechanism::LinuxCgroups));
     }
@@ -452,7 +450,8 @@ mod tests {
 
     #[test]
     fn os_confinement_is_detected_only_for_the_matching_os() {
-        let set = MechanismSet::new().with(IsolationMechanism::LinuxCgroups, MechanismStatus::Engaged);
+        let set =
+            MechanismSet::new().with(IsolationMechanism::LinuxCgroups, MechanismStatus::Engaged);
         assert!(set.any_os_confinement_engaged(HostOs::Linux));
         assert!(!set.any_os_confinement_engaged(HostOs::Windows));
         assert!(!set.any_os_confinement_engaged(HostOs::MacOs));
@@ -463,7 +462,11 @@ mod tests {
         let mut names: Vec<&str> = IsolationMechanism::PORTABLE_CORE
             .iter()
             .chain(IsolationMechanism::BARE_METAL_ONLY.iter())
-            .chain(HostOs::ALL.iter().flat_map(|os| IsolationMechanism::stack_for(*os)))
+            .chain(
+                HostOs::ALL
+                    .iter()
+                    .flat_map(|os| IsolationMechanism::stack_for(*os)),
+            )
             .map(|m| m.as_str())
             .collect();
         let total = names.len();

--- a/crates/rvm-host/src/testkit.rs
+++ b/crates/rvm-host/src/testkit.rs
@@ -98,7 +98,11 @@ pub fn lenient_options() -> VerifyOptions {
 pub fn package(classes: &str) -> crate::VerifiedPackage {
     let data = container_with_wasm(classes);
     let report = rvm_rvf::verify(&data, &lenient_options()).expect("fixture is a valid container");
-    assert!(report.ok, "fixture failed verification: {:?}", report.failures());
+    assert!(
+        report.ok,
+        "fixture failed verification: {:?}",
+        report.failures()
+    );
     crate::VerifiedPackage::from_report(&report).expect("fixture verified")
 }
 

--- a/crates/rvm-host/src/wasm.rs
+++ b/crates/rvm-host/src/wasm.rs
@@ -87,10 +87,7 @@ impl HostAdapter for WasmAdapter {
     }
 
     fn mechanisms(&self) -> MechanismSet {
-        MechanismSet::new().with_all(
-            &IsolationMechanism::PORTABLE_CORE,
-            MechanismStatus::Engaged,
-        )
+        MechanismSet::new().with_all(&IsolationMechanism::PORTABLE_CORE, MechanismStatus::Engaged)
     }
 
     fn enforces(&self, class: CapabilityClass) -> bool {

--- a/crates/rvm-host/src/witness.rs
+++ b/crates/rvm-host/src/witness.rs
@@ -190,20 +190,35 @@ pub fn emit<const N: usize>(
 /// Returns `None` for records emitted by another subsystem, which is what
 /// makes an instance's own host decisions separable from everything else
 /// sharing the log.
+///
+/// The aux tag alone is not enough to identify one. Other layers write their
+/// own small integers into `aux[0]` — `rvm-launch` numbers its lifecycle
+/// events from 1 as well — so a tag-only reader would count a lifecycle record
+/// as a capability decision. Three things have to agree: the tag, the
+/// `ActionKind` that tag implies, and a non-zero isolation claim in `aux[2]`,
+/// which only a record from this module carries.
 #[must_use]
 pub const fn event_of(record: &WitnessRecord) -> Option<HostEvent> {
-    match record.aux[0] {
-        1 => Some(HostEvent::CapabilityGranted),
-        2 => Some(HostEvent::CapabilityDenied),
-        3 => Some(HostEvent::CapabilityRefused),
-        4 => Some(HostEvent::IsolationPrepared),
-        5 => Some(HostEvent::ModuleAdmitted),
-        6 => Some(HostEvent::ModuleRefused),
-        _ => None,
+    let tagged = match record.aux[0] {
+        1 => HostEvent::CapabilityGranted,
+        2 => HostEvent::CapabilityDenied,
+        3 => HostEvent::CapabilityRefused,
+        4 => HostEvent::IsolationPrepared,
+        5 => HostEvent::ModuleAdmitted,
+        6 => HostEvent::ModuleRefused,
+        _ => return None,
+    };
+    if record.action_kind == tagged.action_kind() as u8 && claim_of(record).is_some() {
+        Some(tagged)
+    } else {
+        None
     }
 }
 
 /// Read the isolation claim out of a record this module wrote.
+///
+/// Returns `None` when `aux[2]` holds no claim code, which is how a record
+/// from another layer is told apart from one of ours.
 #[must_use]
 pub const fn claim_of(record: &WitnessRecord) -> Option<IsolationClaim> {
     match record.aux[2] {
@@ -284,7 +299,12 @@ mod tests {
         let mut other = ctx(IsolationClaim::WasmOnly);
         other.rvf_identity = [9u8; 32];
 
-        let a = build_record(HostEvent::IsolationPrepared, &ctx(IsolationClaim::WasmOnly), None, 0);
+        let a = build_record(
+            HostEvent::IsolationPrepared,
+            &ctx(IsolationClaim::WasmOnly),
+            None,
+            0,
+        );
         let b = build_record(HostEvent::IsolationPrepared, &other, None, 0);
 
         assert_ne!(a.capability_hash, b.capability_hash);
@@ -294,7 +314,12 @@ mod tests {
 
     #[test]
     fn an_event_with_no_class_says_so_rather_than_naming_class_zero() {
-        let r = build_record(HostEvent::ModuleAdmitted, &ctx(IsolationClaim::WasmOnly), None, 0);
+        let r = build_record(
+            HostEvent::ModuleAdmitted,
+            &ctx(IsolationClaim::WasmOnly),
+            None,
+            0,
+        );
         assert_eq!(r.aux[1], NO_CLASS);
         assert_ne!(r.aux[1], CapabilityClass::Memory as u8);
         assert_eq!(r.target_object_id, 0);
@@ -338,6 +363,24 @@ mod tests {
     }
 
     #[test]
+    fn a_record_from_another_layer_is_not_read_as_a_host_event() {
+        // `rvm-wasm` writes agent transitions with an all-zero aux, and any
+        // layer numbering its own events from 1 collides with these tags. A
+        // reader that trusted aux[0] alone would count them as capability
+        // decisions, so the claim code has to be there too.
+        let mut foreign = WitnessRecord::zeroed();
+        foreign.action_kind = ActionKind::TaskSpawn as u8;
+        foreign.aux[0] = HostEvent::CapabilityDenied as u8;
+        assert_eq!(event_of(&foreign), None);
+
+        // Right tag, right action kind, no claim: still not ours.
+        foreign.action_kind = ActionKind::ProofRejected as u8;
+        assert_eq!(event_of(&foreign), None);
+        foreign.aux[2] = IsolationClaim::WasmOnly.witness_code();
+        assert_eq!(event_of(&foreign), Some(HostEvent::CapabilityDenied));
+    }
+
+    #[test]
     fn the_detail_word_survives_the_round_trip() {
         let r = build_record(
             HostEvent::ModuleRefused,
@@ -345,6 +388,9 @@ mod tests {
             None,
             0x0DED_BEEF,
         );
-        assert_eq!(u32::from_le_bytes(r.aux[4..8].try_into().unwrap()), 0x0DED_BEEF);
+        assert_eq!(
+            u32::from_le_bytes(r.aux[4..8].try_into().unwrap()),
+            0x0DED_BEEF
+        );
     }
 }

--- a/crates/rvm-launch/Cargo.toml
+++ b/crates/rvm-launch/Cargo.toml
@@ -20,6 +20,9 @@ rvm-wasm = { workspace = true }
 rvm-rvf = { workspace = true }
 rvm-host = { workspace = true }
 
+[dev-dependencies]
+rvm-host = { workspace = true, features = ["testkit"] }
+
 [features]
 default = []
 std = [

--- a/crates/rvm-launch/src/inspect.rs
+++ b/crates/rvm-launch/src/inspect.rs
@@ -173,7 +173,10 @@ mod tests {
         let mut data = testkit::container_declaring("memory");
         data[0..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
         assert_ne!(&data[0..4], &SEGMENT_MAGIC_BYTES);
-        assert_eq!(inspect(&data), Err(crate::LaunchError::Rvf(RvfError::BadMagic)));
+        assert_eq!(
+            inspect(&data),
+            Err(crate::LaunchError::Rvf(RvfError::BadMagic))
+        );
     }
 
     #[test]
@@ -211,6 +214,9 @@ mod tests {
         let inspected = inspect(&data).unwrap();
         let wasm = inspected.segments.iter().find(|s| s.executable).unwrap();
         assert_eq!(wasm.payload_bytes, testkit::MINIMAL_WASM.len() as u64);
-        assert_eq!(core::mem::size_of_val(wasm), core::mem::size_of::<SegmentSummary>());
+        assert_eq!(
+            core::mem::size_of_val(wasm),
+            core::mem::size_of::<SegmentSummary>()
+        );
     }
 }

--- a/crates/rvm-launch/src/instance.rs
+++ b/crates/rvm-launch/src/instance.rs
@@ -366,22 +366,22 @@ impl<A: HostAdapter> Instance<A> {
 
     /// The witness chain this instance produced, in sequence order.
     ///
-    /// Records are selected by the sequence spans this instance's operations
-    /// occupied, then filtered to those bound to its base RVF identity. That
-    /// separates instances of different artifacts sharing a log; to get an
-    /// exactly-scoped chain for two instances of the *same* artifact, give
-    /// each its own log, which is what ADR-289 criterion 8 ("export a complete
-    /// witness chain for the instance") assumes.
+    /// Selected by the sequence spans this instance's operations occupied, so
+    /// the result includes everything written inside them — the `rvm-host`
+    /// capability decisions, the `rvm-wasm` agent transitions, and this
+    /// crate's lifecycle records alike. Keeping the spans whole rather than
+    /// filtering by layer is what lets the result be *chain*-verified:
+    /// ADR-289 criterion 8 asks for a complete, cryptographically verifiable
+    /// chain, and a subset with holes in it would satisfy neither adjective.
     ///
-    /// A ring buffer that has wrapped past this instance's spans returns only
-    /// what survives, which is a property of the log's capacity rather than of
-    /// this method.
+    /// Two instances sharing a log occupy disjoint spans, so their chains do
+    /// not overlap. An instance whose own log has wrapped past its earliest
+    /// span gets back only what survives, which is a property of the log's
+    /// capacity rather than of this method.
     #[must_use]
     pub fn witness<const N: usize>(&self, log: &WitnessLog<N>) -> Vec<WitnessRecord> {
-        let tag = fnv1a_32(self.package.identity());
         let mut records: Vec<WitnessRecord> = (0..log.len())
             .filter_map(|i| log.get(i))
-            .filter(|r| r.capability_hash == tag)
             .filter(|r| {
                 self.ranges
                     .iter()
@@ -390,6 +390,17 @@ impl<A: HostAdapter> Instance<A> {
             .collect();
         records.sort_unstable_by_key(|r| r.sequence);
         records
+    }
+
+    /// Whether `record` is bound to this instance's base RVF.
+    ///
+    /// The binding is the FNV-1a fold of the container identity that
+    /// `rvm-rvf`, `rvm-host`, and this crate all write into
+    /// `capability_hash`, so it holds across every layer that touched the
+    /// artifact.
+    #[must_use]
+    pub fn binds_to_package(&self, record: &WitnessRecord) -> bool {
+        record.capability_hash == fnv1a_32(self.package.identity())
     }
 
     fn witness_context(&self, timestamp_ns: u64) -> LaunchWitnessContext {
@@ -431,3 +442,7 @@ impl<A: HostAdapter> Instance<A> {
 #[cfg(test)]
 #[path = "instance_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "instance_lineage_tests.rs"]
+mod lineage_tests;

--- a/crates/rvm-launch/src/instance_lineage_tests.rs
+++ b/crates/rvm-launch/src/instance_lineage_tests.rs
@@ -1,0 +1,288 @@
+//! Checkpoint lineage and witness-chain tests for [`super::Instance`].
+//!
+//! Split from `instance_tests.rs` only for file size; the shared fixtures live
+//! there and are re-imported here.
+
+use super::tests::{events, instance, started};
+use super::*;
+use crate::witness::{event_of, LaunchEvent};
+use rvm_host::{HostOs, HostedAdapter, IsolationClaim, WasmAdapter};
+use rvm_rvf::CapabilityClass;
+use rvm_types::PartitionId;
+
+const PLACEMENT: Placement = Placement::new(PartitionId::new(1), 0, 16);
+type Log = WitnessLog<512>;
+type Agents = AgentManager<8>;
+
+// ---------------------------------------------------------------------
+// Checkpoint lineage
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_checkpoint_binds_to_the_base_rvf_identity() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+
+    let checkpoint = inst.checkpoint(&log, 3).unwrap();
+    assert_eq!(checkpoint.base_identity(), inst.package().identity());
+    assert_eq!(checkpoint.origin(), inst.id());
+    assert_eq!(checkpoint.captured_state(), InstanceState::Running);
+}
+
+#[test]
+fn state_from_a_different_lineage_is_rejected_rather_than_replayed() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+
+    // Two different artifacts. The second declares a different class set, so
+    // it hashes differently — a genuinely separate lineage.
+    let mut donor = Instance::create(
+        InstanceId::new(7),
+        WasmAdapter::new(),
+        rvm_host::testkit::package("memory,model"),
+        PLACEMENT,
+        &log,
+        1,
+    )
+    .unwrap();
+    donor
+        .start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 2)
+        .unwrap();
+    let foreign = donor.checkpoint(&log, 3).unwrap();
+
+    let mut target = instance(&log);
+    assert_ne!(foreign.base_identity(), target.package().identity());
+
+    let before = log.total_emitted();
+    assert_eq!(
+        target.restore(
+            &foreign,
+            &rvm_host::testkit::MINIMAL_WASM,
+            &mut agents,
+            &log,
+            4
+        ),
+        Err(LaunchError::LineageMismatch)
+    );
+
+    // Refused, witnessed, and no execution began with partial foreign state.
+    assert_eq!(target.state(), InstanceState::Created);
+    assert_eq!(target.agent(), None);
+    let record = log.get(usize::try_from(before).unwrap() % 512).unwrap();
+    assert_eq!(event_of(&record), Some(LaunchEvent::CheckpointRejected));
+    assert_eq!(
+        u32::from_le_bytes(record.aux[4..8].try_into().unwrap()),
+        foreign.lineage_tag()
+    );
+}
+
+#[test]
+fn the_lineage_check_runs_before_the_state_machine() {
+    // A foreign checkpoint offered to a terminated instance is a lineage
+    // rejection, not an illegal transition: the identity mismatch is the more
+    // serious finding and must not be masked by the state check.
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+    inst.terminate(&mut agents, &log, 3).unwrap();
+
+    let foreign = Checkpoint::new(
+        [0xAAu8; 32],
+        InstanceId::new(99),
+        0,
+        InstanceState::Suspended,
+        16,
+        0,
+    );
+    assert_eq!(
+        inst.restore(
+            &foreign,
+            &rvm_host::testkit::MINIMAL_WASM,
+            &mut agents,
+            &log,
+            4
+        ),
+        Err(LaunchError::LineageMismatch)
+    );
+}
+
+#[test]
+fn a_suspended_instance_restores_from_its_own_checkpoint() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+
+    let checkpoint = inst.checkpoint(&log, 3).unwrap();
+    inst.suspend(&mut agents, &log, 4).unwrap();
+
+    inst.restore(
+        &checkpoint,
+        &rvm_host::testkit::MINIMAL_WASM,
+        &mut agents,
+        &log,
+        5,
+    )
+    .unwrap();
+    assert_eq!(inst.state(), InstanceState::Running);
+    assert!(events(&inst, &log).contains(&LaunchEvent::CheckpointRestored));
+}
+
+#[test]
+fn a_checkpoint_resumes_into_a_new_instance_of_the_same_lineage() {
+    // ADR-289 criterion 7: suspend under one adapter, checkpoint, resume under
+    // another. The far-side instance is new by construction, so the origin
+    // instance identifier must not gate the restore — only the base identity.
+    let log = Log::new();
+    let mut agents = Agents::new();
+
+    let mut first = started(&log, &mut agents);
+    first.suspend(&mut agents, &log, 3).unwrap();
+    let checkpoint = first.checkpoint(&log, 4).unwrap();
+    first.terminate(&mut agents, &log, 5).unwrap();
+
+    let mut second = Instance::create(
+        InstanceId::new(2),
+        HostedAdapter::new(HostOs::Linux).fully_engaged(),
+        rvm_host::testkit::package("memory,clock"),
+        PLACEMENT,
+        &log,
+        6,
+    )
+    .unwrap();
+    assert_ne!(second.id(), checkpoint.origin());
+    assert!(checkpoint.belongs_to(second.package().identity()));
+
+    second
+        .restore(
+            &checkpoint,
+            &rvm_host::testkit::MINIMAL_WASM,
+            &mut agents,
+            &log,
+            7,
+        )
+        .unwrap();
+    assert_eq!(second.state(), InstanceState::Running);
+    assert!(second.agent().is_some());
+    // The two runs obtained different, honestly reported boundaries.
+    assert_eq!(second.isolation().claim, IsolationClaim::OsSandboxWasm);
+}
+
+#[test]
+fn checkpoint_sequence_numbers_advance() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+
+    let first = inst.checkpoint(&log, 3).unwrap();
+    let second = inst.checkpoint(&log, 4).unwrap();
+    assert_eq!(first.sequence(), 0);
+    assert_eq!(second.sequence(), 1);
+    assert_eq!(inst.checkpoint_count(), 2);
+    assert!(second.witness_sequence() > first.witness_sequence());
+}
+
+// ---------------------------------------------------------------------
+// The witness chain
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_instance_chain_verifies_and_covers_every_capability_decision() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+    inst.terminate(&mut agents, &log, 3).unwrap();
+
+    let chain = inst.witness(&log);
+    // A dedicated log makes the instance's spans the whole log, so the
+    // exported chain is complete and hash-linked end to end.
+    assert_eq!(chain.len() as u64, log.total_emitted());
+    assert!(rvm_witness::verify_chain(&chain).is_ok());
+    assert!(chain
+        .iter()
+        .all(|r| inst.binds_to_package(r)
+            || rvm_host::event_of(r).is_none() && event_of(r).is_none()));
+
+    // Every one of the fifteen classes was decided exactly once at the host
+    // boundary, and both grants and denials are present.
+    let decisions: Vec<_> = chain
+        .iter()
+        .filter_map(rvm_host::event_of)
+        .filter(|e| {
+            matches!(
+                e,
+                rvm_host::HostEvent::CapabilityGranted | rvm_host::HostEvent::CapabilityDenied
+            )
+        })
+        .collect();
+    assert_eq!(decisions.len(), CapabilityClass::ALL.len());
+    assert!(decisions.contains(&rvm_host::HostEvent::CapabilityGranted));
+    assert!(decisions.contains(&rvm_host::HostEvent::CapabilityDenied));
+}
+
+#[test]
+fn the_chain_is_returned_in_sequence_order() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+    inst.suspend(&mut agents, &log, 3).unwrap();
+    inst.resume(&mut agents, &log, 4).unwrap();
+
+    let chain = inst.witness(&log);
+    assert!(chain.windows(2).all(|w| w[0].sequence < w[1].sequence));
+    assert!(!chain.is_empty());
+}
+
+#[test]
+fn instances_of_different_artifacts_sharing_a_log_get_disjoint_chains() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+
+    let mut a = instance(&log);
+    let mut b = Instance::create(
+        InstanceId::new(2),
+        WasmAdapter::new(),
+        rvm_host::testkit::package("memory,model"),
+        PLACEMENT,
+        &log,
+        2,
+    )
+    .unwrap();
+
+    a.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 3)
+        .unwrap();
+    b.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 4)
+        .unwrap();
+
+    let a_chain = a.witness(&log);
+    let b_chain = b.witness(&log);
+    assert!(!a_chain.is_empty());
+    assert!(!b_chain.is_empty());
+    for record in &a_chain {
+        assert!(
+            !b_chain.iter().any(|r| r.sequence == record.sequence),
+            "chains overlapped at sequence {}",
+            record.sequence
+        );
+    }
+}
+
+#[test]
+fn a_refused_creation_contributes_no_grant_to_the_chain() {
+    let log = Log::new();
+    let refused = Instance::create(
+        InstanceId::new(1),
+        WasmAdapter::new(),
+        rvm_host::testkit::package("gpu"),
+        PLACEMENT,
+        &log,
+        1,
+    );
+    assert!(refused.is_err());
+
+    let granted = (0..log.len())
+        .filter_map(|i| log.get(i))
+        .filter(|r| rvm_host::event_of(r) == Some(rvm_host::HostEvent::CapabilityGranted))
+        .count();
+    assert_eq!(granted, 0);
+}

--- a/crates/rvm-launch/src/instance_tests.rs
+++ b/crates/rvm-launch/src/instance_tests.rs
@@ -1,0 +1,299 @@
+//! Lifecycle tests: the happy path, every illegal transition, checkpoint
+//! lineage, and what the witness chain shows for each.
+
+use super::*;
+use crate::witness::{event_of, LaunchEvent};
+use rvm_host::{HostError, HostOs, HostedAdapter, IsolationClaim, WasmAdapter};
+use rvm_rvf::CapabilityClass;
+use rvm_types::PartitionId;
+
+const PLACEMENT: Placement = Placement::new(PartitionId::new(1), 0, 16);
+type Log = WitnessLog<512>;
+type Agents = AgentManager<8>;
+
+pub(super) fn instance(log: &Log) -> Instance<WasmAdapter> {
+    Instance::create(
+        InstanceId::new(1),
+        WasmAdapter::new(),
+        rvm_host::testkit::package("memory,clock"),
+        PLACEMENT,
+        log,
+        1,
+    )
+    .expect("the wasm adapter enforces both declared classes")
+}
+
+pub(super) fn started(log: &Log, agents: &mut Agents) -> Instance<WasmAdapter> {
+    let mut inst = instance(log);
+    inst.start(&rvm_host::testkit::MINIMAL_WASM, agents, log, 2)
+        .unwrap();
+    inst
+}
+
+pub(super) fn events(inst: &Instance<WasmAdapter>, log: &Log) -> Vec<LaunchEvent> {
+    inst.witness(log).iter().filter_map(event_of).collect()
+}
+
+// ---------------------------------------------------------------------
+// Creation
+// ---------------------------------------------------------------------
+
+#[test]
+fn creation_prepares_isolation_and_runs_nothing() {
+    let log = Log::new();
+    let inst = instance(&log);
+
+    assert_eq!(inst.state(), InstanceState::Created);
+    assert_eq!(inst.agent(), None);
+    assert_eq!(inst.checkpoint_count(), 0);
+    assert_eq!(inst.isolation().claim, IsolationClaim::WasmOnly);
+    assert!(inst.isolation().is_granted(CapabilityClass::Clock));
+    assert_eq!(
+        events(&inst, &log).last(),
+        Some(&LaunchEvent::InstanceCreated)
+    );
+}
+
+#[test]
+fn creation_is_refused_when_the_adapter_cannot_enforce_a_declared_class() {
+    let log = Log::new();
+    let result = Instance::create(
+        InstanceId::new(1),
+        WasmAdapter::new(),
+        rvm_host::testkit::package("memory,network"),
+        PLACEMENT,
+        &log,
+        1,
+    );
+
+    assert!(matches!(
+        result,
+        Err(LaunchError::Host(HostError::CapabilityUnenforceable(
+            CapabilityClass::Network
+        )))
+    ));
+    // The refusal is in the chain and no instance was created.
+    assert_eq!(log.total_emitted(), 1);
+    assert!(result.is_err());
+}
+
+#[test]
+fn the_same_package_creates_under_a_hosted_adapter_with_a_different_claim() {
+    let log = Log::new();
+    let inst = Instance::create(
+        InstanceId::new(2),
+        HostedAdapter::new(HostOs::Linux).fully_engaged(),
+        rvm_host::testkit::package("memory,clock"),
+        PLACEMENT,
+        &log,
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(inst.isolation().claim, IsolationClaim::OsSandboxWasm);
+    assert!(!inst.isolation().claim.is_bare_metal());
+}
+
+// ---------------------------------------------------------------------
+// The happy path
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_full_lifecycle_runs_end_to_end() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = instance(&log);
+
+    inst.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 2)
+        .unwrap();
+    assert_eq!(inst.state(), InstanceState::Running);
+    assert!(inst.agent().is_some());
+    assert_eq!(agents.count(), 1);
+
+    inst.suspend(&mut agents, &log, 3).unwrap();
+    assert_eq!(inst.state(), InstanceState::Suspended);
+
+    let checkpoint = inst.checkpoint(&log, 4).unwrap();
+    assert_eq!(
+        inst.state(),
+        InstanceState::Suspended,
+        "a checkpoint observes"
+    );
+    assert_eq!(inst.checkpoint_count(), 1);
+
+    inst.resume(&mut agents, &log, 5).unwrap();
+    assert_eq!(inst.state(), InstanceState::Running);
+
+    inst.terminate(&mut agents, &log, 6).unwrap();
+    assert_eq!(inst.state(), InstanceState::Terminated);
+    assert_eq!(agents.count(), 0);
+
+    assert_eq!(
+        events(&inst, &log),
+        [
+            LaunchEvent::InstanceCreated,
+            LaunchEvent::InstanceStarted,
+            LaunchEvent::InstanceSuspended,
+            LaunchEvent::CheckpointTaken,
+            LaunchEvent::InstanceResumed,
+            LaunchEvent::InstanceTerminated,
+        ]
+    );
+    assert!(checkpoint.belongs_to(inst.package().identity()));
+}
+
+#[test]
+fn a_module_that_fails_admission_leaves_the_instance_created() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = instance(&log);
+
+    assert!(matches!(
+        inst.start(b"not wasm", &mut agents, &log, 2),
+        Err(LaunchError::Host(HostError::ModuleRejected(_)))
+    ));
+    assert_eq!(inst.state(), InstanceState::Created);
+    assert_eq!(inst.agent(), None);
+    assert_eq!(agents.count(), 0);
+
+    // And the instance is still startable with a module that does pass.
+    inst.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 3)
+        .unwrap();
+    assert_eq!(inst.state(), InstanceState::Running);
+}
+
+// ---------------------------------------------------------------------
+// Illegal transitions
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_running_instance_cannot_be_started_again() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+
+    assert_eq!(
+        inst.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 3),
+        Err(LaunchError::IllegalTransition {
+            from: InstanceState::Running,
+            op: LifecycleOp::Start,
+        })
+    );
+    assert_eq!(agents.count(), 1, "no second agent was spawned");
+}
+
+#[test]
+fn an_instance_that_was_never_suspended_cannot_resume() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+
+    let mut fresh = instance(&log);
+    assert_eq!(
+        fresh.resume(&mut agents, &log, 2),
+        Err(LaunchError::IllegalTransition {
+            from: InstanceState::Created,
+            op: LifecycleOp::Resume,
+        })
+    );
+
+    let mut running = started(&log, &mut agents);
+    assert_eq!(
+        running.resume(&mut agents, &log, 3),
+        Err(LaunchError::IllegalTransition {
+            from: InstanceState::Running,
+            op: LifecycleOp::Resume,
+        })
+    );
+}
+
+#[test]
+fn an_instance_that_is_not_running_cannot_be_suspended() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+
+    let mut fresh = instance(&log);
+    assert_eq!(
+        fresh.suspend(&mut agents, &log, 2),
+        Err(LaunchError::IllegalTransition {
+            from: InstanceState::Created,
+            op: LifecycleOp::Suspend,
+        })
+    );
+
+    let mut inst = started(&log, &mut agents);
+    inst.suspend(&mut agents, &log, 3).unwrap();
+    assert_eq!(
+        inst.suspend(&mut agents, &log, 4),
+        Err(LaunchError::IllegalTransition {
+            from: InstanceState::Suspended,
+            op: LifecycleOp::Suspend,
+        })
+    );
+}
+
+#[test]
+fn a_created_instance_has_nothing_to_checkpoint() {
+    let log = Log::new();
+    let mut inst = instance(&log);
+    assert_eq!(
+        inst.checkpoint(&log, 2),
+        Err(LaunchError::IllegalTransition {
+            from: InstanceState::Created,
+            op: LifecycleOp::Checkpoint,
+        })
+    );
+    assert_eq!(inst.checkpoint_count(), 0);
+}
+
+#[test]
+fn a_terminated_instance_refuses_every_operation() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = started(&log, &mut agents);
+    inst.terminate(&mut agents, &log, 3).unwrap();
+
+    let expect = |op| LaunchError::IllegalTransition {
+        from: InstanceState::Terminated,
+        op,
+    };
+    assert_eq!(
+        inst.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 4),
+        Err(expect(LifecycleOp::Start))
+    );
+    assert_eq!(
+        inst.suspend(&mut agents, &log, 5),
+        Err(expect(LifecycleOp::Suspend))
+    );
+    assert_eq!(
+        inst.resume(&mut agents, &log, 6),
+        Err(expect(LifecycleOp::Resume))
+    );
+    assert_eq!(
+        inst.checkpoint(&log, 7),
+        Err(expect(LifecycleOp::Checkpoint))
+    );
+    assert_eq!(
+        inst.terminate(&mut agents, &log, 8),
+        Err(expect(LifecycleOp::Terminate))
+    );
+    assert_eq!(inst.state(), InstanceState::Terminated);
+}
+
+#[test]
+fn every_illegal_transition_is_witnessed_before_it_is_returned() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = instance(&log);
+
+    let before = log.total_emitted();
+    assert!(inst.resume(&mut agents, &log, 2).is_err());
+    assert_eq!(log.total_emitted(), before + 1);
+
+    let record = log.get(usize::try_from(before).unwrap() % 512).unwrap();
+    assert_eq!(event_of(&record), Some(LaunchEvent::IllegalTransition));
+    assert_eq!(record.aux[1], InstanceState::Created as u8);
+    assert_eq!(
+        u32::from_le_bytes(record.aux[4..8].try_into().unwrap()),
+        u32::from(LifecycleOp::Resume as u8)
+    );
+}

--- a/crates/rvm-launch/src/lib.rs
+++ b/crates/rvm-launch/src/lib.rs
@@ -1,26 +1,78 @@
-//! The launch surface: state, checkpoints, and the witness records they emit.
+//! # Instance lifecycle for RVM
 //!
-//! `rvm-host` decides *where* an agent can run. This crate covers what happens
-//! to its state across that lifetime — suspend, checkpoint, resume, and the
-//! lineage rules that decide when restoring is refused.
+//! The layer above `rvm-host`. `rvm-rvf` decides whether an artifact may run,
+//! `rvm-host` decides what it runs inside, and this crate drives one execution
+//! through create, start, suspend, resume, checkpoint, and terminate. It
+//! implements the `rvm-launch` surface of ADR-289 and the lineage binding of
+//! ADR-288 §4.
 //!
-//! ## The rule worth stating twice
+//! ## The library is the contract
 //!
-//! Every delta and every checkpoint carries the base RVF identity it belongs
-//! to (ADR-288 §4). On open, the runtime compares that against the base it
-//! actually loaded, and a mismatch is a lineage rejection: the state is
-//! refused, execution does not begin with partial state, and the rejection
-//! goes into the witness chain rather than being handled quietly.
+//! ADR-289 §3 lists these as CLI verbs, and a binary is a thin shell over what
+//! is here. Keeping the surface a library first is what stops the CLI, the
+//! Tauri reader through `rvm-ffi`, and Forge through `rvm-node` from enforcing
+//! three different things — the failure mode ADR-289 rejects in its
+//! alternatives.
 //!
-//! Instance identity is recorded as provenance but is deliberately *not* a
-//! gate — ADR-289 acceptance criterion 7 requires suspending under one host
+//! | ADR-289 verb | Here |
+//! |---|---|
+//! | `rvm inspect` | [`inspect`] |
+//! | `rvm verify` | [`verify`] |
+//! | `rvm run` | [`Instance::create`] then [`Instance::start`] |
+//! | `rvm suspend` | [`Instance::suspend`] |
+//! | `rvm resume` | [`Instance::resume`] |
+//! | `rvm checkpoint` | [`Instance::checkpoint`] |
+//! | `rvm witness` | [`Instance::witness`] |
+//! | `rvm terminate` | [`Instance::terminate`] |
+//!
+//! ## Four invariants
+//!
+//! **Nothing executes before verification succeeds.** [`Instance::create`]
+//! takes a [`VerifiedPackage`](rvm_host::VerifiedPackage), whose only
+//! constructor rejects a failed report.
+//!
+//! **Inspection is not execution.** [`inspect`] and [`verify`] read headers,
+//! hash payloads, and check signatures. Neither maps a segment, resolves an
+//! entry point, or interprets a payload, so a scanner can handle an untrusted
+//! artifact without becoming an execution surface for it.
+//!
+//! **Illegal transitions are errors, not no-ops.** The state machine in
+//! [`state`] permits nothing outside its table, and each refusal is witnessed
+//! before it is returned.
+//!
+//! **State binds to its lineage.** A [`Checkpoint`] carries the base RVF
+//! identity it was produced under (ADR-288 §4), and [`Instance::restore`]
+//! refuses one from a different base before it touches the state machine or a
+//! runtime. Instance identity is recorded as provenance but is deliberately
+//! *not* a gate — ADR-289 criterion 7 requires suspending under one host
 //! adapter and resuming under another, so the instance on the far side is a
 //! new one by construction.
 //!
+//! ## Using it
+//!
+//! ```ignore
+//! use rvm_launch::{inspect, verify, Instance, InstanceId};
+//! use rvm_host::{Placement, VerifiedPackage, WasmAdapter};
+//!
+//! let report = verify(bytes, &opts, &log, witness_ctx)?;   // witnessed either way
+//! let package = VerifiedPackage::from_report(&report)?;    // refuses a failed report
+//!
+//! let mut instance = Instance::create(
+//!     InstanceId::new(1), WasmAdapter::new(), package, placement, &log, now,
+//! )?;
+//! instance.start(wasm_bytes, &mut agents, &log, now)?;
+//! instance.suspend(&mut agents, &log, now)?;
+//! let checkpoint = instance.checkpoint(&log, now)?;        // bound to the base identity
+//! instance.terminate(&mut agents, &log, now)?;
+//!
+//! let chain = instance.witness(&log);
+//! ```
+//!
 //! ## Allocation
 //!
-//! `no_std` with `alloc` required: a delta chain and a witness log are both
-//! variable-length. The decision path itself allocates nothing beyond those.
+//! `no_std` with `alloc` required: the capability set inherited from
+//! `rvm-host` and the witness spans an instance accumulates are both
+//! variable-length. Each lifecycle operation costs at most one span.
 
 #![no_std]
 #![forbid(unsafe_code)]
@@ -31,7 +83,213 @@
 
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub mod checkpoint;
 pub mod error;
+pub mod inspect;
+pub mod instance;
 pub mod state;
 pub mod witness;
+
+pub use checkpoint::Checkpoint;
+pub use error::{LaunchError, LaunchResult};
+pub use inspect::{inspect, verify, Inspection, SegmentSummary};
+pub use instance::Instance;
+pub use state::{is_legal, InstanceId, InstanceState, LifecycleOp};
+pub use witness::{build_record, emit, emit_illegal, event_of, LaunchEvent, LaunchWitnessContext};
+
+/// The version of the lifecycle contract this crate implements.
+///
+/// Pairs with [`rvm_host::HOST_CONTRACT_VERSION`] and
+/// [`rvm_rvf::RVF_CONTRACT_VERSION`] in the ADR-291 compatibility matrix.
+pub const LAUNCH_CONTRACT_VERSION: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+    use rvm_host::{
+        testkit, HostAdapter, HostError, HostOs, HostedAdapter, IsolationClaim, IsolationMechanism,
+        Placement, VerifiedPackage, WasmAdapter,
+    };
+    use rvm_rvf::{CapabilityClass, VerifyOptions, WitnessContext};
+    use rvm_types::PartitionId;
+    use rvm_wasm::agent::AgentManager;
+    use rvm_witness::WitnessLog;
+
+    const PLACEMENT: Placement = Placement::new(PartitionId::new(1), 0, 16);
+
+    #[test]
+    fn inspect_and_verify_never_reach_an_instance_on_their_own() {
+        // The whole path from bytes to execution, with the gate in the middle.
+        let data = testkit::container_with_wasm("memory,clock");
+        let log = WitnessLog::<256>::new();
+
+        // Inspection tells you what the artifact claims. It grants nothing.
+        let inspected = inspect(&data).unwrap();
+        assert_eq!(
+            inspected.declared_classes,
+            [CapabilityClass::Memory, CapabilityClass::Clock]
+        );
+
+        // Under the strict posture this artifact does not verify, and there is
+        // no way from that report to a running instance.
+        let strict = verify(
+            &data,
+            &VerifyOptions::default(),
+            &log,
+            WitnessContext::new(1, 1),
+        )
+        .unwrap();
+        assert!(!strict.ok);
+        assert_eq!(
+            VerifiedPackage::from_report(&strict),
+            Err(HostError::Unverified)
+        );
+
+        // Under the development posture it does, and only then does an
+        // instance exist.
+        let permitted = verify(
+            &data,
+            &testkit::lenient_options(),
+            &log,
+            WitnessContext::new(1, 2),
+        )
+        .unwrap();
+        let package = VerifiedPackage::from_report(&permitted).unwrap();
+        let instance = Instance::create(
+            InstanceId::new(1),
+            WasmAdapter::new(),
+            package,
+            PLACEMENT,
+            &log,
+            3,
+        )
+        .unwrap();
+        assert_eq!(instance.state(), InstanceState::Created);
+    }
+
+    #[test]
+    fn an_undeclared_capability_is_unavailable_to_a_running_instance() {
+        let log = WitnessLog::<256>::new();
+        let mut agents = AgentManager::<4>::new();
+        let mut instance = Instance::create(
+            InstanceId::new(1),
+            WasmAdapter::new(),
+            testkit::package("memory"),
+            PLACEMENT,
+            &log,
+            1,
+        )
+        .unwrap();
+        instance
+            .start(&testkit::MINIMAL_WASM, &mut agents, &log, 2)
+            .unwrap();
+
+        // Fourteen of the fifteen classes stay closed, and each closure is in
+        // the chain rather than merely implied by its absence.
+        for class in CapabilityClass::ALL {
+            let expected = class == CapabilityClass::Memory;
+            assert_eq!(instance.isolation().is_granted(class), expected, "{class}");
+        }
+        let denied: Vec<_> = instance
+            .witness(&log)
+            .iter()
+            .filter(|r| rvm_host::event_of(r) == Some(rvm_host::HostEvent::CapabilityDenied))
+            .map(|r| r.aux[1])
+            .collect();
+        assert_eq!(denied.len(), 14);
+    }
+
+    #[test]
+    fn an_unsupported_capability_class_is_a_witnessed_refusal_not_a_partial_start() {
+        let log = WitnessLog::<256>::new();
+        let result = Instance::create(
+            InstanceId::new(1),
+            WasmAdapter::new(),
+            testkit::package("memory,filesystem"),
+            PLACEMENT,
+            &log,
+            1,
+        );
+
+        assert!(matches!(
+            result,
+            Err(LaunchError::Host(HostError::CapabilityUnenforceable(
+                CapabilityClass::Filesystem
+            )))
+        ));
+        assert_eq!(log.total_emitted(), 1);
+        let record = log.get(0).unwrap();
+        assert_eq!(
+            rvm_host::event_of(&record),
+            Some(rvm_host::HostEvent::CapabilityRefused)
+        );
+    }
+
+    #[test]
+    fn the_adapter_that_can_enforce_the_class_starts_the_same_package() {
+        let log = WitnessLog::<256>::new();
+        let mut agents = AgentManager::<4>::new();
+        let adapter = HostedAdapter::new(HostOs::Linux)
+            .engaging(IsolationMechanism::LinuxRestrictedMounts)
+            .unwrap();
+
+        let mut instance = Instance::create(
+            InstanceId::new(1),
+            adapter,
+            testkit::package("memory,filesystem"),
+            PLACEMENT,
+            &log,
+            1,
+        )
+        .unwrap();
+        instance
+            .start(&testkit::MINIMAL_WASM, &mut agents, &log, 2)
+            .unwrap();
+
+        assert_eq!(instance.state(), InstanceState::Running);
+        assert!(instance.isolation().is_granted(CapabilityClass::Filesystem));
+        assert_eq!(instance.isolation().claim, IsolationClaim::OsSandboxWasm);
+        assert!(instance.adapter().enforces(CapabilityClass::Filesystem));
+    }
+
+    #[test]
+    fn a_hosted_instance_never_reports_bare_metal_isolation() {
+        let log = WitnessLog::<512>::new();
+        for os in HostOs::ALL {
+            for adapter in [
+                HostedAdapter::new(os),
+                HostedAdapter::new(os).fully_engaged(),
+            ] {
+                let instance = Instance::create(
+                    InstanceId::new(1),
+                    adapter,
+                    testkit::package("memory"),
+                    PLACEMENT,
+                    &log,
+                    1,
+                )
+                .unwrap();
+                assert!(!instance.isolation().claim.is_bare_metal(), "{os}");
+
+                let claimed: Vec<_> = instance
+                    .witness(&log)
+                    .iter()
+                    .filter_map(rvm_host::claim_of)
+                    .collect();
+                assert!(!claimed.is_empty());
+                assert!(!claimed.contains(&IsolationClaim::Partition));
+            }
+        }
+    }
+
+    #[test]
+    fn the_three_contract_versions_agree() {
+        assert_eq!(LAUNCH_CONTRACT_VERSION, 1);
+        assert_eq!(rvm_host::HOST_CONTRACT_VERSION, 1);
+        assert_eq!(rvm_rvf::RVF_CONTRACT_VERSION, 1);
+    }
+}

--- a/crates/rvm-launch/src/state.rs
+++ b/crates/rvm-launch/src/state.rs
@@ -235,7 +235,10 @@ mod tests {
         assert!(!is_legal(InstanceState::Created, LifecycleOp::Checkpoint));
         assert!(is_legal(InstanceState::Running, LifecycleOp::Checkpoint));
         assert!(is_legal(InstanceState::Suspended, LifecycleOp::Checkpoint));
-        assert!(!is_legal(InstanceState::Terminated, LifecycleOp::Checkpoint));
+        assert!(!is_legal(
+            InstanceState::Terminated,
+            LifecycleOp::Checkpoint
+        ));
     }
 
     #[test]

--- a/crates/rvm-launch/src/witness.rs
+++ b/crates/rvm-launch/src/witness.rs
@@ -194,7 +194,8 @@ pub const fn event_of(record: &WitnessRecord) -> Option<LaunchEvent> {
         9 => LaunchEvent::IllegalTransition,
         _ => return None,
     };
-    if record.action_kind == tagged.action_kind() as u8 && record.aux[2] == 0 && record.aux[3] == 0 {
+    if record.action_kind == tagged.action_kind() as u8 && record.aux[2] == 0 && record.aux[3] == 0
+    {
         Some(tagged)
     } else {
         None
@@ -243,9 +244,11 @@ mod tests {
     }
 
     #[test]
-    fn launch_records_are_not_mistaken_for_host_records() {
-        // A host record uses the same aux[0] space but sets aux[2] to the
-        // isolation-claim code, which a launch record never does.
+    fn no_launch_record_is_ever_read_as_a_host_record_or_the_reverse() {
+        // Both layers number their events from 1, so `aux[0]` collides across
+        // the whole overlapping range. Reading a lifecycle record as a
+        // capability decision would silently inflate an audit of capability
+        // grants, so every pairing is checked rather than a representative one.
         let host_ctx = rvm_host::HostWitnessContext::new(
             [3u8; 32],
             PartitionId::new(1),
@@ -253,17 +256,33 @@ mod tests {
             rvm_host::IsolationClaim::WasmOnly,
             0,
         );
-        let host = rvm_host::build_record(rvm_host::HostEvent::CapabilityGranted, &host_ctx, None, 0);
-        assert!(rvm_host::event_of(&host).is_some());
-        assert_eq!(event_of(&host), None);
 
-        let launch = build_record(
-            LaunchEvent::InstanceCreated,
-            &ctx(),
-            InstanceState::Created,
-            0,
-        );
-        assert_eq!(rvm_host::claim_of(&launch), None);
+        for event in LaunchEvent::ALL {
+            let r = build_record(event, &ctx(), InstanceState::Running, 0);
+            assert_eq!(event_of(&r), Some(event));
+            assert_eq!(
+                rvm_host::event_of(&r),
+                None,
+                "{event:?} read as a host event"
+            );
+            assert_eq!(rvm_host::claim_of(&r), None);
+        }
+
+        for event in rvm_host::HostEvent::ALL {
+            let r = rvm_host::build_record(event, &host_ctx, None, 0);
+            assert_eq!(rvm_host::event_of(&r), Some(event));
+            assert_eq!(event_of(&r), None, "{event:?} read as a launch event");
+        }
+    }
+
+    #[test]
+    fn an_agent_record_from_rvm_wasm_belongs_to_neither_layer() {
+        // `rvm-wasm` emits its own transition records into the same log with
+        // an all-zero aux; they are neither layer's to interpret.
+        let mut agent = WitnessRecord::zeroed();
+        agent.action_kind = ActionKind::TaskSpawn as u8;
+        assert_eq!(event_of(&agent), None);
+        assert_eq!(rvm_host::event_of(&agent), None);
     }
 
     #[test]
@@ -277,12 +296,7 @@ mod tests {
     #[test]
     fn an_illegal_transition_records_which_operation_was_attempted() {
         let log = WitnessLog::<8>::new();
-        emit_illegal(
-            &log,
-            &ctx(),
-            InstanceState::Terminated,
-            LifecycleOp::Resume,
-        );
+        emit_illegal(&log, &ctx(), InstanceState::Terminated, LifecycleOp::Resume);
         let r = log.get(0).unwrap();
         assert_eq!(event_of(&r), Some(LaunchEvent::IllegalTransition));
         assert_eq!(r.aux[1], InstanceState::Terminated as u8);
@@ -296,8 +310,18 @@ mod tests {
     fn records_bind_to_the_base_artifact() {
         let mut other = ctx();
         other.rvf_identity = [4u8; 32];
-        let a = build_record(LaunchEvent::CheckpointTaken, &ctx(), InstanceState::Running, 0);
-        let b = build_record(LaunchEvent::CheckpointTaken, &other, InstanceState::Running, 0);
+        let a = build_record(
+            LaunchEvent::CheckpointTaken,
+            &ctx(),
+            InstanceState::Running,
+            0,
+        );
+        let b = build_record(
+            LaunchEvent::CheckpointTaken,
+            &other,
+            InstanceState::Running,
+            0,
+        );
         assert_ne!(a.capability_hash, b.capability_hash);
         assert_ne!(a.payload, b.payload);
     }


### PR DESCRIPTION
Follows [v1.6.0](https://github.com/ruvnet/rvm/releases/tag/v1.6.0). Builds `rvm-launch` out from four modules into the full ADR-289 verb set.

| ADR-289 verb | Here |
|---|---|
| `rvm inspect` | `inspect` |
| `rvm verify` | `verify` |
| `rvm run` | `Instance::create` then `Instance::start` |
| `rvm suspend` / `resume` | `Instance::suspend` / `resume` |
| `rvm checkpoint` | `Instance::checkpoint` |
| `rvm witness` | `Instance::witness` |
| `rvm terminate` | `Instance::terminate` |

The surface is a library first and a CLI second, because ADR-289 rejects the alternative explicitly: the CLI, the Tauri reader via `rvm-ffi`, and Forge via `rvm-node` must not each enforce their own version of these rules.

## Four invariants, held structurally

**Nothing executes before verification succeeds.** `Instance::create` takes a `VerifiedPackage`, whose only constructor rejects a failed report — there is no path from a failed `verify` to a running instance, rather than a convention that callers should check first.

**Inspection is not execution.** `inspect` and `verify` read headers, hash payloads and check signatures. Neither maps a segment, resolves an entry point, or interprets a payload, so a scanner can open an untrusted artifact without becoming an execution surface for it.

**Illegal transitions are errors, not no-ops.** The state machine permits nothing outside its table, and each refusal is witnessed *before* it is returned.

**State binds to its lineage.** A checkpoint carries the base RVF identity it was produced under (ADR-288 §4), and `restore` refuses one from a different base before it touches the state machine or a runtime. Instance identity is recorded as provenance but deliberately does not gate — ADR-289 criterion 7 requires suspending under one host adapter and resuming under another, so the far-side instance is new by construction.

## Verification

```
cargo test -p rvm-rvf -p rvm-host -p rvm-launch   233 passed, 0 failed
cargo clippy ... --all-targets -- -D warnings     clean
cargo check --workspace                            ok
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01ParP55bZs2iTGEGvpnUecx