### PR TITLE
fix(kernel): gate boot assembly to bare-metal AArch64

### DIFF
--- a/crates/rvm-kernel/src/main.rs
+++ b/crates/rvm-kernel/src/main.rs
@@ -50,7 +50,7 @@ fn main() {}
 // 2. Sets up the stack pointer from `__stack_top`
 // 3. Jumps to `rvm_main` (Rust entry)
 // 4. If `rvm_main` ever returns, parks the CPU via WFE loop
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_os = "none"))]
 core::arch::global_asm!(
     ".section .text.boot",
     ".global _start",


### PR DESCRIPTION
## Summary

- compile the AArch64 boot `global_asm!` only for `target_os = "none"`
- keep hosted AArch64 test builds on the existing test stub

Fixes #27

## Verification

- Before: `cargo test --workspace` failed on Apple Silicon with Darwin assembler errors.
- After: `cargo test --workspace` passed across the full workspace.
- Bare-metal target check was attempted but this host does not have `aarch64-unknown-none` installed. The cfg remains active for that target by construction.

## Adversarial review

**NO BLOCK.** Checked that the condition distinguishes OS target rather than CPU alone and that hosted AArch64 no longer emits `_start`. Residual gate: CI with the installed bare-metal target should run the existing kernel build.