### PR TITLE
fix(deps): update audited Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2165,9 +2165,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
-spin = { version = "0.9", default-features = false }
+spin = { version = "0.10", default-features = false }
 bitflags = { version = "2", default-features = false }
 
 # Testing


### PR DESCRIPTION
## Summary

- update `crossbeam-epoch` to 0.9.20 for RUSTSEC-2026-0204
- update `anyhow` to 1.0.103 for RUSTSEC-2026-0190
- move `spin` from yanked 0.9.8 to non-yanked 0.10.1

Fixes #26

## Verification

- `cargo audit` — no vulnerabilities, unsound advisories, or yanked dependencies reported
- `cargo test --workspace --exclude rvm-kernel` — passed
- `cargo check --workspace` — passed

The kernel test binary exclusion isolates the independently tracked Apple AArch64 assembly failure in #27 / PR #29.

## Adversarial review

**NO BLOCK.** Rejected yanked `spin 0.10.0` during the review and moved to 0.10.1. Confirmed the no_std consumers compile and the complete non-kernel test surface passes. Residual gate: rerun full workspace tests after #29 lands.