### PR TITLE
docs(adr): separate RVF target from delivery status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
       - run: cargo check
       - run: cargo test
       - run: cargo clippy -- -D warnings
+      - run: scripts/check-adr155-status.sh
       - run: cargo check --target aarch64-unknown-none -p rvm-hal --no-default-features

--- a/docs/adr/ADR-155-rvf-execution-contract.md
+++ b/docs/adr/ADR-155-rvf-execution-contract.md
@@ -22,10 +22,10 @@ than on a bare-metal appliance is not one portable agent, it is five agents that
 happen to share a filename.
 
 This ADR records the contract RVM commits to. It is **Accepted as a decision**;
-the implementation in this repository begins with the `rvm-rvf` loader
-(verification, capability mapping, witness emission) and does not yet include
-the execution backends (`rvm-host`, `rvm-launch`, `rvm-ffi`, `rvm-node`) that a
-complete quarantined runtime requires.
+the implementation in this repository includes an initial `rvm-rvf` loader and
+`rvm-host`/`rvm-launch` lifecycle surfaces. These are partial contract
+implementations, not evidence that every backend or acceptance criterion below
+is conformant.
 
 RVM is the execution side of that claim. ADR-149 already established RVF as the
 universal container format for RVM's own artifacts (boot images, dormant memory
@@ -266,17 +266,21 @@ copy is in RuVector at `docs/research/rvf-forge/compatibility-matrix.json`. The
 build provenance record names the matrix revision that admitted a build, so a
 past admission decision can be reconstructed.
 
-The current matrix marks `rvm-native` (bare-metal partition isolation, via the
-seven-phase measured boot of `rvm-boot`) and `linux-microvm` as **planned**, and
-`rvmVersionMin` as null pending `rvm-rvf` shipping a versioned execution
-contract. Landing this ADR's implementation is what populates those fields.
+The current matrix marks `os-isolation+wasm`, `rvm-native` (bare-metal partition
+isolation, via the seven-phase measured boot of `rvm-boot`), and
+`linux-microvm` as **planned**. `rvmVersionMin` remains null until a released
+RVM build is validated against the matrix; a source-level contract constant is
+not release evidence.
 
 ### 7. Hosted-Mode Isolation-Claim Honesty
 
-RVM running as an ordinary desktop process provides **operating-system isolation
-plus WASM**. It provides namespaces, cgroups, seccomp, and network namespaces on
-Linux; Job Objects and restricted tokens on Windows; App Sandbox, hardened
-runtime, and scoped entitlements on macOS.
+The target hosted profile is **operating-system isolation plus WASM**. The
+current `rvm-host` crate models these mechanisms and fails safely to
+`wasm-only`, but it does not apply or independently attest namespaces, cgroups,
+seccomp, Job Objects, restricted tokens, App Sandbox, hardened runtime, or
+entitlements. Platform-owned evidence is tracked in
+[rvm#25](https://github.com/ruvnet/rvm/issues/25); until it lands, the
+`os-isolation+wasm` matrix entry remains planned.
 
 It does **not** provide partition memory isolation, device leases, measured
 boot, or the hardware-backed trust that bare-metal RVM provides. The
@@ -292,6 +296,23 @@ every capability decision in section 3 advisory rather than enforced. Native
 extensions require a separate sandbox or an RVM partition.
 
 ### 8. Acceptance
+
+#### Current implementation status
+
+This table is delivery evidence, not part of the target contract. `Implemented`
+means code exists on `main`; it does not mean cross-platform or production
+validation. `Partial` cannot be used to advertise conformance.
+
+| Criterion | Status | Current evidence / remaining gate |
+|---|---|---|
+| 1 | Planned | No unchanged-artifact conformance run spans hosted Linux, Windows, macOS, QEMU, and bare metal. |
+| 2 | Planned | No cross-backend deterministic evaluation oracle exists. |
+| 3 | Partial | Default-deny mapping and adapter refusals exist; real hosted filesystem/network confinement awaits [rvm#25](https://github.com/ruvnet/rvm/issues/25). |
+| 4 | Planned | Lifecycle metadata crosses adapters, but guest state does not; see [rvm#24](https://github.com/ruvnet/rvm/issues/24). |
+| 5 | Implemented | RVF identity is retained by `VerifiedPackage` and checkpoint lineage checks. |
+| 6 | Planned | `rvm-launch::Checkpoint` explicitly carries metadata only; payload and witness-delta reconstruction are [rvm#24](https://github.com/ruvnet/rvm/issues/24). |
+| 7 | Partial | RVF content hashes are checked, while binding separately supplied runtime bytes is tracked in [rvm#19](https://github.com/ruvnet/rvm/issues/19). Policy/model/state end-to-end rejection is incomplete. |
+| 8 | Partial | Verification and lifecycle records are chained, but complete cross-backend witness coverage has not been demonstrated. |
 
 A release conforms only when one signed RVF:
 

--- a/docs/rvforge-compatibility-matrix.json
+++ b/docs/rvforge-compatibility-matrix.json
@@ -2,7 +2,7 @@
   "canonicalSource": "ruvector/docs/research/rvf-forge/compatibility-matrix.json (github.com/ruvnet/RuVector)",
   "schemaVersion": 1,
   "description": "RVForge <-> RVM runtime compatibility matrix (ADR-291). Forge rejects build/package combinations absent from this matrix. Canonical copy; the CLI vendors this file at build time.",
-  "updated": "2026-08-03",
+  "updated": "2026-08-05",
   "runtimeProfiles": {
     "wasm": {
       "status": "supported",
@@ -17,9 +17,9 @@
       ]
     },
     "os-isolation+wasm": {
-      "status": "supported",
+      "status": "planned",
       "isolationClaim": "os-sandbox+wasm",
-      "note": "Hosted RVM: OS isolation plus WASM. MUST NOT be described as bare-metal isolation (ADR-285).",
+      "note": "Target profile. rvm-host currently models mechanism status but platform integrations do not yet apply or attest the OS controls (rvm#25). MUST NOT be described as implemented or as bare-metal isolation (ADR-285).",
       "stateSchemaVersions": [1],
       "witnessSchemaVersions": [1],
       "platforms": [
@@ -67,6 +67,6 @@
   "rvm": {
     "repo": "https://github.com/ruvnet/rvm",
     "rvmVersionMin": null,
-    "rvmVersionMinNote": "Populated when rvm-rvf ships a versioned RVF execution contract (ADR-284)."
+    "rvmVersionMinNote": "The contract constant exists in rvm-rvf; a minimum remains unpublished until an RVM release is validated against this matrix."
   }
 }

--- a/scripts/check-adr155-status.sh
+++ b/scripts/check-adr155-status.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+adr="$repo_root/docs/adr/ADR-155-rvf-execution-contract.md"
+matrix="$repo_root/docs/rvforge-compatibility-matrix.json"
+
+test -f "$adr"
+test -f "$matrix"
+jq -e '
+  .schemaVersion == 1 and
+  .runtimeProfiles["os-isolation+wasm"].status == "planned" and
+  .runtimeProfiles["rvm-native"].status == "planned" and
+  .rvm.rvmVersionMin == null
+' "$matrix" >/dev/null
+
+for criterion in 1 2 3 4 5 6 7 8; do
+  grep -Eq "^\\| ${criterion} \\|" "$adr"
+done
+
+grep -Fq 'Current implementation status' "$adr"
+grep -Fq 'ruvnet/rvm/issues/24' "$adr"
+grep -Fq 'ruvnet/rvm/issues/25' "$adr"


### PR DESCRIPTION
## Summary

- map all eight ADR-155 acceptance criteria to current implementation evidence
- correct present-tense hosted-isolation and checkpoint portability claims
- mark `os-isolation+wasm` planned until platform evidence exists
- clarify why `rvmVersionMin` remains unpublished
- add a CI check for matrix paths/status and the acceptance evidence table

Fixes #28

## Verification

- `bash -n scripts/check-adr155-status.sh`
- `scripts/check-adr155-status.sh`
- `jq empty docs/rvforge-compatibility-matrix.json`

## Adversarial review

**NO BLOCK after correction.** The first edit accidentally changed the plain WASM profile instead of the similarly named hosted profile; the new executable check caught the mismatch. Rechecked all eight criteria against source and retained the target contract without claiming implementation or validation. Residual risk: the RuVector canonical matrix must be reconciled separately by its owners.