### PR TITLE
fix(rvf): reject unknown capability names

### DIFF
--- a/crates/rvm-rvf/src/capability.rs
+++ b/crates/rvm-rvf/src/capability.rs
@@ -352,6 +352,29 @@ pub fn declared_classes(data: &[u8], segments: &[ParsedSegment]) -> Vec<Capabili
     found
 }
 
+/// Whether a plaintext capability declaration contains a non-empty name that
+/// this RVM version does not understand.
+pub(crate) fn has_unknown_class_name(data: &[u8], segments: &[ParsedSegment]) -> bool {
+    segments.iter().any(|seg| {
+        if seg.header.seg_type != SEG_TYPE_META || seg.header.is_encrypted() {
+            return false;
+        }
+        let Ok(text) = core::str::from_utf8(seg.payload(data)) else {
+            return false;
+        };
+        text.lines().any(|line| {
+            line.strip_prefix(CAPABILITY_DECLARATION_KEY)
+                .and_then(|rest| rest.strip_prefix('='))
+                .is_some_and(|value| {
+                    value.split(',').any(|name| {
+                        let name = name.trim();
+                        !name.is_empty() && CapabilityClass::from_wire(name).is_none()
+                    })
+                })
+        })
+    })
+}
+
 #[cfg(test)]
 #[path = "capability_tests.rs"]
 mod tests;

--- a/crates/rvm-rvf/src/capability_tests.rs
+++ b/crates/rvm-rvf/src/capability_tests.rs
@@ -45,10 +45,14 @@ fn declared_classes_are_read_from_meta() {
 }
 
 #[test]
-fn unknown_class_names_are_skipped_not_granted() {
-    let mapping = map("network,teleportation").unwrap();
-    assert!(mapping.is_granted(CapabilityClass::Network));
-    assert_eq!(mapping.granted().len(), 1);
+fn unknown_class_names_are_detected_for_verification() {
+    let data = testkit::minimal_container("network,teleportation");
+    let segs = walk(&data).unwrap();
+    assert!(has_unknown_class_name(&data, &segs));
+
+    let data = testkit::minimal_container(" network, filesystem, ");
+    let segs = walk(&data).unwrap();
+    assert!(!has_unknown_class_name(&data, &segs));
 }
 
 #[test]

--- a/crates/rvm-rvf/src/detail.rs
+++ b/crates/rvm-rvf/src/detail.rs
@@ -44,6 +44,8 @@ pub enum DetailCode {
     CapabilitiesMapped,
     /// A declared class is one RVM cannot represent.
     CapabilityUnsupported,
+    /// A declared capability name is unknown to this RVM version.
+    CapabilityUnknown,
 }
 
 impl fmt::Display for DetailCode {
@@ -67,6 +69,7 @@ impl fmt::Display for DetailCode {
             Self::ExceedsSizePolicy => "container exceeds a policy limit",
             Self::CapabilitiesMapped => "declared capability classes mapped into rvm-cap",
             Self::CapabilityUnsupported => "declared capability class is unrepresentable",
+            Self::CapabilityUnknown => "declared capability class name is unknown",
         };
         f.write_str(s)
     }

--- a/crates/rvm-rvf/src/error.rs
+++ b/crates/rvm-rvf/src/error.rs
@@ -46,6 +46,8 @@ pub enum RvfError {
     /// quietly runs without a capability it declared is indistinguishable
     /// from an agent that is working.
     UnsupportedCapability(CapabilityClass),
+    /// The container names a capability class unknown to this RVM version.
+    UnknownCapability,
     /// A capability mapping could not be installed into the capability table.
     CapabilityTableFull,
 }
@@ -74,6 +76,7 @@ impl fmt::Display for RvfError {
             Self::UnsupportedCapability(c) => {
                 write!(f, "RVM cannot represent capability class {c}")
             }
+            Self::UnknownCapability => f.write_str("RVF declares an unknown capability class"),
             Self::CapabilityTableFull => write!(f, "capability table has no free slot"),
         }
     }
@@ -82,9 +85,9 @@ impl fmt::Display for RvfError {
 impl From<RvfError> for RvmError {
     fn from(e: RvfError) -> Self {
         match e {
-            RvfError::UnsupportedCapability(_) | RvfError::UnsupportedVersion(_) => {
-                RvmError::Unsupported
-            }
+            RvfError::UnsupportedCapability(_)
+            | RvfError::UnknownCapability
+            | RvfError::UnsupportedVersion(_) => RvmError::Unsupported,
             RvfError::CapabilityTableFull | RvfError::TooManySegments => {
                 RvmError::ResourceLimitExceeded
             }
@@ -118,6 +121,7 @@ mod tests {
             RvfError::TooManySegments,
             RvfError::NoForwardProgress,
             RvfError::UnsupportedCapability(CapabilityClass::Clipboard),
+            RvfError::UnknownCapability,
             RvfError::CapabilityTableFull,
         ];
         for e in all {

--- a/crates/rvm-rvf/src/verify.rs
+++ b/crates/rvm-rvf/src/verify.rs
@@ -14,7 +14,9 @@
 //! **Nothing here executes anything.** The only bytes read from an executable
 //! segment are read to hash them (ADR-284 §1.7).
 
-use crate::capability::{declared_classes, map_declared, CapabilityMapping};
+use crate::capability::{
+    declared_classes, has_unknown_class_name, map_declared, CapabilityMapping,
+};
 use crate::container::{root_manifest, walk, ParsedSegment};
 use crate::detail::DetailCode;
 use crate::error::{RvfError, RvfResult};
@@ -133,6 +135,12 @@ impl VerificationReport {
             return Ok(self);
         }
         if self.first_failure(CheckKind::CapabilityMapping).is_some() {
+            if self.records.iter().any(|record| {
+                record.check == CheckKind::CapabilityMapping
+                    && record.detail == DetailCode::CapabilityUnknown
+            }) {
+                return Err(RvfError::UnknownCapability);
+            }
             // The specific class is already in the record set; report the
             // first declared class RVM cannot represent.
             let class = crate::capability::CapabilityClass::ALL
@@ -313,6 +321,16 @@ fn capability_records(
     data: &[u8],
     segments: &[ParsedSegment],
 ) -> (CapabilityMapping, VerificationRecord) {
+    if has_unknown_class_name(data, segments) {
+        return (
+            map_declared(&[]).unwrap_or_else(|_| unreachable!("the empty declaration always maps")),
+            container_record(
+                CheckKind::CapabilityMapping,
+                Outcome::Fail,
+                DetailCode::CapabilityUnknown,
+            ),
+        );
+    }
     let declared = declared_classes(data, segments);
     match map_declared(&declared) {
         Ok(mapping) => (

--- a/crates/rvm-rvf/src/verify_tests.rs
+++ b/crates/rvm-rvf/src/verify_tests.rs
@@ -260,6 +260,22 @@ fn an_unsupported_capability_class_is_witnessed_and_then_refused() {
 }
 
 #[test]
+fn an_unknown_capability_name_is_witnessed_and_refused() {
+    let data = crate::testkit::minimal_container("network,teleportation");
+    let report = verify(&data, &VerifyOptions::default()).unwrap();
+
+    let capability = record_for(&report, CheckKind::CapabilityMapping);
+    assert_eq!(capability.outcome, Outcome::Fail);
+    assert_eq!(capability.detail, DetailCode::CapabilityUnknown);
+    assert!(!report.ok);
+    assert!(report.capabilities.granted().is_empty());
+    assert_eq!(
+        report.into_result(),
+        Err(crate::RvfError::UnknownCapability)
+    );
+}
+
+#[test]
 fn a_malformed_container_is_an_error_not_a_report() {
     let junk = vec![b'x'; 128];
     assert_eq!(
@@ -328,6 +344,7 @@ fn detail_codes_all_render() {
         DetailCode::ExceedsSizePolicy,
         DetailCode::CapabilitiesMapped,
         DetailCode::CapabilityUnsupported,
+        DetailCode::CapabilityUnknown,
     ];
     for code in codes {
         let mut s = alloc::string::String::new();


### PR DESCRIPTION
## Summary

- detect non-empty unknown names in plaintext capability declarations
- fail capability verification and retain a deny-all mapping
- emit a distinct `CapabilityUnknown` witness detail and `UnknownCapability` error
- preserve empty, whitespace-normalized, encrypted, and absent declaration behavior

Fixes #23

## Verification

- `cargo test -p rvm-rvf` (100 passed)
- `cargo clippy -p rvm-rvf --all-targets -- -D warnings`
- `cargo check --workspace`

## TDD evidence

The mixed known/unknown declaration regression failed before implementation.

## Adversarial review

**NO BLOCK after one REMAND.** The first green implementation produced the wrong public error (`UnsupportedCapability(Randomness)`) for unknown names. Added a second red regression and a stable `UnknownCapability` path. Checked later META segments, mixed known/unknown names, whitespace, empty entries, and deny-all behavior.