### PR TITLE
feat(context): add capability-governed ruv:// namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64ct"
-version = "1.8.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beef"
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -730,6 +730,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -1270,6 +1286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1299,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -1423,6 +1451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1653,6 +1682,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1806,10 +1870,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rvm-anchor"
@@ -1828,6 +1917,7 @@ dependencies = [
  "criterion",
  "rvm-cap",
  "rvm-coherence",
+ "rvm-context",
  "rvm-gpu",
  "rvm-memory",
  "rvm-proof",
@@ -1866,6 +1956,21 @@ dependencies = [
  "rvm-partition",
  "rvm-sched",
  "rvm-types",
+]
+
+[[package]]
+name = "rvm-context"
+version = "0.1.1"
+dependencies = [
+ "ed25519-dalek",
+ "proptest",
+ "rvm-cap",
+ "rvm-proof",
+ "rvm-rvf",
+ "rvm-types",
+ "rvm-witness",
+ "sha2",
+ "sha3",
 ]
 
 [[package]]
@@ -2251,6 +2356,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,6 +2628,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2887,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/rvm-security",
     "crates/rvm-host",
     "crates/rvm-launch",
+    "crates/rvm-context",
     "crates/rvm-gpu",
     "crates/rvm-kernel",
     "tests",
@@ -53,6 +54,7 @@ rvm-wasm = { path = "crates/rvm-wasm" }
 rvm-rvf = { path = "crates/rvm-rvf" }
 rvm-host = { path = "crates/rvm-host" }
 rvm-launch = { path = "crates/rvm-launch" }
+rvm-context = { path = "crates/rvm-context" }
 rvm-security = { path = "crates/rvm-security" }
 rvm-kernel = { path = "crates/rvm-kernel" }
 rvm-gpu = { path = "crates/rvm-gpu" }
@@ -69,7 +71,7 @@ bitflags = { version = "2", default-features = false }
 
 # Testing
 criterion = { version = "0.5", features = ["html_reports"] }
-proptest = "1.5"
+proptest = "=1.5.0"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 [![Rust](https://img.shields.io/badge/Rust-1.77+-orange.svg)](https://www.rust-lang.org)
 [![no_std](https://img.shields.io/badge/no__std-compatible-green.svg)](https://doc.rust-lang.org/reference/names/preludes.html)
 [![License](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
-[![ADR](https://img.shields.io/badge/ADRs-132--144-purple.svg)](docs/adr/)
-[![Tests](https://img.shields.io/badge/tests-945_passing-brightgreen.svg)](https://github.com/ruvnet/rvm)
+[![ADR](https://img.shields.io/badge/ADRs-index-purple.svg)](docs/adr/)
+[![Tests](https://img.shields.io/badge/tests-see_CI-informational.svg)](https://github.com/ruvnet/rvm/actions)
 [![GPU](https://img.shields.io/badge/GPU-CUDA%20%7C%20Metal%20%7C%20WebGPU-blue.svg)](docs/adr/ADR-144-gpu-compute-support.md)
-[![Nightly](https://img.shields.io/badge/Nightly-Verified%20Releases-brightgreen.svg)](https://github.com/ruvnet/rvm/releases)
+[![Nightly](https://img.shields.io/badge/Nightly-Releases-informational.svg)](https://github.com/ruvnet/rvm/releases)
 [![EPIC](https://img.shields.io/badge/EPIC-ruvnet%2FRuVector%23328-brightgreen.svg)](https://github.com/ruvnet/RuVector/issues/328)
 
 ### **Agents don't fit in VMs. They need something that understands how they think.**
 
-> **945 tests. 15 crates. 6 GPU backends. Zero regressions.** RVM automatically detects new [Claude Code](https://www.npmjs.com/package/@anthropic-ai/claude-code) releases, runs full verification with AI-powered discovery analysis, and publishes verified nightly builds. See [Releases](https://github.com/ruvnet/rvm/releases) | [User Guide](userguide/) | [pi.ruv.io](https://pi.ruv.io)
+> **19 runtime and library crates, plus integration and benchmark packages.** RVM automatically detects new [Claude Code](https://www.npmjs.com/package/@anthropic-ai/claude-code) releases, runs its release workflow, and publishes nightly builds. See [Releases](https://github.com/ruvnet/rvm/releases) | [User Guide](userguide/) | [pi.ruv.io](https://pi.ruv.io)
 
-> Part of the [RuVector](https://github.com/ruvnet/RuVector) ecosystem. Uses [RuVix](../../crates/ruvix/) kernel primitives and [RVF](../../crates/rvf/) package format. Designed for [Cognitum](https://cognitum.one) Seed, Appliance, and future chip targets.
+> Part of the [RuVector](https://github.com/ruvnet/RuVector) ecosystem. Uses [RuVix](ruvector/crates/ruvix/) kernel primitives and [RVF](ruvector/crates/rvf/) package format. Designed for [Cognitum](https://cognitum.one) Seed, Appliance, and future chip targets.
 
 Traditional hypervisors were built for an era of static server workloads —
 long-running VMs with predictable resource needs. AI agents are different.
@@ -181,8 +181,10 @@ Layer 0: Machine Entry (assembly, <500 LoC)
 | `rvm-kernel` | Full integration: coherence engine, IPC→graph feeding, scheduler, split/merge, security gates, tier management |
 | `rvm-gpu` | GPU compute subsystem: device, context, kernel, buffer, queue, budget (optional, feature-gated) |
 | `rvm-rvf` | RVF loader for RVForge packages: manifest verification, per-segment verification, capability mapping, identity preservation ([ADR-155](docs/adr/ADR-155-rvf-execution-contract.md)) |
+| `rvm-anchor` | Verifies external evaluation receipts and anchors their commitments into the RVM witness chain ([ADR-156](docs/adr/ADR-156-external-receipt-anchoring.md)) |
 | `rvm-host` | Per-OS adapters and isolation mechanisms: picks the strongest available isolation, places the agent, spawns it |
 | `rvm-launch` | Instance lifecycle over the adapters: `inspect`, `verify`, run, suspend, resume, checkpoint, witness, terminate ([ADR-289](https://github.com/ruvnet/RuVector/tree/main/docs/adr)) |
+| `rvm-context` | Capability-governed `ruv://` names, immutable RVF revisions, CAS aliases, progressive views, and epoch receipts ([ADR-157](docs/adr/ADR-157-ruv-context-namespace.md)) |
 
 ### Dependency Graph
 
@@ -194,12 +196,20 @@ rvm-types (foundation, no deps)
     ├── rvm-proof ← rvm-cap + rvm-witness
     ├── rvm-partition ← rvm-hal + rvm-cap + rvm-witness
     ├── rvm-sched ← rvm-partition + rvm-witness
-    ├── rvm-memory ← rvm-hal + rvm-partition + rvm-witness
+    ├── rvm-memory
     ├── rvm-coherence ← rvm-partition + rvm-sched [OPTIONAL]
     ├── rvm-boot ← rvm-hal + rvm-partition + rvm-witness + rvm-sched + rvm-memory
     ├── rvm-wasm ← rvm-partition + rvm-cap + rvm-witness [OPTIONAL]
-    ├── rvm-security ← rvm-cap + rvm-proof + rvm-witness
-    └── rvm-kernel ← ALL
+    ├── rvm-security ← rvm-witness
+    ├── rvm-gpu
+    ├── rvm-rvf ← rvm-cap + rvm-witness
+    ├── rvm-anchor ← rvm-witness
+    ├── rvm-host ← rvm-cap + rvm-witness + rvm-partition + rvm-wasm + rvm-rvf
+    ├── rvm-launch ← rvm-witness + rvm-wasm + rvm-rvf + rvm-host
+    ├── rvm-context ← rvm-cap + rvm-witness + rvm-proof + rvm-rvf
+    └── rvm-kernel ← rvm-hal + rvm-cap + rvm-witness + rvm-proof +
+                     rvm-partition + rvm-sched + rvm-memory + rvm-coherence +
+                     rvm-boot + rvm-wasm + rvm-security + rvm-gpu
 ```
 
 ---
@@ -210,10 +220,10 @@ rvm-types (foundation, no deps)
 # Check (no_std by default)
 cargo check
 
-# Run all 945 tests
+# Run workspace library tests
 cargo test --workspace --lib
 
-# Run 21 criterion benchmarks
+# Run Criterion benchmarks
 cargo bench
 
 # Build with std support
@@ -274,6 +284,11 @@ Run `cargo bench` for full criterion results with HTML reports.
 
 ## Implementation Status
 
+The numeric counts below are the repository's legacy documented snapshot, not
+release evidence for this change. Newer crates are listed without invented
+counts; use the current CI run for authoritative test results. ADR-157 keeps
+its acceptance evidence marked planned until that run is attached.
+
 | Crate | Tests | Key Features |
 |-------|-------|-------------|
 | `rvm-types` | ~40 types | 64-byte `WitnessRecord` (compile-time asserted), ~40 `ActionKind` variants, 34 error variants |
@@ -287,12 +302,17 @@ Run `cargo bench` for full criterion results with HTML reports.
 | `rvm-coherence` | 59 | Unified coherence engine, pluggable MinCut/Coherence backends, edge decay, bridge to ruvector |
 | `rvm-boot` | 26 | 7-phase measured boot, attestation digest, HAL init, entry point |
 | `rvm-wasm` | 33 | 7-state agent lifecycle, `HostContext` trait, section parser (13 section types), migration |
+| `rvm-rvf` | — | Full-container identity, structural and segment checks, capability mapping, verified-package boundary |
+| `rvm-anchor` | — | External receipt verification and domain-separated witness anchoring |
 | `rvm-security` | 45 | Unified security gate (P1/P2/P3), `SignedSecurityGate` with per-link signature verification, input validation, attestation chain, DMA budget |
+| `rvm-host` | — | Isolation selection and placement for verified RVF packages |
+| `rvm-launch` | — | Verified instance lifecycle, checkpoint lineage, and witnessed refusals |
+| `rvm-context` | — | Strict `ruv://` parser, live capability scopes, immutable RVF objects, CAS aliases, views, and epoch receipts |
 | `rvm-kernel` | 62 | Full integration: IPC→coherence, scheduler, split/merge, security gates, degraded mode, device leases, tier mgmt |
 | `rvm-gpu` | 65 | Device/context/kernel/buffer/queue management, 4-dimensional budget, coherence acceleration configs |
 | **Integration** | 48 | 17 e2e scenarios: agent lifecycle, split pressure, memory tiers, cap chain, boot timing |
 | **Benchmarks** | 21 | Criterion benchmarks for all performance-critical paths |
-| **Total** | **945** | **0 failures, 0 clippy warnings** |
+| **Legacy documented total** | **945** | **Excludes rows marked —; consult current CI for pass/fail evidence** |
 
 ### Security Audit Results
 
@@ -362,7 +382,7 @@ Capability-based isolation, proof-gated execution, and witness attestation on mi
 
 | # | Criterion | Target |
 |---|-----------|--------|
-| 1 | All 13 crates compile with `#![no_std]` and `#![forbid(unsafe_code)]` | Enforced |
+| 1 | Workspace runtime crates preserve their declared `no_std` and safe-Rust policies | CI gate |
 | 2 | Cold boot to first witness | < 250ms on Appliance hardware |
 | 3 | Hot partition switch | < 10 microseconds |
 | 4 | Witness record is exactly 64 bytes, cache-line aligned | Compile-time asserted |
@@ -581,10 +601,10 @@ brew install qemu  # macOS
 ```bash
 # 1. Clone and verify (--recurse-submodules pulls ruvector + rudevolution)
 git clone --recurse-submodules https://github.com/ruvnet/rvm.git && cd rvm
-cargo test --workspace --lib    # 945 tests, 0 failures
+cargo test --workspace --lib    # Run the current workspace library suite
 
 # 2. Run benchmarks
-cargo bench -p rvm-benches      # 11 criterion benchmarks
+cargo bench -p rvm-benches      # Criterion benchmark suite
 
 # 3. Build for bare metal
 rustup target add aarch64-unknown-none
@@ -608,25 +628,27 @@ use rvm_kernel::{
 
 ### Full User Guide
 
-The [`userguide/`](userguide/) directory contains 17 chapters covering every subsystem:
+The [`userguide/`](userguide/) directory contains 16 numbered chapters covering
+the kernel, artifact, and governed-context subsystems:
 
 | Chapter | Topic |
 |---------|-------|
 | [01 Quick Start](userguide/01-quickstart.md) | Build, test, and boot in 5 minutes |
 | [02 Core Concepts](userguide/02-core-concepts.md) | Partitions, capabilities, witnesses, proofs, coherence |
 | [03 Architecture](userguide/03-architecture.md) | Layer diagram, data flow, boot sequence, feature flags |
-| [04 Crate Reference](userguide/04-crate-reference.md) | All 13 crates with types, APIs, and dependencies |
+| [04 Crate Reference](userguide/04-crate-reference.md) | Workspace crate types, APIs, and dependencies |
 | [05 Capabilities & Proofs](userguide/05-capabilities-proofs.md) | 7 rights, delegation trees, 3 proof tiers, TEE |
 | [06 Witness & Audit](userguide/06-witness-audit.md) | 64-byte records, hash chains, signing, querying |
 | [07 Partitions & Scheduling](userguide/07-partitions-scheduling.md) | Lifecycle, IPC, split/merge, 2-signal scheduler |
 | [08 Memory Model](userguide/08-memory-model.md) | 4 tiers, buddy allocator, reconstruction |
 | [09 WASM Agents](userguide/09-wasm-agents.md) | Module validation, 7-state lifecycle, migration |
 | [10 Security](userguide/10-security.md) | 3-stage gate, attestation, audit results |
-| [11 Performance](userguide/11-performance.md) | 11 benchmarks, build profiles, tuning |
+| [11 Performance](userguide/11-performance.md) | Benchmark methodology, build profiles, tuning |
 | [12 Bare Metal](userguide/12-bare-metal.md) | Linker script, QEMU, measured boot, Seed/Appliance |
 | [13 Advanced & Exotic](userguide/13-advanced-exotic.md) | 6 novel capabilities, fault rollback, RuVector |
 | [14 Troubleshooting](userguide/14-troubleshooting.md) | 12 categories of common issues |
 | [15 Glossary](userguide/15-glossary.md) | 60+ terms with cross-references |
+| [16 Governed `ruv://` Context](userguide/16-ruv-context.md) | Canonical names, capabilities, immutable RVF revisions, CAS aliases, views, and receipts |
 | [Cross-Reference](userguide/cross-reference.md) | Concept index, API finder, "I want to..." tasks |
 
 </details>
@@ -685,6 +707,40 @@ node dist/cli.js h "deploy"   # howto
 ```
 
 </details>
+
+---
+
+## Governed `ruv://` Context
+
+`rvm-context` adds a canonical logical namespace for resources, memories, and
+skills while keeping authority in live RVM capabilities:
+
+```text
+# Mutable, human-friendly alias
+ruv://context.example/acme/agent/researcher/skills/web-search?view=overview
+
+# Immutable citation to the complete RVF bytes
+ruv://context.example/acme/agent/researcher/skills/web-search?rev=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&view=content
+```
+
+| Property | Contract |
+|---|---|
+| Identity | A pinned revision is SHA-256 over the complete RVF byte stream |
+| Authority | Capability handle and exact namespace grant travel out of band; a URI never grants access |
+| Retrieval boundary | Authorization and its witness record occur before resolver access or search enumeration |
+| Mutation | Pinned bytes are immutable; versionless aliases advance by full-snapshot compare-and-swap |
+| Representation | Abstract, overview, and content views are digest-bound through a profile in the existing RVF `PROFILE` segment |
+| Execution | Reading a skill never executes it; `EXECUTE` requires a pinned URI and returns a permit for the verified launch path |
+| Audit durability | Contiguous RVM witness ranges are signed as epoch receipts and committed through the existing RVF `WITNESS` segment |
+
+The implementation takes inspiration from OpenViking's unified hierarchy and
+progressive context patterns, but it is an independent RVM-native design and
+does not copy OpenViking code. `ruv://` is a logical identifier, not a network
+transport or a registered public URI scheme.
+
+See [the user guide](userguide/16-ruv-context.md) and
+[ADR-157](docs/adr/ADR-157-ruv-context-namespace.md) for the canonical grammar,
+threat model, receipt bridge, limits, and planned acceptance evidence.
 
 ---
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -16,6 +16,7 @@ rvm-coherence = { workspace = true }
 rvm-memory = { workspace = true }
 rvm-proof = { workspace = true }
 rvm-security = { workspace = true }
+rvm-context = { workspace = true }
 rvm-gpu = { workspace = true }
 criterion = { workspace = true }
 
@@ -33,4 +34,8 @@ harness = false
 
 [[bench]]
 name = "gpu_bench"
+harness = false
+
+[[bench]]
+name = "context"
 harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -12,9 +12,8 @@ RVM design constraints. It is not published and exists solely for
 |-----------|------|------------------|
 | `coherence` | `benches/coherence.rs` | `EmaFilter::update` throughput (fixed-point EMA computation) |
 | `witness` | `benches/witness.rs` | `WitnessLog::append` throughput (256-slot ring buffer) |
-
-A placeholder benchmark (`rvm_bench.rs`) is also present for future
-expansion.
+| `context` | `benches/context.rs` | Canonical `ruv://` parse and format latency |
+| `rvm_bench` | `benches/rvm_bench.rs` | Integrated witness, capability, proof, partition, coherence, memory, security, and GPU hot paths |
 
 ## Running
 

--- a/benches/benches/context.rs
+++ b/benches/benches/context.rs
@@ -1,0 +1,29 @@
+//! Benchmarks for canonical `ruv://` parsing.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rvm_context::RuvUri;
+
+const ALIAS: &str =
+    "ruv://context.example/acme/agent/researcher/resources/projects/orion/spec?view=overview";
+const PINNED: &str = concat!(
+    "ruv://context.example/acme/agent/researcher/skills/web-search?rev=sha256:",
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "&view=content",
+);
+
+fn bench_context_uri(c: &mut Criterion) {
+    c.bench_function("ruv_uri_parse_alias", |b| {
+        b.iter(|| RuvUri::parse(black_box(ALIAS)).unwrap());
+    });
+    c.bench_function("ruv_uri_parse_pinned", |b| {
+        b.iter(|| RuvUri::parse(black_box(PINNED)).unwrap());
+    });
+
+    let parsed = RuvUri::parse(PINNED).unwrap();
+    c.bench_function("ruv_uri_format_pinned", |b| {
+        b.iter(|| black_box(&parsed).to_string());
+    });
+}
+
+criterion_group!(benches, bench_context_uri);
+criterion_main!(benches);

--- a/crates/rvm-anchor/Cargo.toml
+++ b/crates/rvm-anchor/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib"]
 rvm-types = { workspace = true }
 rvm-witness = { workspace = true }
 sha2 = { workspace = true }
-ed25519-dalek = { version = "2.1", default-features = false }
+ed25519-dalek = { version = "=2.1.1", default-features = false }
 
 [dev-dependencies]
 

--- a/crates/rvm-context/Cargo.toml
+++ b/crates/rvm-context/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "rvm-rvf"
+name = "rvm-context"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "RVF execution contract for RVM: verify-before-load, capability mapping, witnessed results (ADR-284, ADR-286)"
-keywords = ["rvf", "hypervisor", "capability", "no_std", "verification"]
+description = "Capability-gated ruv context namespace for RVM"
+keywords = ["context", "capability", "rvf", "no_std"]
 categories = ["no-std", "embedded", "os"]
 
 [lib]
@@ -17,13 +17,14 @@ crate-type = ["rlib"]
 rvm-types = { workspace = true }
 rvm-cap = { workspace = true }
 rvm-witness = { workspace = true }
+rvm-proof = { workspace = true }
+rvm-rvf = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
-subtle = { workspace = true }
-xxhash-rust = { workspace = true }
-ed25519-dalek = { version = "=2.1.1", default-features = false }
 
 [dev-dependencies]
+ed25519-dalek = { version = "=2.1.1", default-features = false }
+proptest = { workspace = true }
 
 [features]
 default = []
@@ -31,8 +32,6 @@ std = [
     "rvm-types/std",
     "rvm-cap/std",
     "rvm-witness/std",
-    "sha2/std",
-    "sha3/std",
-    "subtle/std",
-    "ed25519-dalek/std",
+    "rvm-proof/std",
+    "rvm-rvf/std",
 ]

--- a/crates/rvm-context/src/capability.rs
+++ b/crates/rvm-context/src/capability.rs
@@ -1,0 +1,1132 @@
+//! Live capability binding and authorization for `ruv://` operations.
+//!
+//! A URI is never authority. This module resolves an opaque capability handle
+//! against a live [`CapabilityManager`], then verifies its generation, epoch,
+//! rights, type, owner, and trusted namespace binding before any resolver is
+//! called. Raw [`rvm_types::CapToken`] values are intentionally not accepted.
+
+use crate::error::{ContextError, ContextResult};
+use crate::uri::{Authority, Collection, PathSegment, ProgressiveView, RuvUri, Subject, TenantId};
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use rvm_cap::{CapManagerConfig, CapabilityManager};
+use rvm_types::{ActionKind, CapRights, CapType, PartitionId, WitnessRecord};
+use rvm_witness::WitnessLog;
+use sha2::{Digest, Sha256};
+
+/// Maximum number of entries returned by one governed search.
+pub const MAX_SEARCH_RESULTS: usize = 64;
+
+/// An index and generation pair into the live RVM capability table.
+///
+/// Handles are safe to accept from an untrusted caller because authorization
+/// always resolves them through the manager and rejects stale generations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CapabilityHandle {
+    index: u32,
+    generation: u32,
+}
+
+impl CapabilityHandle {
+    /// Construct a handle received from an RVM partition boundary.
+    #[must_use]
+    pub const fn new(index: u32, generation: u32) -> Self {
+        Self { index, generation }
+    }
+
+    /// Return the capability-table index.
+    #[must_use]
+    pub const fn index(self) -> u32 {
+        self.index
+    }
+
+    /// Return the generation used for stale-handle detection.
+    #[must_use]
+    pub const fn generation(self) -> u32 {
+        self.generation
+    }
+}
+
+/// A governed operation over the context namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ContextOperation {
+    /// Resolve an immutable revision or versionless alias.
+    Resolve = 0,
+    /// List direct children below a context path.
+    List = 1,
+    /// Traverse context containment below a path.
+    Tree = 2,
+    /// Read context bytes or a derived representation.
+    Read = 3,
+    /// Enumerate semantically relevant context candidates.
+    Search = 4,
+    /// Inspect prior immutable revisions of an alias.
+    History = 5,
+    /// Verify a revision and produce proof material.
+    Verify = 6,
+    /// Register a new immutable whole-RVF revision.
+    Put = 7,
+    /// Advance a versionless alias with compare-and-swap.
+    CompareAndSwapAlias = 8,
+    /// Advance an alias to a tombstone revision.
+    Forget = 9,
+    /// Authorize execution without granting readable bytes.
+    Execute = 10,
+    /// Delegate a narrower context capability.
+    Grant = 11,
+    /// Revoke a context capability lineage.
+    Revoke = 12,
+    /// Seal witnessed decisions into an external receipt.
+    SealReceipt = 13,
+}
+
+impl ContextOperation {
+    /// Return the exact RVM rights required for this operation.
+    #[must_use]
+    pub const fn required_rights(self) -> CapRights {
+        match self {
+            Self::Resolve | Self::List | Self::Tree | Self::Read | Self::Search | Self::History => {
+                CapRights::READ
+            }
+            Self::Verify => CapRights::READ.union(CapRights::PROVE),
+            Self::Put | Self::CompareAndSwapAlias | Self::Forget => CapRights::WRITE,
+            Self::Execute => CapRights::EXECUTE,
+            Self::Grant => CapRights::GRANT,
+            Self::Revoke => CapRights::REVOKE,
+            Self::SealReceipt => CapRights::PROVE,
+        }
+    }
+
+    /// Return the witness action emitted after a successful operation.
+    #[must_use]
+    pub const fn action_kind(self) -> ActionKind {
+        match self {
+            Self::Resolve | Self::List | Self::Tree | Self::History | Self::Verify => {
+                ActionKind::ContextResolve
+            }
+            Self::Read => ActionKind::ContextRead,
+            Self::Search => ActionKind::ContextSearch,
+            Self::Put => ActionKind::ContextPut,
+            Self::CompareAndSwapAlias => ActionKind::ContextAliasUpdate,
+            Self::Forget => ActionKind::ContextForget,
+            Self::Execute => ActionKind::ContextExecute,
+            Self::Grant => ActionKind::CapabilityGrant,
+            Self::Revoke => ActionKind::CapabilityRevoke,
+            Self::SealReceipt => ActionKind::ContextEpochSeal,
+        }
+    }
+
+    fn required_view_bit(self, explicit: Option<ProgressiveView>) -> u8 {
+        if let Some(view) = explicit {
+            return view_bit(view);
+        }
+        match self {
+            Self::Resolve | Self::List | Self::Tree | Self::History | Self::Verify => {
+                ContextViewMask::MANIFEST.0
+            }
+            Self::Read => ContextViewMask::CONTENT.0,
+            Self::Search => ContextViewMask::OVERVIEW.0,
+            Self::Put
+            | Self::CompareAndSwapAlias
+            | Self::Forget
+            | Self::Execute
+            | Self::Grant
+            | Self::Revoke
+            | Self::SealReceipt => 0,
+        }
+    }
+
+    fn target_shape_is_valid(self, target: &RuvUri) -> bool {
+        match self {
+            Self::Put | Self::Verify | Self::SealReceipt => {
+                target.is_pinned() && target.view().is_none()
+            }
+            Self::Execute => {
+                target.is_pinned()
+                    && target.view().is_none()
+                    && target.collection() == Collection::Skills
+            }
+            Self::List | Self::Tree | Self::History | Self::CompareAndSwapAlias | Self::Forget => {
+                !target.is_pinned() && target.view().is_none()
+            }
+            Self::Grant | Self::Revoke => target.view().is_none(),
+            Self::Resolve | Self::Read | Self::Search => true,
+        }
+    }
+}
+
+/// Bit mask of progressive representations a context grant may disclose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContextViewMask(u8);
+
+impl ContextViewMask {
+    /// Permit manifest metadata.
+    pub const MANIFEST: Self = Self(0x01);
+    /// Permit the compact abstract representation.
+    pub const ABSTRACT: Self = Self(0x02);
+    /// Permit the navigational overview representation.
+    pub const OVERVIEW: Self = Self(0x04);
+    /// Permit full L2 content bytes.
+    pub const CONTENT: Self = Self(0x08);
+    /// Backward-compatible spelling for full L2 content bytes.
+    pub const RAW: Self = Self::CONTENT;
+    /// Permit every v1 representation.
+    pub const ALL: Self = Self(0x0f);
+
+    /// Construct a mask from known bits, rejecting reserved bits.
+    #[must_use]
+    pub const fn from_bits(bits: u8) -> Option<Self> {
+        if bits != 0 && bits & !Self::ALL.0 == 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    /// Return the underlying stable bit representation.
+    #[must_use]
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// Combine two view masks.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Whether this mask permits a representation.
+    #[must_use]
+    pub const fn allows(self, view: ProgressiveView) -> bool {
+        let bit = view_bit(view);
+        self.0 & bit == bit
+    }
+
+    /// Whether `other` is equal to or narrower than this mask.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+const fn view_bit(view: ProgressiveView) -> u8 {
+    match view {
+        ProgressiveView::Abstract => ContextViewMask::ABSTRACT.0,
+        ProgressiveView::Overview => ContextViewMask::OVERVIEW.0,
+        ProgressiveView::Content => ContextViewMask::CONTENT.0,
+    }
+}
+
+/// A trusted namespace and path-prefix binding for one capability lineage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextScope {
+    authority: Authority,
+    tenant: TenantId,
+    subject: Subject,
+    collection: Collection,
+    path_prefix: Vec<PathSegment>,
+    views: ContextViewMask,
+}
+
+impl ContextScope {
+    /// Bind a scope to the typed identity and segment prefix of `root`.
+    ///
+    /// A revision and view on `root` do not become part of the authority;
+    /// revision immutability and requested views are checked independently.
+    #[must_use]
+    pub fn from_uri(root: &RuvUri, views: ContextViewMask) -> Self {
+        Self {
+            authority: root.authority().clone(),
+            tenant: root.tenant().clone(),
+            subject: root.subject().clone(),
+            collection: root.collection(),
+            path_prefix: root.path().to_vec(),
+            views,
+        }
+    }
+
+    /// Return the bound authority.
+    #[must_use]
+    pub const fn authority(&self) -> &Authority {
+        &self.authority
+    }
+
+    /// Return the bound tenant.
+    #[must_use]
+    pub const fn tenant(&self) -> &TenantId {
+        &self.tenant
+    }
+
+    /// Return the bound subject.
+    #[must_use]
+    pub const fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    /// Return the bound collection.
+    #[must_use]
+    pub const fn collection(&self) -> Collection {
+        self.collection
+    }
+
+    /// Return the path-segment prefix.
+    #[must_use]
+    pub fn path_prefix(&self) -> &[PathSegment] {
+        &self.path_prefix
+    }
+
+    /// Return the permitted progressive representations.
+    #[must_use]
+    pub const fn views(&self) -> ContextViewMask {
+        self.views
+    }
+
+    /// Whether `child` is equal to or narrower than this trusted scope.
+    #[must_use]
+    pub fn contains_scope(&self, child: &Self) -> bool {
+        self.authority == child.authority
+            && self.tenant == child.tenant
+            && self.subject == child.subject
+            && self.collection == child.collection
+            && path_has_prefix(&child.path_prefix, &self.path_prefix)
+            && self.views.contains(child.views)
+    }
+
+    fn allows(&self, target: &RuvUri, operation: ContextOperation) -> bool {
+        if &self.authority != target.authority()
+            || &self.tenant != target.tenant()
+            || &self.subject != target.subject()
+            || self.collection != target.collection()
+            || !path_has_prefix(target.path(), &self.path_prefix)
+        {
+            return false;
+        }
+        let required_view = operation.required_view_bit(target.view());
+        self.views.bits() & required_view == required_view
+    }
+
+    fn fingerprint(&self) -> u64 {
+        let mut hasher = Sha256::new();
+        hasher.update(b"RUV-CONTEXT-SCOPE-V1");
+        hasher.update(self.authority.to_string().as_bytes());
+        hasher.update([0]);
+        hasher.update(self.tenant.to_string().as_bytes());
+        hasher.update([0]);
+        hasher.update(self.subject.kind().as_str().as_bytes());
+        hasher.update([0]);
+        hasher.update(self.subject.id().as_str().as_bytes());
+        hasher.update([0]);
+        hasher.update(self.collection.to_string().as_bytes());
+        for segment in &self.path_prefix {
+            hasher.update([0xff]);
+            hasher.update(segment.to_string().as_bytes());
+        }
+        hasher.update([self.views.bits()]);
+        let digest = hasher.finalize();
+        let mut first = [0u8; 8];
+        first.copy_from_slice(&digest[..8]);
+        u64::from_le_bytes(first)
+    }
+}
+
+fn path_has_prefix(path: &[PathSegment], prefix: &[PathSegment]) -> bool {
+    path.len() >= prefix.len() && &path[..prefix.len()] == prefix
+}
+
+/// One request presented to the governed runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextRequest {
+    capability: CapabilityHandle,
+    operation: ContextOperation,
+    target: RuvUri,
+}
+
+impl ContextRequest {
+    /// Construct an untrusted request. Authorization occurs later.
+    #[must_use]
+    pub fn new(capability: CapabilityHandle, operation: ContextOperation, target: RuvUri) -> Self {
+        Self {
+            capability,
+            operation,
+            target,
+        }
+    }
+
+    /// Return the opaque capability handle.
+    #[must_use]
+    pub const fn capability(&self) -> CapabilityHandle {
+        self.capability
+    }
+
+    /// Return the requested operation.
+    #[must_use]
+    pub const fn operation(&self) -> ContextOperation {
+        self.operation
+    }
+
+    /// Return the canonical target.
+    #[must_use]
+    pub const fn target(&self) -> &RuvUri {
+        &self.target
+    }
+}
+
+/// A request proven against the live capability and trusted scope tables.
+///
+/// Fields and construction are private. Resolver implementations receive this
+/// type only after the runtime has appended a P1 allow witness record.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuthorizedRequest {
+    actor: PartitionId,
+    operation: ContextOperation,
+    target: RuvUri,
+    capability_hash: u32,
+    witness_sequence: u64,
+    timestamp_ns: u64,
+}
+
+impl AuthorizedRequest {
+    /// Return the authorized actor.
+    #[must_use]
+    pub const fn actor(&self) -> PartitionId {
+        self.actor
+    }
+
+    /// Return the one authorized operation.
+    #[must_use]
+    pub const fn operation(&self) -> ContextOperation {
+        self.operation
+    }
+
+    /// Return the exact authorized target.
+    #[must_use]
+    pub const fn target(&self) -> &RuvUri {
+        &self.target
+    }
+
+    /// Return the non-secret truncated capability identifier.
+    #[must_use]
+    pub const fn capability_hash(&self) -> u32 {
+        self.capability_hash
+    }
+
+    /// Return the allow witness sequence emitted before resolver access.
+    #[must_use]
+    pub const fn witness_sequence(&self) -> u64 {
+        self.witness_sequence
+    }
+}
+
+/// Trusted scope binding for one live capability token identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextGrant {
+    token_id: u64,
+    scope: ContextScope,
+}
+
+impl ContextGrant {
+    /// Return the live capability token identifier this binding protects.
+    #[must_use]
+    pub const fn token_id(&self) -> u64 {
+        self.token_id
+    }
+
+    /// Return the trusted scope.
+    #[must_use]
+    pub const fn scope(&self) -> &ContextScope {
+        &self.scope
+    }
+}
+
+/// A const-bounded trusted binding table.
+///
+/// The table is keyed by live token identifier rather than `CapSlot.badge`:
+/// badges may change during ordinary capability delegation and are therefore
+/// not a safe authority binding.
+#[derive(Debug)]
+pub struct ContextGrantTable<const N: usize> {
+    grants: Vec<ContextGrant>,
+}
+
+impl<const N: usize> ContextGrantTable<N> {
+    /// Create an empty binding table.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { grants: Vec::new() }
+    }
+
+    /// Return the number of trusted bindings.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.grants.len()
+    }
+
+    /// Whether no capability has a trusted binding.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.grants.is_empty()
+    }
+
+    /// Return the compile-time capacity.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        N
+    }
+
+    /// Look up a binding by live token identifier.
+    #[must_use]
+    pub fn get(&self, token_id: u64) -> Option<&ContextGrant> {
+        self.grants.iter().find(|grant| grant.token_id == token_id)
+    }
+
+    fn bind(&mut self, token_id: u64, scope: ContextScope) -> ContextResult<()> {
+        if let Some(existing) = self.get(token_id) {
+            return if existing.scope == scope {
+                Ok(())
+            } else {
+                Err(ContextError::GrantAlreadyBound)
+            };
+        }
+        if self.grants.len() >= N {
+            return Err(ContextError::GrantTableFull);
+        }
+        self.grants.push(ContextGrant { token_id, scope });
+        Ok(())
+    }
+
+    fn retain_live<const C: usize>(&mut self, manager: &CapabilityManager<C>) {
+        self.grants.retain(|grant| {
+            manager
+                .table()
+                .iter()
+                .any(|(_, slot)| slot.token.id() == grant.token_id)
+        });
+    }
+
+    fn clear(&mut self) {
+        self.grants.clear();
+    }
+}
+
+impl<const N: usize> Default for ContextGrantTable<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Owner of live context capabilities and their trusted scope bindings.
+///
+/// Keeping the capability manager inside this authority prevents callers from
+/// minting an unbound `Context` capability through a parallel mutable path.
+pub struct ContextAuthority<const C: usize, const G: usize> {
+    manager: CapabilityManager<C>,
+    grants: ContextGrantTable<G>,
+}
+
+impl<const C: usize, const G: usize> ContextAuthority<C, G> {
+    /// Wrap a capability manager and begin with no trusted context bindings.
+    #[must_use]
+    pub const fn new(manager: CapabilityManager<C>) -> Self {
+        Self {
+            manager,
+            grants: ContextGrantTable::new(),
+        }
+    }
+
+    /// Create an authority with the default RVM capability configuration.
+    #[must_use]
+    pub const fn with_defaults() -> Self {
+        Self::new(CapabilityManager::new(CapManagerConfig::new()))
+    }
+
+    /// Return read-only access to the live capability manager.
+    #[must_use]
+    pub const fn capability_manager(&self) -> &CapabilityManager<C> {
+        &self.manager
+    }
+
+    /// Return read-only access to trusted bindings.
+    #[must_use]
+    pub const fn grants(&self) -> &ContextGrantTable<G> {
+        &self.grants
+    }
+
+    /// Issue and bind a root context capability.
+    ///
+    /// # Errors
+    ///
+    /// Only the hypervisor may issue a root. Capability-table and grant-table
+    /// capacity errors are returned without leaving an unbound live grant.
+    pub fn issue_root(
+        &mut self,
+        scope: ContextScope,
+        rights: CapRights,
+        owner: PartitionId,
+        caller: PartitionId,
+    ) -> ContextResult<CapabilityHandle> {
+        let badge = scope.fingerprint();
+        let (index, generation) = self.manager.create_root_capability_checked(
+            CapType::Context,
+            rights,
+            badge,
+            owner,
+            caller,
+        )?;
+        let handle = CapabilityHandle::new(index, generation);
+        let token_id = self.manager.table().lookup(index, generation)?.token.id();
+        if let Err(error) = self.grants.bind(token_id, scope) {
+            let _ = self.manager.revoke(index, generation);
+            return Err(error);
+        }
+        Ok(handle)
+    }
+
+    /// Bind an existing live context capability supplied by trusted kernel code.
+    ///
+    /// # Errors
+    ///
+    /// Refuses stale handles and every capability type except
+    /// [`CapType::Context`]. This is an administrative integration path, not a
+    /// partition-facing request API.
+    pub fn bind_existing(
+        &mut self,
+        handle: CapabilityHandle,
+        scope: ContextScope,
+    ) -> ContextResult<()> {
+        self.manager
+            .verify_p1(handle.index, handle.generation, CapRights::empty())
+            .map_err(|_| ContextError::AccessDenied)?;
+        let slot = self
+            .manager
+            .table()
+            .lookup(handle.index, handle.generation)
+            .map_err(|_| ContextError::AccessDenied)?;
+        if slot.token.cap_type() != CapType::Context {
+            return Err(ContextError::AccessDenied);
+        }
+        self.grants.bind(slot.token.id(), scope)
+    }
+
+    /// Delegate a capability to an equal or narrower trusted context scope.
+    ///
+    /// # Errors
+    ///
+    /// Refuses scope or view widening, missing `GRANT`, ownership mismatch,
+    /// rights escalation, stale handles, and capacity exhaustion.
+    pub fn delegate(
+        &mut self,
+        source: CapabilityHandle,
+        child_scope: ContextScope,
+        requested_rights: CapRights,
+        target_owner: PartitionId,
+        caller: PartitionId,
+    ) -> ContextResult<CapabilityHandle> {
+        self.manager
+            .verify_p1(source.index, source.generation, CapRights::GRANT)
+            .map_err(|_| ContextError::AccessDenied)?;
+        let source_slot = *self
+            .manager
+            .table()
+            .lookup(source.index, source.generation)
+            .map_err(|_| ContextError::AccessDenied)?;
+        if source_slot.token.cap_type() != CapType::Context || source_slot.owner != caller {
+            return Err(ContextError::AccessDenied);
+        }
+        let parent = self
+            .grants
+            .get(source_slot.token.id())
+            .ok_or(ContextError::AccessDenied)?;
+        if !parent.scope.contains_scope(&child_scope) {
+            return Err(ContextError::ScopeEscalation);
+        }
+
+        let badge = child_scope.fingerprint();
+        let (index, generation) = self.manager.grant_checked(
+            source.index,
+            source.generation,
+            requested_rights,
+            badge,
+            target_owner,
+            caller,
+        )?;
+        let handle = CapabilityHandle::new(index, generation);
+        let token_id = self.manager.table().lookup(index, generation)?.token.id();
+        if let Err(error) = self.grants.bind(token_id, child_scope) {
+            let _ = self.manager.revoke(index, generation);
+            return Err(error);
+        }
+        Ok(handle)
+    }
+
+    /// Revoke a capability and all descendants, then prune stale bindings.
+    ///
+    /// # Errors
+    ///
+    /// Returns the capability manager's error for an invalid or stale handle.
+    pub fn revoke(&mut self, handle: CapabilityHandle) -> ContextResult<usize> {
+        let result = self.manager.revoke(handle.index, handle.generation)?;
+        self.grants.retain_live(&self.manager);
+        Ok(result.revoked_count)
+    }
+
+    /// Rotate the capability epoch, immediately invalidating prior handles.
+    pub fn increment_epoch(&mut self) {
+        self.manager.increment_epoch();
+        self.grants.clear();
+    }
+
+    pub(crate) fn authorize<const W: usize>(
+        &self,
+        actor: PartitionId,
+        timestamp_ns: u64,
+        request: &ContextRequest,
+        expected_operation: ContextOperation,
+        witness: &WitnessLog<W>,
+    ) -> ContextResult<AuthorizedRequest> {
+        let record_denial = |capability_hash| {
+            Self::emit_denied(actor, timestamp_ns, request, witness, capability_hash);
+        };
+        if request.operation != expected_operation
+            || !expected_operation.target_shape_is_valid(&request.target)
+        {
+            record_denial(handle_fingerprint(request.capability));
+            return Err(if request.operation != expected_operation {
+                ContextError::OperationMismatch
+            } else if matches!(
+                expected_operation,
+                ContextOperation::Put
+                    | ContextOperation::Verify
+                    | ContextOperation::Execute
+                    | ContextOperation::SealReceipt
+            ) && !request.target.is_pinned()
+            {
+                ContextError::PinnedUriRequired
+            } else if matches!(
+                expected_operation,
+                ContextOperation::List
+                    | ContextOperation::Tree
+                    | ContextOperation::History
+                    | ContextOperation::CompareAndSwapAlias
+                    | ContextOperation::Forget
+            ) && request.target.is_pinned()
+            {
+                ContextError::VersionlessUriRequired
+            } else {
+                ContextError::InvalidTarget
+            });
+        }
+
+        let rights = expected_operation.required_rights();
+        if self
+            .manager
+            .verify_p1(
+                request.capability.index,
+                request.capability.generation,
+                rights,
+            )
+            .is_err()
+        {
+            record_denial(handle_fingerprint(request.capability));
+            return Err(ContextError::AccessDenied);
+        }
+        let Ok(slot) = self
+            .manager
+            .table()
+            .lookup(request.capability.index, request.capability.generation)
+        else {
+            record_denial(handle_fingerprint(request.capability));
+            return Err(ContextError::AccessDenied);
+        };
+        let token = slot.token;
+        if token.cap_type() != CapType::Context || slot.owner != actor {
+            record_denial(token.truncated_hash());
+            return Err(ContextError::AccessDenied);
+        }
+        let Some(grant) = self.grants.get(token.id()) else {
+            record_denial(token.truncated_hash());
+            return Err(ContextError::AccessDenied);
+        };
+        if !grant.scope.allows(&request.target, expected_operation) {
+            record_denial(token.truncated_hash());
+            return Err(ContextError::AccessDenied);
+        }
+
+        let sequence = emit_decision(
+            witness,
+            ActionKind::ProofVerifiedP1,
+            actor,
+            timestamp_ns,
+            request,
+            token.truncated_hash(),
+        );
+        Ok(AuthorizedRequest {
+            actor,
+            operation: expected_operation,
+            target: request.target.clone(),
+            capability_hash: token.truncated_hash(),
+            witness_sequence: sequence,
+            timestamp_ns,
+        })
+    }
+
+    /// Record a completed resolver operation after validating its result.
+    pub(crate) fn record_success<const W: usize>(
+        request: &AuthorizedRequest,
+        witness: &WitnessLog<W>,
+    ) -> u64 {
+        emit_authorized(witness, request.operation.action_kind(), request)
+    }
+
+    /// Record rejection of an invalid or out-of-scope resolver response.
+    pub(crate) fn record_resolver_rejection<const W: usize>(
+        request: &AuthorizedRequest,
+        witness: &WitnessLog<W>,
+    ) -> u64 {
+        emit_authorized(witness, ActionKind::ProofRejected, request)
+    }
+
+    fn emit_denied<const W: usize>(
+        actor: PartitionId,
+        timestamp_ns: u64,
+        request: &ContextRequest,
+        witness: &WitnessLog<W>,
+        capability_hash: u32,
+    ) {
+        let _ = emit_decision(
+            witness,
+            ActionKind::ProofRejected,
+            actor,
+            timestamp_ns,
+            request,
+            capability_hash,
+        );
+    }
+}
+
+fn emit_authorized<const W: usize>(
+    witness: &WitnessLog<W>,
+    action: ActionKind,
+    request: &AuthorizedRequest,
+) -> u64 {
+    let digest = Sha256::digest(request.target.to_string().as_bytes());
+    emit_record(
+        witness,
+        action,
+        request.operation,
+        request.actor,
+        request.capability_hash,
+        request.timestamp_ns,
+        &digest,
+    )
+}
+
+fn handle_fingerprint(handle: CapabilityHandle) -> u32 {
+    handle.index ^ handle.generation.rotate_left(13)
+}
+
+fn emit_decision<const W: usize>(
+    witness: &WitnessLog<W>,
+    action: ActionKind,
+    actor: PartitionId,
+    timestamp_ns: u64,
+    request: &ContextRequest,
+    capability_hash: u32,
+) -> u64 {
+    let digest = Sha256::digest(request.target.to_string().as_bytes());
+    emit_record(
+        witness,
+        action,
+        request.operation,
+        actor,
+        capability_hash,
+        timestamp_ns,
+        &digest,
+    )
+}
+
+fn emit_record<const W: usize>(
+    witness: &WitnessLog<W>,
+    action: ActionKind,
+    operation: ContextOperation,
+    actor: PartitionId,
+    capability_hash: u32,
+    timestamp_ns: u64,
+    digest: &[u8],
+) -> u64 {
+    let mut target = [0u8; 8];
+    target.copy_from_slice(&digest[..8]);
+    let mut record = WitnessRecord::zeroed();
+    record.action_kind = action as u8;
+    record.proof_tier = 1;
+    record.flags = operation as u8;
+    record.actor_partition_id = actor.as_u32();
+    record.target_object_id = u64::from_le_bytes(target);
+    record.capability_hash = capability_hash;
+    record.payload.copy_from_slice(&digest[8..16]);
+    record.timestamp_ns = timestamp_ns;
+    witness.append(record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+    use core::str::FromStr;
+
+    type AuthorityUnderTest = ContextAuthority<16, 16>;
+
+    fn uri(path: &str, view: Option<&str>, pinned: bool) -> RuvUri {
+        let revision = if pinned {
+            format!("?rev=sha256:{}", "11".repeat(32))
+        } else {
+            alloc::string::String::new()
+        };
+        let view = view.map_or_else(alloc::string::String::new, |value| {
+            if revision.is_empty() {
+                format!("?view={value}")
+            } else {
+                format!("&view={value}")
+            }
+        });
+        let suffix = if path.is_empty() {
+            alloc::string::String::new()
+        } else {
+            format!("/{path}")
+        };
+        RuvUri::from_str(&format!(
+            "ruv://example.com/acme/user/alice/memory{suffix}{revision}{view}"
+        ))
+        .unwrap()
+    }
+
+    fn issue(
+        authority: &mut AuthorityUnderTest,
+        root: &RuvUri,
+        views: ContextViewMask,
+        rights: CapRights,
+        owner: PartitionId,
+    ) -> CapabilityHandle {
+        authority
+            .issue_root(
+                ContextScope::from_uri(root, views),
+                rights,
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn operation_rights_are_total_and_read_execute_are_separate() {
+        assert_eq!(ContextOperation::Read.required_rights(), CapRights::READ);
+        assert_eq!(
+            ContextOperation::Execute.required_rights(),
+            CapRights::EXECUTE
+        );
+        assert_eq!(
+            ContextOperation::Verify.required_rights(),
+            CapRights::READ | CapRights::PROVE
+        );
+        assert_eq!(
+            ContextOperation::CompareAndSwapAlias.required_rights(),
+            CapRights::WRITE
+        );
+    }
+
+    #[test]
+    fn live_generation_epoch_owner_rights_scope_and_view_are_enforced() {
+        let owner = PartitionId::new(7);
+        let root = uri("docs", None, false);
+        let target = uri("docs/item", Some("overview"), false);
+        let mut authority = AuthorityUnderTest::with_defaults();
+        let handle = issue(
+            &mut authority,
+            &root,
+            ContextViewMask::OVERVIEW,
+            CapRights::READ,
+            owner,
+        );
+        let log = WitnessLog::<32>::new();
+
+        let allowed = ContextRequest::new(handle, ContextOperation::Read, target.clone());
+        assert!(authority
+            .authorize(owner, 1, &allowed, ContextOperation::Read, &log)
+            .is_ok());
+
+        let wrong_owner = ContextRequest::new(handle, ContextOperation::Read, target.clone());
+        assert_eq!(
+            authority.authorize(
+                PartitionId::new(8),
+                2,
+                &wrong_owner,
+                ContextOperation::Read,
+                &log
+            ),
+            Err(ContextError::AccessDenied)
+        );
+
+        let sibling = ContextRequest::new(
+            handle,
+            ContextOperation::Read,
+            uri("other/item", Some("overview"), false),
+        );
+        assert_eq!(
+            authority.authorize(owner, 3, &sibling, ContextOperation::Read, &log),
+            Err(ContextError::AccessDenied)
+        );
+
+        let raw = ContextRequest::new(
+            handle,
+            ContextOperation::Read,
+            uri("docs/item", Some("content"), false),
+        );
+        assert_eq!(
+            authority.authorize(owner, 4, &raw, ContextOperation::Read, &log),
+            Err(ContextError::AccessDenied)
+        );
+
+        authority.increment_epoch();
+        assert_eq!(
+            authority.authorize(owner, 5, &allowed, ContextOperation::Read, &log),
+            Err(ContextError::AccessDenied)
+        );
+        assert_eq!(log.total_emitted(), 5);
+    }
+
+    #[test]
+    fn path_prefix_is_segment_aware() {
+        let owner = PartitionId::new(7);
+        let root = uri("foo", None, false);
+        let mut authority = AuthorityUnderTest::with_defaults();
+        let handle = issue(
+            &mut authority,
+            &root,
+            ContextViewMask::OVERVIEW,
+            CapRights::READ,
+            owner,
+        );
+        let log = WitnessLog::<8>::new();
+        let request = ContextRequest::new(
+            handle,
+            ContextOperation::Search,
+            uri("foobar", Some("overview"), false),
+        );
+        assert_eq!(
+            authority.authorize(owner, 1, &request, ContextOperation::Search, &log),
+            Err(ContextError::AccessDenied)
+        );
+    }
+
+    #[test]
+    fn epoch_rotation_releases_stale_grant_capacity() {
+        let owner = PartitionId::new(7);
+        let root = uri("docs", None, false);
+        let mut authority = ContextAuthority::<4, 1>::with_defaults();
+        authority
+            .issue_root(
+                ContextScope::from_uri(&root, ContextViewMask::ALL),
+                CapRights::READ,
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .unwrap();
+        assert_eq!(authority.grants().len(), 1);
+
+        authority.increment_epoch();
+        assert!(authority.grants().is_empty());
+        assert!(authority
+            .issue_root(
+                ContextScope::from_uri(&root, ContextViewMask::ALL),
+                CapRights::READ,
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn read_capability_cannot_execute_and_execute_capability_cannot_read() {
+        let owner = PartitionId::new(7);
+        let root = uri("skills", None, false);
+        let target = RuvUri::parse(&format!(
+            "ruv://example.com/acme/user/alice/skills/tool?rev=sha256:{}",
+            "11".repeat(32)
+        ))
+        .unwrap();
+        let mut authority = AuthorityUnderTest::with_defaults();
+        let read = issue(
+            &mut authority,
+            &root,
+            ContextViewMask::ALL,
+            CapRights::READ,
+            owner,
+        );
+        let execute = issue(
+            &mut authority,
+            &root,
+            ContextViewMask::MANIFEST,
+            CapRights::EXECUTE,
+            owner,
+        );
+        let log = WitnessLog::<8>::new();
+        let execute_with_read =
+            ContextRequest::new(read, ContextOperation::Execute, target.clone());
+        assert_eq!(
+            authority.authorize(
+                owner,
+                1,
+                &execute_with_read,
+                ContextOperation::Execute,
+                &log
+            ),
+            Err(ContextError::AccessDenied)
+        );
+        let read_with_execute = ContextRequest::new(execute, ContextOperation::Read, target);
+        assert_eq!(
+            authority.authorize(owner, 2, &read_with_execute, ContextOperation::Read, &log),
+            Err(ContextError::AccessDenied)
+        );
+    }
+
+    #[test]
+    fn delegation_cannot_widen_path_or_views() {
+        let owner = PartitionId::new(7);
+        let root = uri("docs", None, false);
+        let mut authority = AuthorityUnderTest::with_defaults();
+        let parent = issue(
+            &mut authority,
+            &root,
+            ContextViewMask::OVERVIEW,
+            CapRights::READ | CapRights::GRANT,
+            owner,
+        );
+        let wider_path = ContextScope::from_uri(&uri("", None, false), ContextViewMask::OVERVIEW);
+        assert_eq!(
+            authority.delegate(parent, wider_path, CapRights::READ, owner, owner),
+            Err(ContextError::ScopeEscalation)
+        );
+        let wider_view = ContextScope::from_uri(&root, ContextViewMask::ALL);
+        assert_eq!(
+            authority.delegate(parent, wider_view, CapRights::READ, owner, owner),
+            Err(ContextError::ScopeEscalation)
+        );
+    }
+
+    #[test]
+    fn non_context_capability_cannot_be_bound() {
+        let owner = PartitionId::new(7);
+        let mut manager = CapabilityManager::<8>::with_defaults();
+        let (index, generation) = manager
+            .create_root_capability(CapType::Region, CapRights::READ, 0, owner)
+            .unwrap();
+        let mut authority = ContextAuthority::<8, 8>::new(manager);
+        assert_eq!(
+            authority.bind_existing(
+                CapabilityHandle::new(index, generation),
+                ContextScope::from_uri(&uri("docs", None, false), ContextViewMask::ALL),
+            ),
+            Err(ContextError::AccessDenied)
+        );
+    }
+}

--- a/crates/rvm-context/src/error.rs
+++ b/crates/rvm-context/src/error.rs
@@ -1,0 +1,130 @@
+//! Error types for the governed context namespace.
+
+use core::fmt;
+use rvm_cap::CapError;
+
+/// Errors returned by governed context operations.
+///
+/// Authorization failures deliberately collapse to [`Self::AccessDenied`].
+/// The witness trail retains the attempted operation without exposing whether
+/// an alias, revision, or tenant exists to an unauthorized caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextError {
+    /// The capability, actor, scope, view, or requested right was not valid.
+    AccessDenied,
+    /// A trusted capability binding table reached its configured capacity.
+    GrantTableFull,
+    /// The capability already has a different trusted scope binding.
+    GrantAlreadyBound,
+    /// A delegated grant attempted to widen its parent's scope or views.
+    ScopeEscalation,
+    /// A capability-manager operation failed during issuance or revocation.
+    Capability(CapError),
+    /// The operation requires a pinned, immutable URI.
+    PinnedUriRequired,
+    /// The operation requires a versionless alias URI.
+    VersionlessUriRequired,
+    /// An immutable revision was targeted by a mutation.
+    ImmutableRevision,
+    /// The requested immutable revision is not present.
+    RevisionNotFound,
+    /// Existing bytes or logical identity conflict with an immutable revision.
+    RevisionConflict,
+    /// The requested versionless alias is not present.
+    AliasNotFound,
+    /// Compare-and-swap observed a different alias snapshot.
+    AliasConflict,
+    /// The alias generation counter cannot advance without wrapping.
+    AliasGenerationExhausted,
+    /// The configured object table reached capacity.
+    ObjectTableFull,
+    /// The configured alias table reached capacity.
+    AliasTableFull,
+    /// An RVF object exceeds the bounded in-memory resolver limit.
+    ObjectTooLarge,
+    /// A search query is empty or exceeds its bounded input limit.
+    InvalidQuery,
+    /// A requested result limit is zero or exceeds the public maximum.
+    InvalidResultLimit,
+    /// The alias or immutable object is a tombstone and has no readable body.
+    Tombstoned,
+    /// The request operation does not match the runtime entry point used.
+    OperationMismatch,
+    /// The supplied bytes do not hash to the pinned whole-RVF revision.
+    RevisionHashMismatch,
+    /// RVF structure, signatures, context profile, or view binding failed.
+    RvfVerificationFailed,
+    /// A witness epoch could not be snapshotted, sealed, or encoded.
+    ReceiptSealFailed,
+    /// A URI or stored identity is structurally unsuitable for the operation.
+    InvalidTarget,
+    /// A resolver returned a target outside the authorized request scope.
+    ResolverScopeViolation,
+}
+
+impl fmt::Display for ContextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AccessDenied => f.write_str("context access denied"),
+            Self::GrantTableFull => f.write_str("context grant table is full"),
+            Self::GrantAlreadyBound => {
+                f.write_str("capability already has a different context binding")
+            }
+            Self::ScopeEscalation => f.write_str("delegated context scope widens authority"),
+            Self::Capability(error) => write!(f, "capability operation failed: {error}"),
+            Self::PinnedUriRequired => f.write_str("operation requires a pinned ruv URI"),
+            Self::VersionlessUriRequired => f.write_str("operation requires a versionless ruv URI"),
+            Self::ImmutableRevision => f.write_str("immutable revision cannot be changed"),
+            Self::RevisionNotFound => f.write_str("context revision was not found"),
+            Self::RevisionConflict => f.write_str("immutable context revision conflicts"),
+            Self::AliasNotFound => f.write_str("context alias was not found"),
+            Self::AliasConflict => f.write_str("context alias compare-and-swap conflict"),
+            Self::AliasGenerationExhausted => f.write_str("context alias generation is exhausted"),
+            Self::ObjectTableFull => f.write_str("context object table is full"),
+            Self::AliasTableFull => f.write_str("context alias table is full"),
+            Self::ObjectTooLarge => f.write_str("context object exceeds the size limit"),
+            Self::InvalidQuery => f.write_str("context search query is invalid"),
+            Self::InvalidResultLimit => f.write_str("context result limit is invalid"),
+            Self::Tombstoned => f.write_str("context object has been tombstoned"),
+            Self::OperationMismatch => f.write_str("context runtime operation mismatch"),
+            Self::RevisionHashMismatch => f.write_str("RVF bytes do not match the pinned revision"),
+            Self::RvfVerificationFailed => f.write_str("RVF context profile verification failed"),
+            Self::ReceiptSealFailed => f.write_str("context witness epoch seal failed"),
+            Self::InvalidTarget => f.write_str("context target is invalid for this operation"),
+            Self::ResolverScopeViolation => {
+                f.write_str("resolver returned context outside the authorized scope")
+            }
+        }
+    }
+}
+
+impl From<CapError> for ContextError {
+    fn from(error: CapError) -> Self {
+        Self::Capability(error)
+    }
+}
+
+/// Result type for governed context operations.
+pub type ContextResult<T> = core::result::Result<T, ContextError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errors_have_nonempty_stable_messages() {
+        use alloc::string::ToString;
+
+        let errors = [
+            ContextError::AccessDenied,
+            ContextError::GrantTableFull,
+            ContextError::ImmutableRevision,
+            ContextError::AliasConflict,
+            ContextError::Tombstoned,
+            ContextError::Capability(CapError::StaleHandle),
+        ];
+        for error in errors {
+            assert!(!error.to_string().is_empty());
+        }
+    }
+}

--- a/crates/rvm-context/src/lib.rs
+++ b/crates/rvm-context/src/lib.rs
@@ -1,0 +1,60 @@
+//! Governed cognitive context for RVM through canonical `ruv://` names.
+//!
+//! This crate names context but never treats a name as authority. Every
+//! resolver operation first passes through an RVM capability binding, and
+//! every decision is committed to the witness trail. Immutable revisions are
+//! whole RVF SHA-256 identities; versionless names are mutable aliases changed
+//! only with compare-and-swap.
+//!
+//! The public surface separates inspection, reading, mutation, and execution.
+//! In particular, resolving or reading a skill never confers permission to
+//! execute it.
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+pub mod capability;
+pub mod error;
+pub mod profile;
+pub mod receipt;
+pub mod resolver;
+pub mod runtime;
+pub mod uri;
+
+pub use capability::{
+    AuthorizedRequest, CapabilityHandle, ContextAuthority, ContextGrant, ContextGrantTable,
+    ContextOperation, ContextRequest, ContextScope, ContextViewMask, MAX_SEARCH_RESULTS,
+};
+pub use error::{ContextError, ContextResult};
+pub use profile::{
+    ContextProfile, ContextProfileError, DerivedView, ProfileTrust, ProfileView,
+    VerifiedContextProfile, CONTEXT_PROFILE_MAGIC, CONTEXT_PROFILE_VERSION, MAX_CONTEXT_RVF_BYTES,
+};
+pub use receipt::{
+    rvf_witness_entry_hash, ContextEpochReceipt, ContextReceiptError, SignedContextEpochReceipt,
+    VerifiedContextEpochReceipt, CONTEXT_RECEIPT_ENCODED_SIZE, CONTEXT_RECEIPT_VERSION,
+    MAX_CONTEXT_EPOCH_RECORDS, RVF_WITNESS_COMPUTATION, RVF_WITNESS_ENTRY_SIZE,
+};
+pub use resolver::{
+    AliasGeneration, AliasSnapshot, ContextHit, ContextResolver, MemoryResolver, ResolvedContext,
+    MAX_ENUM_RESULTS, MAX_RVF_BYTES, MAX_SEARCH_QUERY_BYTES,
+};
+pub use runtime::{
+    ContextClock, ContextRuntime, ExecutionPermit, LogicalContextClock, ReceiptChainState,
+};
+pub use uri::{
+    Authority, Collection, PathSegment, PinnedRuvUri, ProgressiveView, Revision, RuvUri,
+    RuvUriBuilder, Subject, SubjectId, SubjectKind, TenantId, UriError,
+};
+
+/// Version of the RVM `ruv://` namespace contract.
+pub const RUV_CONTEXT_CONTRACT_VERSION: u32 = 1;

--- a/crates/rvm-context/src/profile.rs
+++ b/crates/rvm-context/src/profile.rs
@@ -1,0 +1,838 @@
+//! Deterministic RVF profile binding progressive context views to segments.
+//!
+//! The canonical RVF registry already assigns `PROFILE_SEG` (`0x0B`). This
+//! module defines a versioned payload for that existing segment and does not
+//! mint RVM-only RVF discriminants. A `ruv://` revision always identifies the
+//! complete RVF by SHA-256; the profile only maps abstract, overview, and
+//! content views to verified segment IDs inside those bytes.
+
+use crate::uri::{ProgressiveView, Revision};
+use alloc::vec::Vec;
+use rvm_rvf::{
+    sha256, verify, walk, CheckKind, Outcome, VerificationReport, VerifyOptions, SEG_TYPE_PROFILE,
+};
+
+/// Magic at the start of a `ruv.context/1` RVF profile payload.
+pub const CONTEXT_PROFILE_MAGIC: [u8; 4] = *b"RUVC";
+
+/// Version of the context profile payload.
+pub const CONTEXT_PROFILE_VERSION: u8 = 1;
+
+/// Maximum complete RVF size accepted by the v1 context profile verifier.
+pub const MAX_CONTEXT_RVF_BYTES: usize = 16 * 1024 * 1024;
+
+const HEADER_SIZE: usize = 8;
+const VIEW_RECORD_SIZE: usize = 204;
+const MAX_VIEWS: usize = 3;
+
+/// Trust requirement applied to the RVF profile segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileTrust {
+    /// Require the profile segment's signature check to have passed against a
+    /// trusted Ed25519 key in the supplied `rvm-rvf` verification report.
+    TrustedSignature,
+    /// Accept an unsigned profile because its complete RVF identity was
+    /// authenticated out of band and supplied as `expected_identity`.
+    PinnedIdentity,
+}
+
+/// Failure while decoding or binding a context profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextProfileError {
+    /// The byte payload has the wrong magic, version, length, or reserved bits.
+    Encoding(&'static str),
+    /// A profile does not contain exactly one content view.
+    ContentViewRequired,
+    /// The same progressive view occurs more than once.
+    DuplicateView,
+    /// Two views name the same RVF segment.
+    DuplicateSegment,
+    /// A derived representation has missing or inconsistent provenance.
+    InvalidProvenance,
+    /// A zero digest was used where a content identity is required.
+    ZeroDigest,
+    /// The supplied RVF verification report did not pass.
+    UnverifiedRvf,
+    /// The report, bytes, and expected whole-RVF identity do not agree.
+    IdentityMismatch,
+    /// The RVF does not contain exactly one readable context profile segment.
+    ProfileSegment,
+    /// A trusted signature was required but did not pass for the profile.
+    UntrustedProfile,
+    /// A view names no unique, uncompressed RVF segment.
+    ViewSegment,
+    /// A view's SHA-256 digest does not match its segment payload.
+    ViewDigestMismatch,
+    /// The supplied bytes are not a structurally valid RVF.
+    InvalidRvf,
+    /// The complete RVF exceeds the context ingress ceiling.
+    RvfTooLarge,
+}
+
+impl core::fmt::Display for ContextProfileError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Encoding(message) => write!(f, "context profile encoding: {message}"),
+            Self::ContentViewRequired => f.write_str("context profile needs one content view"),
+            Self::DuplicateView => f.write_str("context profile repeats a view"),
+            Self::DuplicateSegment => f.write_str("context profile repeats a segment"),
+            Self::InvalidProvenance => f.write_str("derived view provenance is invalid"),
+            Self::ZeroDigest => f.write_str("context profile contains a zero digest"),
+            Self::UnverifiedRvf => f.write_str("RVF verification report did not pass"),
+            Self::IdentityMismatch => f.write_str("RVF identity does not match pinned revision"),
+            Self::ProfileSegment => f.write_str("RVF context profile segment is invalid"),
+            Self::UntrustedProfile => f.write_str("RVF context profile is not trusted"),
+            Self::ViewSegment => f.write_str("context view segment is unavailable"),
+            Self::ViewDigestMismatch => f.write_str("context view payload digest does not match"),
+            Self::InvalidRvf => f.write_str("bytes are not a valid RVF"),
+            Self::RvfTooLarge => f.write_str("RVF exceeds the context ingress limit"),
+        }
+    }
+}
+
+/// Provenance required for a derived progressive view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DerivedView {
+    /// SHA-256 digest of the full content bytes this view summarizes.
+    source: Revision,
+    /// Identity of the deterministic generator implementation.
+    generator: Revision,
+    /// Identity of the model or algorithm weights.
+    model: Revision,
+    /// Digest of the exact prompt or transformation configuration.
+    prompt: Revision,
+    /// Digest of the policy governing generation and disclosure.
+    policy: Revision,
+}
+
+impl DerivedView {
+    /// Construct a complete derived-view provenance binding.
+    ///
+    /// # Errors
+    ///
+    /// Refuses an all-zero digest, which is reserved as the absent sentinel in
+    /// the fixed profile encoding.
+    pub fn new(
+        source: Revision,
+        generator: Revision,
+        model: Revision,
+        prompt: Revision,
+        policy: Revision,
+    ) -> Result<Self, ContextProfileError> {
+        for digest in [source, generator, model, prompt, policy] {
+            if is_zero(digest) {
+                return Err(ContextProfileError::ZeroDigest);
+            }
+        }
+        Ok(Self {
+            source,
+            generator,
+            model,
+            prompt,
+            policy,
+        })
+    }
+
+    /// Return the source content digest.
+    #[must_use]
+    pub const fn source(self) -> Revision {
+        self.source
+    }
+
+    /// Return the generator implementation identity.
+    #[must_use]
+    pub const fn generator(self) -> Revision {
+        self.generator
+    }
+
+    /// Return the model or algorithm identity.
+    #[must_use]
+    pub const fn model(self) -> Revision {
+        self.model
+    }
+
+    /// Return the prompt or transformation digest.
+    #[must_use]
+    pub const fn prompt(self) -> Revision {
+        self.prompt
+    }
+
+    /// Return the generation policy digest.
+    #[must_use]
+    pub const fn policy(self) -> Revision {
+        self.policy
+    }
+}
+
+/// Mapping from one progressive view to an RVF segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProfileView {
+    /// Abstract, overview, or full content.
+    view: ProgressiveView,
+    /// RVF segment ordinal containing the representation bytes.
+    segment_id: u64,
+    /// SHA-256 digest of the exact stored segment payload.
+    payload: Revision,
+    /// Required derivation binding for abstract and overview views.
+    derived: Option<DerivedView>,
+}
+
+impl ProfileView {
+    /// Construct the authoritative full-content mapping.
+    ///
+    /// # Errors
+    ///
+    /// Refuses segment ID zero and a zero payload digest.
+    pub fn content(segment_id: u64, payload: Revision) -> Result<Self, ContextProfileError> {
+        if segment_id == 0 {
+            return Err(ContextProfileError::ViewSegment);
+        }
+        if is_zero(payload) {
+            return Err(ContextProfileError::ZeroDigest);
+        }
+        Ok(Self {
+            view: ProgressiveView::Content,
+            segment_id,
+            payload,
+            derived: None,
+        })
+    }
+
+    /// Construct an abstract or overview mapping with provenance.
+    ///
+    /// # Errors
+    ///
+    /// Refuses `content` as a derived selector, segment ID zero, or a zero
+    /// payload digest.
+    pub fn derived(
+        view: ProgressiveView,
+        segment_id: u64,
+        payload: Revision,
+        derived: DerivedView,
+    ) -> Result<Self, ContextProfileError> {
+        if view == ProgressiveView::Content || segment_id == 0 {
+            return Err(ContextProfileError::InvalidProvenance);
+        }
+        if is_zero(payload) {
+            return Err(ContextProfileError::ZeroDigest);
+        }
+        Ok(Self {
+            view,
+            segment_id,
+            payload,
+            derived: Some(derived),
+        })
+    }
+
+    /// Return the progressive view selector.
+    #[must_use]
+    pub const fn view(&self) -> ProgressiveView {
+        self.view
+    }
+
+    /// Return the referenced RVF segment ordinal.
+    #[must_use]
+    pub const fn segment_id(&self) -> u64 {
+        self.segment_id
+    }
+
+    /// Return the digest of the exact stored segment payload.
+    #[must_use]
+    pub const fn payload(&self) -> Revision {
+        self.payload
+    }
+
+    /// Return provenance for an abstract or overview representation.
+    #[must_use]
+    pub const fn provenance(&self) -> Option<DerivedView> {
+        self.derived
+    }
+}
+
+/// Canonical `ruv.context/1` profile decoded from an RVF `PROFILE_SEG`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextProfile {
+    views: Vec<ProfileView>,
+}
+
+impl ContextProfile {
+    /// Validate and canonicalize view mappings into L0, L1, L2 order.
+    ///
+    /// # Errors
+    ///
+    /// Refuses missing or duplicate views, duplicate segment IDs, zero
+    /// digests, and derived views not bound to the content digest.
+    pub fn new(mut views: Vec<ProfileView>) -> Result<Self, ContextProfileError> {
+        if views.is_empty() || views.len() > MAX_VIEWS {
+            return Err(ContextProfileError::ContentViewRequired);
+        }
+        views.sort_by_key(|view| view.view);
+        for pair in views.windows(2) {
+            if pair[0].view == pair[1].view {
+                return Err(ContextProfileError::DuplicateView);
+            }
+        }
+        for (index, view) in views.iter().enumerate() {
+            if view.segment_id == 0 || is_zero(view.payload) {
+                return Err(ContextProfileError::ViewSegment);
+            }
+            if views[..index]
+                .iter()
+                .any(|prior| prior.segment_id == view.segment_id)
+            {
+                return Err(ContextProfileError::DuplicateSegment);
+            }
+        }
+        let content = views
+            .iter()
+            .find(|view| view.view == ProgressiveView::Content)
+            .ok_or(ContextProfileError::ContentViewRequired)?;
+        if content.derived.is_some() {
+            return Err(ContextProfileError::InvalidProvenance);
+        }
+        for view in &views {
+            if view.view != ProgressiveView::Content {
+                let derived = view.derived.ok_or(ContextProfileError::InvalidProvenance)?;
+                for digest in [
+                    derived.source,
+                    derived.generator,
+                    derived.model,
+                    derived.prompt,
+                    derived.policy,
+                ] {
+                    if is_zero(digest) {
+                        return Err(ContextProfileError::ZeroDigest);
+                    }
+                }
+                if derived.source != content.payload {
+                    return Err(ContextProfileError::InvalidProvenance);
+                }
+            }
+        }
+        Ok(Self { views })
+    }
+
+    /// Progressive view mappings in canonical abstract, overview, content order.
+    #[must_use]
+    pub fn views(&self) -> &[ProfileView] {
+        &self.views
+    }
+
+    /// Return one progressive view mapping.
+    #[must_use]
+    pub fn view(&self, requested: ProgressiveView) -> Option<&ProfileView> {
+        self.views.iter().find(|view| view.view == requested)
+    }
+
+    /// Encode the deterministic fixed-record profile payload.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HEADER_SIZE + self.views.len() * VIEW_RECORD_SIZE);
+        out.extend_from_slice(&CONTEXT_PROFILE_MAGIC);
+        out.push(CONTEXT_PROFILE_VERSION);
+        out.push(u8::try_from(self.views.len()).unwrap_or(0));
+        out.extend_from_slice(&[0; 2]);
+        for view in &self.views {
+            encode_view(&mut out, view);
+        }
+        out
+    }
+
+    /// Decode and validate a deterministic profile payload.
+    ///
+    /// # Errors
+    ///
+    /// Refuses noncanonical byte length, order, reserved values, digest
+    /// sentinels, and invalid derivation bindings.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, ContextProfileError> {
+        if data.len() < HEADER_SIZE || data[..4] != CONTEXT_PROFILE_MAGIC {
+            return Err(ContextProfileError::Encoding(
+                "wrong magic or truncated header",
+            ));
+        }
+        if data[4] != CONTEXT_PROFILE_VERSION {
+            return Err(ContextProfileError::Encoding("unsupported version"));
+        }
+        if data[6..8] != [0; 2] {
+            return Err(ContextProfileError::Encoding(
+                "reserved header bytes are nonzero",
+            ));
+        }
+        let count = usize::from(data[5]);
+        if count == 0 || count > MAX_VIEWS || data.len() != HEADER_SIZE + count * VIEW_RECORD_SIZE {
+            return Err(ContextProfileError::Encoding("wrong view count or length"));
+        }
+        let mut views = Vec::with_capacity(count);
+        for index in 0..count {
+            let start = HEADER_SIZE + index * VIEW_RECORD_SIZE;
+            views.push(decode_view(&data[start..start + VIEW_RECORD_SIZE])?);
+        }
+        let profile = Self::new(views)?;
+        if profile.to_bytes() != data {
+            return Err(ContextProfileError::Encoding("noncanonical view order"));
+        }
+        Ok(profile)
+    }
+}
+
+/// Profile proven to belong to a particular complete RVF identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedContextProfile {
+    rvf_identity: Revision,
+    profile: ContextProfile,
+    segments: Vec<BoundSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BoundSegment {
+    view: ProgressiveView,
+    segment_type: u8,
+    start: usize,
+    end: usize,
+}
+
+impl VerifiedContextProfile {
+    /// Verify an RVF and bind its decoded profile to a pinned identity.
+    ///
+    /// This operation only inspects and hashes bytes. It does not map or
+    /// execute any referenced segment. Verification is performed internally;
+    /// callers cannot supply a forgeable success report. `trusted_keys` are
+    /// the Ed25519 publisher keys accepted when `trust` requires a signature.
+    ///
+    /// # Errors
+    ///
+    /// Refuses an unsuccessful or replayed report, a missing or unsigned
+    /// profile under the selected trust posture, ambiguous segment mappings,
+    /// compression, and payload digest mismatches.
+    pub fn from_rvf(
+        data: &[u8],
+        expected_identity: Revision,
+        trust: ProfileTrust,
+        trusted_keys: &[[u8; 32]],
+    ) -> Result<Self, ContextProfileError> {
+        if data.len() > MAX_CONTEXT_RVF_BYTES {
+            return Err(ContextProfileError::RvfTooLarge);
+        }
+        let mut options = VerifyOptions::with_trusted_keys(trusted_keys.to_vec())
+            .expect_identity(*expected_identity.as_bytes());
+        if trust == ProfileTrust::PinnedIdentity {
+            // The complete byte identity is the out-of-band trust anchor in
+            // this posture. Execution remains separately capability-gated and
+            // the launch boundary must still apply its own publisher policy.
+            options.allow_unsigned_executable = true;
+        }
+        let report = verify(data, &options).map_err(|_| ContextProfileError::InvalidRvf)?;
+        Self::bind_verified(data, &report, expected_identity, trust)
+    }
+
+    fn bind_verified(
+        data: &[u8],
+        report: &VerificationReport,
+        expected_identity: Revision,
+        trust: ProfileTrust,
+    ) -> Result<Self, ContextProfileError> {
+        let actual = sha256(data);
+        if actual != report.rvf_identity || actual != *expected_identity.as_bytes() {
+            return Err(ContextProfileError::IdentityMismatch);
+        }
+        if !report.ok {
+            return Err(ContextProfileError::UnverifiedRvf);
+        }
+        let segments = walk(data).map_err(|_| ContextProfileError::InvalidRvf)?;
+        let mut profiles = segments
+            .iter()
+            .filter(|segment| segment.header.seg_type == SEG_TYPE_PROFILE);
+        let profile_segment = profiles.next().ok_or(ContextProfileError::ProfileSegment)?;
+        if profiles.next().is_some()
+            || profile_segment.header.is_encrypted()
+            || profile_segment.header.compression != 0
+        {
+            return Err(ContextProfileError::ProfileSegment);
+        }
+        if trust == ProfileTrust::TrustedSignature {
+            let signature_passed = profile_segment.header.is_signed()
+                && report.records.iter().any(|record| {
+                    record.check == CheckKind::Signature
+                        && record.outcome == Outcome::Pass
+                        && record.segment_index == Some(profile_segment.index)
+                        && record.segment_id == Some(profile_segment.header.segment_id)
+                });
+            if !signature_passed {
+                return Err(ContextProfileError::UntrustedProfile);
+            }
+        }
+
+        let profile = ContextProfile::from_bytes(profile_segment.payload(data))?;
+        let mut bound = Vec::with_capacity(profile.views().len());
+        for view in profile.views() {
+            let mut matching = segments
+                .iter()
+                .filter(|segment| segment.header.segment_id == view.segment_id);
+            let segment = matching.next().ok_or(ContextProfileError::ViewSegment)?;
+            if matching.next().is_some()
+                || segment.header.seg_type == SEG_TYPE_PROFILE
+                || segment.header.compression != 0
+            {
+                return Err(ContextProfileError::ViewSegment);
+            }
+            if view.view != ProgressiveView::Content && segment.header.is_executable() {
+                return Err(ContextProfileError::ViewSegment);
+            }
+            if sha256(segment.payload(data)) != *view.payload.as_bytes() {
+                return Err(ContextProfileError::ViewDigestMismatch);
+            }
+            bound.push(BoundSegment {
+                view: view.view,
+                segment_type: segment.header.seg_type,
+                start: segment.payload.start,
+                end: segment.payload.end,
+            });
+        }
+
+        Ok(Self {
+            rvf_identity: expected_identity,
+            profile,
+            segments: bound,
+        })
+    }
+
+    /// Complete RVF identity suitable for a pinned `ruv://` revision.
+    #[must_use]
+    pub const fn rvf_identity(&self) -> Revision {
+        self.rvf_identity
+    }
+
+    /// Decoded progressive view profile.
+    #[must_use]
+    pub const fn profile(&self) -> &ContextProfile {
+        &self.profile
+    }
+
+    /// Whether the mapped segment is executable code.
+    #[must_use]
+    pub fn is_executable(&self, view: ProgressiveView) -> bool {
+        self.segments
+            .iter()
+            .find(|segment| segment.view == view)
+            .is_some_and(|segment| rvm_rvf::is_executable(segment.segment_type))
+    }
+
+    /// Borrow one verified stored representation from the same RVF bytes.
+    ///
+    /// This is inspection only. Returning executable bytes does not execute
+    /// them and does not confer RVM `EXECUTE` authority.
+    ///
+    /// # Errors
+    ///
+    /// Refuses different RVF bytes or a view absent from the profile.
+    pub fn payload<'a>(
+        &self,
+        data: &'a [u8],
+        view: ProgressiveView,
+    ) -> Result<&'a [u8], ContextProfileError> {
+        if sha256(data) != *self.rvf_identity.as_bytes() {
+            return Err(ContextProfileError::IdentityMismatch);
+        }
+        let segment = self
+            .segments
+            .iter()
+            .find(|segment| segment.view == view)
+            .ok_or(ContextProfileError::ViewSegment)?;
+        data.get(segment.start..segment.end)
+            .ok_or(ContextProfileError::ViewSegment)
+    }
+}
+
+fn encode_view(out: &mut Vec<u8>, view: &ProfileView) {
+    out.push(view_code(view.view));
+    out.push(u8::from(view.derived.is_some()));
+    out.extend_from_slice(&[0; 2]);
+    out.extend_from_slice(&view.segment_id.to_le_bytes());
+    out.extend_from_slice(view.payload.as_bytes());
+    if let Some(derived) = view.derived {
+        for digest in [
+            derived.source,
+            derived.generator,
+            derived.model,
+            derived.prompt,
+            derived.policy,
+        ] {
+            out.extend_from_slice(digest.as_bytes());
+        }
+    } else {
+        out.extend_from_slice(&[0; 160]);
+    }
+}
+
+fn decode_view(data: &[u8]) -> Result<ProfileView, ContextProfileError> {
+    if data.len() != VIEW_RECORD_SIZE || data[2..4] != [0; 2] {
+        return Err(ContextProfileError::Encoding("view record is malformed"));
+    }
+    let view = match data[0] {
+        0 => ProgressiveView::Abstract,
+        1 => ProgressiveView::Overview,
+        2 => ProgressiveView::Content,
+        _ => return Err(ContextProfileError::Encoding("unknown view")),
+    };
+    let segment_id = u64::from_le_bytes(data[4..12].try_into().unwrap_or([0; 8]));
+    let payload = Revision::from_bytes(array32(data, 12));
+    match data[1] {
+        0 => {
+            if data[44..].iter().any(|byte| *byte != 0) {
+                return Err(ContextProfileError::Encoding(
+                    "absent provenance is nonzero",
+                ));
+            }
+            Ok(ProfileView {
+                view,
+                segment_id,
+                payload,
+                derived: None,
+            })
+        }
+        1 => Ok(ProfileView {
+            view,
+            segment_id,
+            payload,
+            derived: Some(DerivedView::new(
+                Revision::from_bytes(array32(data, 44)),
+                Revision::from_bytes(array32(data, 76)),
+                Revision::from_bytes(array32(data, 108)),
+                Revision::from_bytes(array32(data, 140)),
+                Revision::from_bytes(array32(data, 172)),
+            )?),
+        }),
+        _ => Err(ContextProfileError::Encoding("invalid provenance flag")),
+    }
+}
+
+const fn view_code(view: ProgressiveView) -> u8 {
+    match view {
+        ProgressiveView::Abstract => 0,
+        ProgressiveView::Overview => 1,
+        ProgressiveView::Content => 2,
+    }
+}
+
+fn is_zero(revision: Revision) -> bool {
+    revision.as_bytes().iter().all(|byte| *byte == 0)
+}
+
+fn array32(data: &[u8], offset: usize) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&data[offset..offset + 32]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use ed25519_dalek::{Signer, SigningKey};
+    use rvm_rvf::{
+        content_hash, SegmentHeader, SEGMENT_HEADER_SIZE, SEGMENT_MAGIC, SEGMENT_VERSION,
+    };
+
+    const SEG_TYPE_META: u8 = 0x07;
+    const SEG_TYPE_MANIFEST: u8 = 0x05;
+
+    fn revision(byte: u8) -> Revision {
+        Revision::from_bytes([byte; 32])
+    }
+
+    fn profile() -> ContextProfile {
+        let content_bytes = b"full content";
+        let content = Revision::from_bytes(sha256(content_bytes));
+        let overview = ProfileView::derived(
+            ProgressiveView::Overview,
+            2,
+            Revision::from_bytes(sha256(b"overview")),
+            DerivedView::new(content, revision(2), revision(3), revision(4), revision(5)).unwrap(),
+        )
+        .unwrap();
+        ContextProfile::new(vec![ProfileView::content(1, content).unwrap(), overview]).unwrap()
+    }
+
+    fn segment(segment_type: u8, segment_id: u64, payload: &[u8]) -> Vec<u8> {
+        let total = SEGMENT_HEADER_SIZE + payload.len();
+        let padded = total.div_ceil(64) * 64;
+        let header = SegmentHeader {
+            magic: SEGMENT_MAGIC,
+            version: SEGMENT_VERSION,
+            seg_type: segment_type,
+            flags: 0,
+            segment_id,
+            payload_length: u64::try_from(payload.len()).unwrap(),
+            timestamp_ns: segment_id,
+            checksum_algo: 2,
+            compression: 0,
+            reserved_0: 0,
+            reserved_1: 0,
+            content_hash: content_hash(2, payload),
+            uncompressed_len: 0,
+            alignment_pad: u32::try_from(padded - total).unwrap(),
+        };
+        let mut bytes = header.to_bytes().to_vec();
+        bytes.extend_from_slice(payload);
+        bytes.resize(padded, 0);
+        bytes
+    }
+
+    fn signed_segment(
+        segment_type: u8,
+        segment_id: u64,
+        payload: &[u8],
+        seed: u8,
+    ) -> (Vec<u8>, [u8; 32]) {
+        use rvm_rvf::format::{
+            build_signed_message, compute_footer_length, FLAG_SIGNED, SIG_ALGO_ED25519,
+        };
+
+        let footer_length = usize::try_from(compute_footer_length(64)).unwrap();
+        let total = SEGMENT_HEADER_SIZE + payload.len() + footer_length;
+        let padded = total.div_ceil(64) * 64;
+        let header = SegmentHeader {
+            magic: SEGMENT_MAGIC,
+            version: SEGMENT_VERSION,
+            seg_type: segment_type,
+            flags: FLAG_SIGNED,
+            segment_id,
+            payload_length: u64::try_from(payload.len()).unwrap(),
+            timestamp_ns: segment_id,
+            checksum_algo: 2,
+            compression: 0,
+            reserved_0: 0,
+            reserved_1: 0,
+            content_hash: content_hash(2, payload),
+            uncompressed_len: 0,
+            alignment_pad: u32::try_from(padded - total).unwrap(),
+        };
+        let secret = sha256(&[seed; 32]);
+        let signing_key = SigningKey::from_bytes(&secret);
+        let signature = signing_key
+            .sign(&build_signed_message(&header, payload))
+            .to_bytes();
+        let mut bytes = header.to_bytes().to_vec();
+        bytes.extend_from_slice(payload);
+        bytes.extend_from_slice(&SIG_ALGO_ED25519.to_le_bytes());
+        bytes.extend_from_slice(&64u16.to_le_bytes());
+        bytes.extend_from_slice(&signature);
+        bytes.extend_from_slice(&compute_footer_length(64).to_le_bytes());
+        bytes.resize(padded, 0);
+        (bytes, signing_key.verifying_key().to_bytes())
+    }
+
+    fn rvf(profile: &ContextProfile) -> Vec<u8> {
+        let mut bytes = segment(SEG_TYPE_META, 1, b"full content");
+        bytes.extend(segment(SEG_TYPE_META, 2, b"overview"));
+        bytes.extend(segment(SEG_TYPE_PROFILE, 3, &profile.to_bytes()));
+        bytes.extend(segment(SEG_TYPE_MANIFEST, 4, b"root"));
+        bytes
+    }
+
+    fn signed_profile_rvf(profile: &ContextProfile, seed: u8) -> (Vec<u8>, [u8; 32]) {
+        let mut bytes = segment(SEG_TYPE_META, 1, b"full content");
+        bytes.extend(segment(SEG_TYPE_META, 2, b"overview"));
+        let (signed_profile, public_key) =
+            signed_segment(SEG_TYPE_PROFILE, 3, &profile.to_bytes(), seed);
+        bytes.extend(signed_profile);
+        bytes.extend(segment(SEG_TYPE_MANIFEST, 4, b"root"));
+        (bytes, public_key)
+    }
+
+    #[test]
+    fn deterministic_profile_round_trip() {
+        let profile = profile();
+        let encoded = profile.to_bytes();
+        assert_eq!(ContextProfile::from_bytes(&encoded).unwrap(), profile);
+        assert_eq!(profile.views()[0].view, ProgressiveView::Overview);
+        assert_eq!(profile.views()[1].view, ProgressiveView::Content);
+    }
+
+    #[test]
+    fn derived_view_must_bind_the_content_digest() {
+        let derived = DerivedView::new(
+            revision(9),
+            revision(2),
+            revision(3),
+            revision(4),
+            revision(5),
+        )
+        .unwrap();
+        let result = ContextProfile::new(vec![
+            ProfileView::content(1, revision(1)).unwrap(),
+            ProfileView::derived(ProgressiveView::Abstract, 2, revision(6), derived).unwrap(),
+        ]);
+        assert_eq!(result, Err(ContextProfileError::InvalidProvenance));
+    }
+
+    #[test]
+    fn pinned_rvf_identity_binds_verified_view_bytes() {
+        let profile = profile();
+        let data = rvf(&profile);
+        let identity = Revision::from_bytes(sha256(&data));
+        let verified =
+            VerifiedContextProfile::from_rvf(&data, identity, ProfileTrust::PinnedIdentity, &[])
+                .unwrap();
+        assert_eq!(
+            verified.payload(&data, ProgressiveView::Overview).unwrap(),
+            b"overview"
+        );
+        assert!(!verified.is_executable(ProgressiveView::Content));
+    }
+
+    #[test]
+    fn different_identity_and_unsigned_trust_are_refused() {
+        let data = rvf(&profile());
+        let identity = Revision::from_bytes(sha256(&data));
+        assert_eq!(
+            VerifiedContextProfile::from_rvf(
+                &data,
+                revision(99),
+                ProfileTrust::PinnedIdentity,
+                &[],
+            ),
+            Err(ContextProfileError::IdentityMismatch)
+        );
+        assert_eq!(
+            VerifiedContextProfile::from_rvf(&data, identity, ProfileTrust::TrustedSignature, &[],),
+            Err(ContextProfileError::UntrustedProfile)
+        );
+    }
+
+    #[test]
+    fn trusted_profile_is_verified_internally_against_publisher_keys() {
+        let (data, trusted_key) = signed_profile_rvf(&profile(), 7);
+        let identity = Revision::from_bytes(sha256(&data));
+        let verified = VerifiedContextProfile::from_rvf(
+            &data,
+            identity,
+            ProfileTrust::TrustedSignature,
+            &[trusted_key],
+        )
+        .unwrap();
+        assert_eq!(verified.rvf_identity(), identity);
+
+        assert_eq!(
+            VerifiedContextProfile::from_rvf(
+                &data,
+                identity,
+                ProfileTrust::TrustedSignature,
+                &[[0x44; 32]],
+            ),
+            Err(ContextProfileError::UnverifiedRvf)
+        );
+    }
+
+    #[test]
+    fn profile_payload_hash_mismatch_is_refused() {
+        let mut profile = profile();
+        profile.views[0].payload = revision(0x44);
+        let data = rvf(&profile);
+        let identity = Revision::from_bytes(sha256(&data));
+        assert_eq!(
+            VerifiedContextProfile::from_rvf(&data, identity, ProfileTrust::PinnedIdentity, &[],),
+            Err(ContextProfileError::ViewDigestMismatch)
+        );
+    }
+}

--- a/crates/rvm-context/src/receipt.rs
+++ b/crates/rvm-context/src/receipt.rs
@@ -1,0 +1,1089 @@
+//! Signed epoch receipts bridging the RVM witness ring to RVF witnesses.
+//!
+//! The hot RVM log is deliberately small and lossy. A context epoch receipt
+//! seals a contiguous, non-wrapped slice with SHA-256, binds it to the active
+//! namespace, policy, detail commitment, and RVF identity, then signs the
+//! result with the full 64-byte signer from `rvm-proof`. The resulting receipt
+//! can be committed into the canonical 73-byte RVF witness shape without
+//! pretending that RVF and RVM use the same record format.
+
+use alloc::vec::Vec;
+use rvm_proof::{SignatureError, WitnessSigner};
+use rvm_types::{ActionKind, WitnessRecord};
+use rvm_witness::{
+    compute_chain_hash, record_to_bytes, verify_chain_from, ChainIntegrityError,
+    SnapshotSinceError, WitnessCheckpoint, WitnessLog,
+};
+use sha2::{Digest, Sha256};
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+
+/// Version of the signed context epoch receipt wire contract.
+pub const CONTEXT_RECEIPT_VERSION: u16 = 1;
+
+/// Fixed size of an encoded signed receipt.
+pub const CONTEXT_RECEIPT_ENCODED_SIZE: usize = 352;
+
+/// Fixed size of one canonical RVF witness entry.
+pub const RVF_WITNESS_ENTRY_SIZE: usize = 73;
+
+/// RVF witness type for a computation commitment.
+pub const RVF_WITNESS_COMPUTATION: u8 = 0x02;
+
+/// Maximum records sealed by one context epoch.
+///
+/// This matches the documented default RVM witness ring and bounds receipt
+/// scratch plus Merkle memory even when [`ContextEpochReceipt::seal`] is
+/// called directly with an arbitrary slice.
+pub const MAX_CONTEXT_EPOCH_RECORDS: usize = rvm_witness::DEFAULT_RING_CAPACITY;
+
+const MAGIC: [u8; 4] = *b"RUCR";
+const SIGNING_DOMAIN: &[u8] = b"RUV-CONTEXT-EPOCH-RECEIPT-V1";
+const SIGNED_ID_DOMAIN: &[u8] = b"RUV-CONTEXT-EPOCH-RECEIPT-ID-V1";
+const LEAF_DOMAIN: &[u8] = b"RUV-CONTEXT-WITNESS-LEAF-V1";
+const NODE_DOMAIN: &[u8] = b"RUV-CONTEXT-WITNESS-NODE-V1";
+
+/// Failure while sealing or validating a context epoch receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextReceiptError {
+    /// An epoch must contain at least one witnessed decision.
+    EmptyEpoch,
+    /// More records were supplied than the bounded epoch ceiling permits.
+    TooManyRecords,
+    /// The record sequence range does not match its declared count.
+    SequenceRange,
+    /// The encoded or reproduced timestamp bounds are inconsistent.
+    TimestampBounds,
+    /// The RVM witness chain is incomplete or corrupt.
+    Chain(ChainIntegrityError),
+    /// The requested epoch is unavailable from the hot ring.
+    Snapshot(SnapshotSinceError),
+    /// The receipt signer does not match the signer identifier in the record.
+    SignerMismatch,
+    /// The 64-byte receipt signature did not verify.
+    Signature(SignatureError),
+    /// Encoded bytes violate the fixed receipt schema.
+    Encoding(&'static str),
+    /// Supplied records do not reproduce the committed Merkle root.
+    WitnessRootMismatch,
+    /// A verified receipt is not the required genesis or direct successor.
+    ReceiptContinuity,
+}
+
+impl core::fmt::Display for ContextReceiptError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::EmptyEpoch => f.write_str("context epoch is empty"),
+            Self::TooManyRecords => f.write_str("context epoch has too many records"),
+            Self::SequenceRange => f.write_str("context epoch sequence range is invalid"),
+            Self::TimestampBounds => f.write_str("context epoch timestamp bounds do not match"),
+            Self::Chain(error) => write!(f, "context witness chain is invalid: {error}"),
+            Self::Snapshot(error) => write!(f, "context witness snapshot failed: {error}"),
+            Self::SignerMismatch => f.write_str("context receipt signer does not match"),
+            Self::Signature(error) => write!(f, "context receipt signature failed: {error:?}"),
+            Self::Encoding(message) => write!(f, "context receipt encoding is invalid: {message}"),
+            Self::WitnessRootMismatch => f.write_str("context witness root does not match"),
+            Self::ReceiptContinuity => f.write_str("context receipt continuity is invalid"),
+        }
+    }
+}
+
+impl From<ChainIntegrityError> for ContextReceiptError {
+    fn from(error: ChainIntegrityError) -> Self {
+        Self::Chain(error)
+    }
+}
+
+impl From<SnapshotSinceError> for ContextReceiptError {
+    fn from(error: SnapshotSinceError) -> Self {
+        Self::Snapshot(error)
+    }
+}
+
+/// Unsigned, canonical content of one context witness epoch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextEpochReceipt {
+    /// Monotonic epoch identifier derived by the governed runtime.
+    epoch_id: u64,
+    /// First RVM witness sequence covered by this epoch.
+    first_sequence: u64,
+    /// Last RVM witness sequence covered by this epoch.
+    last_sequence: u64,
+    /// Number of RVM records committed by `witness_root`.
+    record_count: u32,
+    /// Minimum timestamp observed in the epoch.
+    started_ns: u64,
+    /// Maximum timestamp observed in the epoch.
+    ended_ns: u64,
+    /// Full RVM chain hash immediately before `first_sequence`.
+    initial_chain_hash: u64,
+    /// SHA-256 identifier of the previous signed context receipt.
+    previous_receipt: [u8; 32],
+    /// Commitment to the alias and tombstone state after this epoch.
+    namespace_root: [u8; 32],
+    /// RVF identity whose context profile governed the epoch.
+    rvf_identity: [u8; 32],
+    /// Commitment to the authorization and retention policy.
+    policy_hash: [u8; 32],
+    /// Commitment to encrypted detailed search or trajectory evidence.
+    detail_root: [u8; 32],
+    /// SHA-256 Merkle root of canonical 64-byte RVM witness records.
+    witness_root: [u8; 32],
+}
+
+impl ContextEpochReceipt {
+    /// Return the monotonic epoch identifier.
+    #[must_use]
+    pub const fn epoch_id(&self) -> u64 {
+        self.epoch_id
+    }
+
+    /// Return the first covered RVM witness sequence.
+    #[must_use]
+    pub const fn first_sequence(&self) -> u64 {
+        self.first_sequence
+    }
+
+    /// Return the last covered RVM witness sequence.
+    #[must_use]
+    pub const fn last_sequence(&self) -> u64 {
+        self.last_sequence
+    }
+
+    /// Return the number of covered witness records.
+    #[must_use]
+    pub const fn record_count(&self) -> u32 {
+        self.record_count
+    }
+
+    /// Return the minimum timestamp observed in the epoch.
+    #[must_use]
+    pub const fn started_ns(&self) -> u64 {
+        self.started_ns
+    }
+
+    /// Return the maximum timestamp observed in the epoch.
+    #[must_use]
+    pub const fn ended_ns(&self) -> u64 {
+        self.ended_ns
+    }
+
+    /// Return the full chain hash immediately before this epoch.
+    #[must_use]
+    pub const fn initial_chain_hash(&self) -> u64 {
+        self.initial_chain_hash
+    }
+
+    /// Return the previous signed receipt identifier.
+    #[must_use]
+    pub const fn previous_receipt(&self) -> &[u8; 32] {
+        &self.previous_receipt
+    }
+
+    /// Return the namespace state commitment.
+    #[must_use]
+    pub const fn namespace_root(&self) -> &[u8; 32] {
+        &self.namespace_root
+    }
+
+    /// Return the governed whole-RVF identity.
+    #[must_use]
+    pub const fn rvf_identity(&self) -> &[u8; 32] {
+        &self.rvf_identity
+    }
+
+    /// Return the authorization and retention policy commitment.
+    #[must_use]
+    pub const fn policy_hash(&self) -> &[u8; 32] {
+        &self.policy_hash
+    }
+
+    /// Return the encrypted detail commitment.
+    #[must_use]
+    pub const fn detail_root(&self) -> &[u8; 32] {
+        &self.detail_root
+    }
+
+    /// Return the Merkle root of canonical witness records.
+    #[must_use]
+    pub const fn witness_root(&self) -> &[u8; 32] {
+        &self.witness_root
+    }
+
+    /// Seal a supplied record slice beginning at `checkpoint`.
+    ///
+    /// # Errors
+    ///
+    /// Refuses empty, non-contiguous, corrupt, or oversized slices. Sequence
+    /// and chain coordinates define record order; timestamps are committed as
+    /// observed minimum and maximum bounds. No incomplete receipt is returned.
+    #[allow(clippy::too_many_arguments)]
+    pub fn seal(
+        epoch_id: u64,
+        checkpoint: WitnessCheckpoint,
+        records: &[WitnessRecord],
+        previous_receipt: [u8; 32],
+        namespace_root: [u8; 32],
+        rvf_identity: [u8; 32],
+        policy_hash: [u8; 32],
+        detail_root: [u8; 32],
+    ) -> Result<Self, ContextReceiptError> {
+        if records.is_empty() {
+            return Err(ContextReceiptError::EmptyEpoch);
+        }
+        if records.len() > MAX_CONTEXT_EPOCH_RECORDS {
+            return Err(ContextReceiptError::TooManyRecords);
+        }
+        let record_count =
+            u32::try_from(records.len()).map_err(|_| ContextReceiptError::TooManyRecords)?;
+        verify_chain_from(records, checkpoint.chain_hash(), checkpoint.next_sequence())?;
+
+        let first = records[0];
+        let last = records[records.len() - 1];
+        let (started_ns, ended_ns) = timestamp_bounds(records);
+        let expected_last = first
+            .sequence
+            .checked_add(u64::from(record_count) - 1)
+            .ok_or(ContextReceiptError::SequenceRange)?;
+        if last.sequence != expected_last {
+            return Err(ContextReceiptError::SequenceRange);
+        }
+        Ok(Self {
+            epoch_id,
+            first_sequence: first.sequence,
+            last_sequence: last.sequence,
+            record_count,
+            started_ns,
+            ended_ns,
+            initial_chain_hash: checkpoint.chain_hash(),
+            previous_receipt,
+            namespace_root,
+            rvf_identity,
+            policy_hash,
+            detail_root,
+            witness_root: merkle_root(records),
+        })
+    }
+
+    /// Atomically snapshot and seal records emitted after `checkpoint`.
+    ///
+    /// # Errors
+    ///
+    /// In addition to [`Self::seal`] failures, refuses a wrapped epoch or an
+    /// undersized scratch slice through [`ContextReceiptError::Snapshot`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn seal_from_log<const N: usize>(
+        epoch_id: u64,
+        log: &WitnessLog<N>,
+        checkpoint: WitnessCheckpoint,
+        scratch: &mut [WitnessRecord],
+        previous_receipt: [u8; 32],
+        namespace_root: [u8; 32],
+        rvf_identity: [u8; 32],
+        policy_hash: [u8; 32],
+        detail_root: [u8; 32],
+    ) -> Result<(Self, WitnessCheckpoint), ContextReceiptError> {
+        let snapshot = log.snapshot_since(checkpoint, scratch)?;
+        let receipt = Self::seal(
+            epoch_id,
+            checkpoint,
+            &scratch[..snapshot.count()],
+            previous_receipt,
+            namespace_root,
+            rvf_identity,
+            policy_hash,
+            detail_root,
+        )?;
+        Ok((receipt, snapshot.end_checkpoint()))
+    }
+
+    /// Verify that `records` reproduce this receipt's sequence and Merkle root.
+    ///
+    /// # Errors
+    ///
+    /// Refuses a count/range or timestamp-bound mismatch, broken RVM chain, or
+    /// different root.
+    pub fn verify_records(&self, records: &[WitnessRecord]) -> Result<(), ContextReceiptError> {
+        let expected_count =
+            usize::try_from(self.record_count).map_err(|_| ContextReceiptError::SequenceRange)?;
+        if expected_count > MAX_CONTEXT_EPOCH_RECORDS {
+            return Err(ContextReceiptError::TooManyRecords);
+        }
+        if records.len() != expected_count || records.is_empty() {
+            return Err(ContextReceiptError::SequenceRange);
+        }
+        if records[0].sequence != self.first_sequence
+            || records[records.len() - 1].sequence != self.last_sequence
+        {
+            return Err(ContextReceiptError::SequenceRange);
+        }
+        if timestamp_bounds(records) != (self.started_ns, self.ended_ns) {
+            return Err(ContextReceiptError::TimestampBounds);
+        }
+        verify_chain_from(records, self.initial_chain_hash, self.first_sequence)?;
+        if merkle_root(records) != self.witness_root {
+            return Err(ContextReceiptError::WitnessRootMismatch);
+        }
+        Ok(())
+    }
+
+    /// Sign this receipt with a full `rvm-proof` signer.
+    #[must_use]
+    pub fn sign<S: WitnessSigner>(&self, signer: &S) -> SignedContextEpochReceipt {
+        let signer_id = signer.signer_id();
+        let digest = self.signing_digest(&signer_id);
+        SignedContextEpochReceipt {
+            receipt: self.clone(),
+            signer_id,
+            signature: signer.sign(&digest),
+        }
+    }
+
+    fn signing_digest(&self, signer_id: &[u8; 32]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        Digest::update(&mut hasher, SIGNING_DOMAIN);
+        Digest::update(&mut hasher, self.encode_unsigned());
+        Digest::update(&mut hasher, signer_id);
+        finalize_sha256(hasher)
+    }
+
+    fn encode_unsigned(&self) -> [u8; 256] {
+        let mut out = [0u8; 256];
+        out[0..4].copy_from_slice(&MAGIC);
+        out[4..6].copy_from_slice(&CONTEXT_RECEIPT_VERSION.to_le_bytes());
+        out[8..16].copy_from_slice(&self.epoch_id.to_le_bytes());
+        out[16..24].copy_from_slice(&self.first_sequence.to_le_bytes());
+        out[24..32].copy_from_slice(&self.last_sequence.to_le_bytes());
+        out[32..36].copy_from_slice(&self.record_count.to_le_bytes());
+        out[40..48].copy_from_slice(&self.started_ns.to_le_bytes());
+        out[48..56].copy_from_slice(&self.ended_ns.to_le_bytes());
+        out[56..64].copy_from_slice(&self.initial_chain_hash.to_le_bytes());
+        out[64..96].copy_from_slice(&self.previous_receipt);
+        out[96..128].copy_from_slice(&self.namespace_root);
+        out[128..160].copy_from_slice(&self.rvf_identity);
+        out[160..192].copy_from_slice(&self.policy_hash);
+        out[192..224].copy_from_slice(&self.detail_root);
+        out[224..256].copy_from_slice(&self.witness_root);
+        out
+    }
+}
+
+/// A context epoch receipt with signer identity and a 64-byte signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedContextEpochReceipt {
+    /// Canonical unsigned fields.
+    receipt: ContextEpochReceipt,
+    /// Typed signer identifier supplied by `rvm-proof`.
+    signer_id: [u8; 32],
+    /// Signature over the domain-separated receipt digest.
+    signature: [u8; 64],
+}
+
+impl SignedContextEpochReceipt {
+    /// Return the canonical unsigned receipt fields.
+    #[must_use]
+    pub const fn receipt(&self) -> &ContextEpochReceipt {
+        &self.receipt
+    }
+
+    /// Return the typed receipt signer identifier.
+    #[must_use]
+    pub const fn signer_id(&self) -> &[u8; 32] {
+        &self.signer_id
+    }
+
+    /// Return the full receipt signature.
+    #[must_use]
+    pub const fn signature(&self) -> &[u8; 64] {
+        &self.signature
+    }
+
+    /// Verify signer identity and signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns a signer mismatch before attempting cryptographic verification,
+    /// or wraps the signer's signature error.
+    pub fn verify<'a, S: WitnessSigner>(
+        &'a self,
+        signer: &S,
+    ) -> Result<VerifiedContextEpochReceipt<'a>, ContextReceiptError> {
+        if signer.signer_id() != self.signer_id {
+            return Err(ContextReceiptError::SignerMismatch);
+        }
+        let digest = self.receipt.signing_digest(&self.signer_id);
+        signer
+            .verify(&digest, &self.signature)
+            .map_err(ContextReceiptError::Signature)?;
+        Ok(VerifiedContextEpochReceipt { signed: self })
+    }
+
+    /// Encode the complete signed receipt in its fixed 352-byte form.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; CONTEXT_RECEIPT_ENCODED_SIZE] {
+        let mut out = [0u8; CONTEXT_RECEIPT_ENCODED_SIZE];
+        out[..256].copy_from_slice(&self.receipt.encode_unsigned());
+        out[256..288].copy_from_slice(&self.signer_id);
+        out[288..352].copy_from_slice(&self.signature);
+        out
+    }
+
+    /// Decode a fixed signed receipt.
+    ///
+    /// This checks structural invariants but cannot authenticate the signature;
+    /// call [`Self::verify`] with a trusted signer after decoding.
+    ///
+    /// # Errors
+    ///
+    /// Refuses wrong magic, version, reserved bytes, empty or oversized ranges,
+    /// and count mismatches.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, ContextReceiptError> {
+        if data.len() != CONTEXT_RECEIPT_ENCODED_SIZE {
+            return Err(ContextReceiptError::Encoding("wrong byte length"));
+        }
+        if data[..4] != MAGIC {
+            return Err(ContextReceiptError::Encoding("wrong magic"));
+        }
+        if read_u16(data, 4) != CONTEXT_RECEIPT_VERSION {
+            return Err(ContextReceiptError::Encoding("unsupported version"));
+        }
+        if data[6..8].iter().any(|byte| *byte != 0) || data[36..40].iter().any(|byte| *byte != 0) {
+            return Err(ContextReceiptError::Encoding("reserved bytes are nonzero"));
+        }
+
+        let first_sequence = read_u64(data, 16);
+        let last_sequence = read_u64(data, 24);
+        let record_count = read_u32(data, 32);
+        let decoded_count =
+            usize::try_from(record_count).map_err(|_| ContextReceiptError::TooManyRecords)?;
+        if decoded_count > MAX_CONTEXT_EPOCH_RECORDS {
+            return Err(ContextReceiptError::TooManyRecords);
+        }
+        let sequence_count = last_sequence
+            .checked_sub(first_sequence)
+            .and_then(|distance| distance.checked_add(1));
+        if record_count == 0 || sequence_count != Some(u64::from(record_count)) {
+            return Err(ContextReceiptError::SequenceRange);
+        }
+        let started_ns = read_u64(data, 40);
+        let ended_ns = read_u64(data, 48);
+        if ended_ns < started_ns {
+            return Err(ContextReceiptError::TimestampBounds);
+        }
+
+        let receipt = ContextEpochReceipt {
+            epoch_id: read_u64(data, 8),
+            first_sequence,
+            last_sequence,
+            record_count,
+            started_ns,
+            ended_ns,
+            initial_chain_hash: read_u64(data, 56),
+            previous_receipt: array32(data, 64),
+            namespace_root: array32(data, 96),
+            rvf_identity: array32(data, 128),
+            policy_hash: array32(data, 160),
+            detail_root: array32(data, 192),
+            witness_root: array32(data, 224),
+        };
+        let mut signature = [0u8; 64];
+        signature.copy_from_slice(&data[288..352]);
+        Ok(Self {
+            receipt,
+            signer_id: array32(data, 256),
+            signature,
+        })
+    }
+
+    /// SHA-256 identifier of the complete signed receipt.
+    #[must_use]
+    pub fn receipt_id(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        Digest::update(&mut hasher, SIGNED_ID_DOMAIN);
+        Digest::update(&mut hasher, self.to_bytes());
+        finalize_sha256(hasher)
+    }
+}
+
+/// A signed epoch receipt authenticated by a trusted signer.
+///
+/// This typestate prevents bytes decoded from an untrusted source from being
+/// committed into RVF or the live witness trail before verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerifiedContextEpochReceipt<'a> {
+    signed: &'a SignedContextEpochReceipt,
+}
+
+impl VerifiedContextEpochReceipt<'_> {
+    /// Return the authenticated signed receipt.
+    #[must_use]
+    pub const fn signed(&self) -> &SignedContextEpochReceipt {
+        self.signed
+    }
+
+    /// Verify that this receipt is the canonical witness-log genesis.
+    ///
+    /// Genesis begins at epoch and sequence zero, has the zero initial chain
+    /// hash, and does not link to a prior signed receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContextReceiptError::ReceiptContinuity`] when any genesis
+    /// coordinate is nonzero.
+    pub fn verify_genesis(&self) -> Result<(), ContextReceiptError> {
+        let receipt = &self.signed.receipt;
+        if receipt.epoch_id != 0
+            || receipt.first_sequence != 0
+            || receipt.initial_chain_hash != 0
+            || receipt.previous_receipt != [0; 32]
+        {
+            return Err(ContextReceiptError::ReceiptContinuity);
+        }
+        Ok(())
+    }
+
+    /// Verify that this receipt directly follows `previous`.
+    ///
+    /// Both values must already have authenticated signatures. Continuity
+    /// requires the exact previous signed-receipt identifier, checked epoch
+    /// increment, checked sequence adjacency, and the full chain hash obtained
+    /// by applying [`compute_chain_hash`] across every prior sequence.
+    /// Timestamps are deliberately excluded from ordering authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContextReceiptError::ReceiptContinuity`] for a fork, replay,
+    /// skipped/overflowed epoch, or skipped/overflowed sequence.
+    pub fn verify_successor(
+        &self,
+        previous: &VerifiedContextEpochReceipt<'_>,
+    ) -> Result<(), ContextReceiptError> {
+        let receipt = &self.signed.receipt;
+        let prior = &previous.signed.receipt;
+        let expected_epoch = prior
+            .epoch_id
+            .checked_add(1)
+            .ok_or(ContextReceiptError::ReceiptContinuity)?;
+        let expected_sequence = prior
+            .last_sequence
+            .checked_add(1)
+            .ok_or(ContextReceiptError::ReceiptContinuity)?;
+        let mut expected_initial_chain_hash = prior.initial_chain_hash;
+        for offset in 0..u64::from(prior.record_count) {
+            let sequence = prior
+                .first_sequence
+                .checked_add(offset)
+                .ok_or(ContextReceiptError::ReceiptContinuity)?;
+            expected_initial_chain_hash = compute_chain_hash(expected_initial_chain_hash, sequence);
+        }
+        if receipt.previous_receipt != previous.signed.receipt_id()
+            || receipt.epoch_id != expected_epoch
+            || receipt.first_sequence != expected_sequence
+            || receipt.initial_chain_hash != expected_initial_chain_hash
+        {
+            return Err(ContextReceiptError::ReceiptContinuity);
+        }
+        Ok(())
+    }
+
+    /// Encode a commitment to this receipt as one canonical RVF witness entry.
+    ///
+    /// `previous_entry_hash` is zero for a genesis entry, otherwise it is
+    /// SHAKE-256 of the preceding 73-byte entry.
+    #[must_use]
+    pub fn to_rvf_witness_entry(&self, previous_entry_hash: [u8; 32]) -> [u8; 73] {
+        let mut entry = [0u8; RVF_WITNESS_ENTRY_SIZE];
+        entry[..32].copy_from_slice(&previous_entry_hash);
+        entry[32..64].copy_from_slice(&shake256(&self.signed.to_bytes()));
+        entry[64..72].copy_from_slice(&self.signed.receipt.ended_ns.to_le_bytes());
+        entry[72] = RVF_WITNESS_COMPUTATION;
+        entry
+    }
+
+    /// Emit the authenticated epoch seal into the next RVM witness epoch.
+    #[must_use]
+    pub fn emit_seal<const N: usize>(
+        &self,
+        log: &WitnessLog<N>,
+        actor_partition_id: u32,
+        capability_hash: u32,
+        timestamp_ns: u64,
+    ) -> u64 {
+        let id = self.signed.receipt_id();
+        let mut record = WitnessRecord::zeroed();
+        record.action_kind = ActionKind::ContextEpochSeal as u8;
+        // Receipt signature verification authenticates the signer but does
+        // not itself run the P2 policy engine. Record the actual P1 runtime
+        // authorization rather than overstating the assurance tier.
+        record.proof_tier = 1;
+        record.actor_partition_id = actor_partition_id;
+        record.target_object_id = u64::from_le_bytes(id[..8].try_into().unwrap_or([0; 8]));
+        record.capability_hash = capability_hash;
+        record.payload = self.signed.receipt.last_sequence.to_le_bytes();
+        record
+            .aux
+            .copy_from_slice(&self.signed.receipt.witness_root[..8]);
+        record.timestamp_ns = timestamp_ns;
+        log.append(record)
+    }
+}
+
+/// SHAKE-256 hash of one serialized RVF witness entry.
+#[must_use]
+pub fn rvf_witness_entry_hash(entry: &[u8; RVF_WITNESS_ENTRY_SIZE]) -> [u8; 32] {
+    shake256(entry)
+}
+
+fn merkle_root(records: &[WitnessRecord]) -> [u8; 32] {
+    let mut level: Vec<[u8; 32]> = records
+        .iter()
+        .map(|record| {
+            let mut hasher = Sha256::new();
+            Digest::update(&mut hasher, LEAF_DOMAIN);
+            Digest::update(&mut hasher, record_to_bytes(record));
+            finalize_sha256(hasher)
+        })
+        .collect();
+
+    while level.len() > 1 {
+        let current_len = level.len();
+        let parent_count = current_len.div_ceil(2);
+        for parent in 0..parent_count {
+            let left_index = parent * 2;
+            let right = if left_index + 1 < current_len {
+                level[left_index + 1]
+            } else {
+                level[left_index]
+            };
+            let mut hasher = Sha256::new();
+            Digest::update(&mut hasher, NODE_DOMAIN);
+            Digest::update(&mut hasher, level[left_index]);
+            Digest::update(&mut hasher, right);
+            level[parent] = finalize_sha256(hasher);
+        }
+        level.truncate(parent_count);
+    }
+    level.first().copied().unwrap_or([0; 32])
+}
+
+fn timestamp_bounds(records: &[WitnessRecord]) -> (u64, u64) {
+    let initial = records.first().map_or(0, |record| record.timestamp_ns);
+    records
+        .iter()
+        .fold((initial, initial), |(minimum, maximum), record| {
+            (
+                minimum.min(record.timestamp_ns),
+                maximum.max(record.timestamp_ns),
+            )
+        })
+}
+
+fn finalize_sha256(hasher: Sha256) -> [u8; 32] {
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+fn shake256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = sha3::Shake256::default();
+    hasher.update(data);
+    let mut out = [0u8; 32];
+    hasher.finalize_xof().read(&mut out);
+    out
+}
+
+fn read_u16(data: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap_or([0; 2]))
+}
+
+fn read_u32(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap_or([0; 4]))
+}
+
+fn read_u64(data: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap_or([0; 8]))
+}
+
+fn array32(data: &[u8], offset: usize) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&data[offset..offset + 32]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rvm_proof::HmacSha256WitnessSigner;
+
+    fn context_record(kind: ActionKind, target: u64, timestamp_ns: u64) -> WitnessRecord {
+        let mut record = WitnessRecord::zeroed();
+        record.action_kind = kind as u8;
+        record.actor_partition_id = 7;
+        record.target_object_id = target;
+        record.timestamp_ns = timestamp_ns;
+        record
+    }
+
+    fn sealed() -> (
+        SignedContextEpochReceipt,
+        Vec<WitnessRecord>,
+        HmacSha256WitnessSigner,
+    ) {
+        let log = WitnessLog::<16>::new();
+        let checkpoint = log.checkpoint();
+        log.append(context_record(ActionKind::ContextResolve, 1, 10));
+        log.append(context_record(ActionKind::ContextRead, 2, 11));
+        let mut records = [WitnessRecord::zeroed(); 4];
+        let (receipt, _) = ContextEpochReceipt::seal_from_log(
+            9,
+            &log,
+            checkpoint,
+            &mut records,
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+        let signer = HmacSha256WitnessSigner::new([0x55; 32]);
+        (receipt.sign(&signer), records[..2].to_vec(), signer)
+    }
+
+    #[test]
+    fn signed_receipt_round_trips_and_reproduces_records() {
+        let (sealed_receipt, records, authenticator) = sealed();
+        sealed_receipt.verify(&authenticator).unwrap();
+        sealed_receipt.receipt.verify_records(&records).unwrap();
+        let decoded = SignedContextEpochReceipt::from_bytes(&sealed_receipt.to_bytes()).unwrap();
+        assert_eq!(decoded, sealed_receipt);
+        decoded.verify(&authenticator).unwrap();
+    }
+
+    #[test]
+    fn one_bit_tamper_fails_signature() {
+        let (sealed_receipt, _, authenticator) = sealed();
+        let mut bytes = sealed_receipt.to_bytes();
+        bytes[128] ^= 1;
+        let tampered = SignedContextEpochReceipt::from_bytes(&bytes).unwrap();
+        assert!(matches!(
+            tampered.verify(&authenticator),
+            Err(ContextReceiptError::Signature(_))
+        ));
+    }
+
+    #[test]
+    fn adversarial_sequence_span_is_rejected_without_overflow() {
+        let (signed, _, _) = sealed();
+        let mut bytes = signed.to_bytes();
+        bytes[16..24].copy_from_slice(&0u64.to_le_bytes());
+        bytes[24..32].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert_eq!(
+            SignedContextEpochReceipt::from_bytes(&bytes),
+            Err(ContextReceiptError::SequenceRange)
+        );
+    }
+
+    #[test]
+    fn decoded_record_count_cannot_exceed_epoch_limit() {
+        let (signed, _, _) = sealed();
+        let mut bytes = signed.to_bytes();
+        let count = u32::try_from(MAX_CONTEXT_EPOCH_RECORDS + 1).unwrap();
+        bytes[16..24].copy_from_slice(&0u64.to_le_bytes());
+        bytes[24..32].copy_from_slice(&(u64::from(count) - 1).to_le_bytes());
+        bytes[32..36].copy_from_slice(&count.to_le_bytes());
+        assert_eq!(
+            SignedContextEpochReceipt::from_bytes(&bytes),
+            Err(ContextReceiptError::TooManyRecords)
+        );
+    }
+
+    #[test]
+    fn sequence_order_accepts_non_monotonic_timestamps_and_commits_bounds() {
+        let log = WitnessLog::<8>::new();
+        let checkpoint = log.checkpoint();
+        log.append(context_record(ActionKind::ContextResolve, 1, 30));
+        log.append(context_record(ActionKind::ContextRead, 2, 10));
+        log.append(context_record(ActionKind::ContextRead, 3, 20));
+        let mut scratch = [WitnessRecord::zeroed(); 3];
+        let (receipt, _) = ContextEpochReceipt::seal_from_log(
+            0,
+            &log,
+            checkpoint,
+            &mut scratch,
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+
+        assert_eq!(receipt.started_ns(), 10);
+        assert_eq!(receipt.ended_ns(), 30);
+        receipt.verify_records(&scratch).unwrap();
+    }
+
+    #[test]
+    fn record_tamper_fails_committed_root() {
+        let (signed, mut records, _) = sealed();
+        records[0].target_object_id ^= 1;
+        assert!(signed.receipt.verify_records(&records).is_err());
+    }
+
+    #[test]
+    fn different_signer_is_rejected_before_signature_check() {
+        let (signed, _, _) = sealed();
+        let other = HmacSha256WitnessSigner::new([0x56; 32]);
+        assert_eq!(
+            signed.verify(&other),
+            Err(ContextReceiptError::SignerMismatch)
+        );
+    }
+
+    #[test]
+    fn wrapped_epoch_is_never_partially_sealed() {
+        let log = WitnessLog::<2>::new();
+        let checkpoint = log.checkpoint();
+        for sequence in 0..3 {
+            log.append(context_record(ActionKind::ContextRead, sequence, sequence));
+        }
+        let mut records = [WitnessRecord::zeroed(); 3];
+        let result = ContextEpochReceipt::seal_from_log(
+            1,
+            &log,
+            checkpoint,
+            &mut records,
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+        );
+        assert_eq!(
+            result,
+            Err(ContextReceiptError::Snapshot(
+                SnapshotSinceError::RecordsOverwritten
+            ))
+        );
+    }
+
+    #[test]
+    fn direct_seal_rejects_more_than_the_default_ring_capacity() {
+        let records = alloc::vec![
+            WitnessRecord::zeroed();
+            MAX_CONTEXT_EPOCH_RECORDS + 1
+        ];
+        let checkpoint = WitnessLog::<1>::new().checkpoint();
+        assert_eq!(
+            ContextEpochReceipt::seal(
+                1, checkpoint, &records, [0; 32], [0; 32], [0; 32], [0; 32], [0; 32],
+            ),
+            Err(ContextReceiptError::TooManyRecords)
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn verified_receipts_enforce_genesis_and_successor_continuity() {
+        let signer = HmacSha256WitnessSigner::new([0x77; 32]);
+        let log = WitnessLog::<8>::new();
+        let genesis = log.checkpoint();
+        log.append(context_record(ActionKind::ContextResolve, 1, 30));
+        let mut first_records = [WitnessRecord::zeroed(); 1];
+        let (first, next) = ContextEpochReceipt::seal_from_log(
+            0,
+            &log,
+            genesis,
+            &mut first_records,
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+        let first_signed = first.sign(&signer);
+        let first_verified = first_signed.verify(&signer).unwrap();
+        first_verified.verify_genesis().unwrap();
+
+        log.append(context_record(ActionKind::ContextRead, 2, 10));
+        let mut second_records = [WitnessRecord::zeroed(); 1];
+        let (second, after_second) = ContextEpochReceipt::seal_from_log(
+            1,
+            &log,
+            next,
+            &mut second_records,
+            first_signed.receipt_id(),
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+        let second_signed = second.sign(&signer);
+        let second_verified = second_signed.verify(&signer).unwrap();
+        second_verified.verify_successor(&first_verified).unwrap();
+
+        log.append(context_record(ActionKind::ContextRead, 3, 20));
+        let mut skipped_records = [WitnessRecord::zeroed(); 1];
+        let (skipped, _) = ContextEpochReceipt::seal_from_log(
+            1,
+            &log,
+            after_second,
+            &mut skipped_records,
+            first_signed.receipt_id(),
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+        let skipped_signed = skipped.sign(&signer);
+        let skipped_verified = skipped_signed.verify(&signer).unwrap();
+        assert_eq!(
+            skipped_verified.verify_genesis(),
+            Err(ContextReceiptError::ReceiptContinuity)
+        );
+        assert_eq!(
+            skipped_verified.verify_successor(&first_verified),
+            Err(ContextReceiptError::ReceiptContinuity)
+        );
+
+        let wrong_link = ContextEpochReceipt::seal(
+            1,
+            next,
+            &second_records,
+            [9; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap()
+        .sign(&signer);
+        assert_eq!(
+            wrong_link
+                .verify(&signer)
+                .unwrap()
+                .verify_successor(&first_verified),
+            Err(ContextReceiptError::ReceiptContinuity)
+        );
+
+        let mut wrong_initial_chain = second.clone();
+        wrong_initial_chain.initial_chain_hash ^= 1;
+        let wrong_initial_chain = wrong_initial_chain.sign(&signer);
+        assert_eq!(
+            wrong_initial_chain
+                .verify(&signer)
+                .unwrap()
+                .verify_successor(&first_verified),
+            Err(ContextReceiptError::ReceiptContinuity)
+        );
+
+        let skipped_epoch = ContextEpochReceipt::seal(
+            2,
+            next,
+            &second_records,
+            first_signed.receipt_id(),
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap()
+        .sign(&signer);
+        assert_eq!(
+            skipped_epoch
+                .verify(&signer)
+                .unwrap()
+                .verify_successor(&first_verified),
+            Err(ContextReceiptError::ReceiptContinuity)
+        );
+
+        let overflowed_prior = ContextEpochReceipt::seal(
+            u64::MAX,
+            genesis,
+            &first_records,
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap()
+        .sign(&signer);
+        assert_eq!(
+            second_verified.verify_successor(&overflowed_prior.verify(&signer).unwrap()),
+            Err(ContextReceiptError::ReceiptContinuity)
+        );
+    }
+
+    #[test]
+    fn rvf_entry_is_exact_and_chain_linked() {
+        let (sealed_receipt, _, authenticator) = sealed();
+        let verified = sealed_receipt.verify(&authenticator).unwrap();
+        let first = verified.to_rvf_witness_entry([0; 32]);
+        assert_eq!(first.len(), RVF_WITNESS_ENTRY_SIZE);
+        assert_eq!(first[72], RVF_WITNESS_COMPUTATION);
+        let previous = rvf_witness_entry_hash(&first);
+        let second = verified.to_rvf_witness_entry(previous);
+        assert_eq!(&second[..32], &previous);
+        assert_ne!(&second[32..64], &[0; 32]);
+    }
+
+    #[test]
+    fn seal_event_belongs_to_the_next_epoch() {
+        let (sealed_receipt, _, authenticator) = sealed();
+        let verified = sealed_receipt.verify(&authenticator).unwrap();
+        let log = WitnessLog::<4>::new();
+        let sequence = verified.emit_seal(&log, 7, 99, 12);
+        assert_eq!(sequence, 0);
+        assert_eq!(
+            log.get(0).unwrap().action_kind,
+            ActionKind::ContextEpochSeal as u8
+        );
+        assert_eq!(log.get(0).unwrap().proof_tier, 1);
+    }
+
+    #[test]
+    fn atomic_end_checkpoint_prevents_records_falling_between_epochs() {
+        let log = WitnessLog::<8>::new();
+        let genesis = log.checkpoint();
+        log.append(context_record(ActionKind::ContextResolve, 1, 10));
+        let mut first_records = [WitnessRecord::zeroed(); 4];
+        let (first, next) = ContextEpochReceipt::seal_from_log(
+            1,
+            &log,
+            genesis,
+            &mut first_records,
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+
+        log.append(context_record(ActionKind::ContextRead, 2, 11));
+        let mut second_records = [WitnessRecord::zeroed(); 4];
+        let (second, end) = ContextEpochReceipt::seal_from_log(
+            2,
+            &log,
+            next,
+            &mut second_records,
+            first
+                .sign(&HmacSha256WitnessSigner::new([9; 32]))
+                .receipt_id(),
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+        )
+        .unwrap();
+
+        assert_eq!((first.first_sequence, first.last_sequence), (0, 0));
+        assert_eq!((second.first_sequence, second.last_sequence), (1, 1));
+        assert_eq!(end, log.checkpoint());
+    }
+}

--- a/crates/rvm-context/src/resolver.rs
+++ b/crates/rvm-context/src/resolver.rs
@@ -1,0 +1,1574 @@
+//! Resolver contract and a bounded in-memory conformance implementation.
+//!
+//! The trait accepts only [`AuthorizedRequest`] values. Their construction is
+//! private to this crate and occurs after a live capability check and witness
+//! append, making resolver invocation structurally later than authorization.
+//! [`MemoryResolver`] is intentionally a deterministic reference backend, not
+//! an ANN implementation; production RuVector adapters implement the same
+//! contract without treating metadata filters as an authorization boundary.
+
+use crate::capability::{AuthorizedRequest, ContextOperation, MAX_SEARCH_RESULTS};
+use crate::error::{ContextError, ContextResult};
+use crate::profile::{ProfileTrust, VerifiedContextProfile};
+use crate::uri::{PinnedRuvUri, Revision, RuvUri};
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use sha2::{Digest, Sha256};
+
+/// Maximum whole-RVF size accepted by the in-memory conformance resolver.
+pub const MAX_RVF_BYTES: usize = 16 * 1024 * 1024;
+
+/// Maximum query size accepted by the in-memory conformance search.
+pub const MAX_SEARCH_QUERY_BYTES: usize = 4 * 1024;
+
+/// Maximum entries returned by list, tree, or history enumeration.
+pub const MAX_ENUM_RESULTS: usize = 64;
+
+const TOMBSTONE_DOMAIN: &[u8] = b"RUV-CONTEXT-TOMBSTONE-V1";
+
+/// Monotonic generation of one versionless alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AliasGeneration(u64);
+
+impl AliasGeneration {
+    /// First generation assigned when an alias is created.
+    pub const INITIAL: Self = Self(1);
+
+    /// Construct a nonzero generation.
+    #[must_use]
+    pub const fn new(value: u64) -> Option<Self> {
+        if value == 0 {
+            None
+        } else {
+            Some(Self(value))
+        }
+    }
+
+    /// Return the numeric generation.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    fn next(self) -> ContextResult<Self> {
+        self.0
+            .checked_add(1)
+            .map(Self)
+            .ok_or(ContextError::AliasGenerationExhausted)
+    }
+}
+
+/// Complete compare-and-swap state of a versionless alias.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AliasSnapshot {
+    alias: RuvUri,
+    revision: Revision,
+    generation: AliasGeneration,
+    tombstone: bool,
+}
+
+impl AliasSnapshot {
+    /// Return the canonical versionless alias.
+    #[must_use]
+    pub const fn alias(&self) -> &RuvUri {
+        &self.alias
+    }
+
+    /// Return the immutable revision currently named by the alias.
+    #[must_use]
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Return the anti-ABA generation.
+    #[must_use]
+    pub const fn generation(&self) -> AliasGeneration {
+        self.generation
+    }
+
+    /// Whether the alias is permanently tombstoned.
+    #[must_use]
+    pub const fn is_tombstone(&self) -> bool {
+        self.tombstone
+    }
+}
+
+/// Metadata returned after resolving a target to one immutable RVF revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedContext {
+    pinned_uri: PinnedRuvUri,
+    revision: Revision,
+    alias: Option<AliasSnapshot>,
+    rvf_len: usize,
+}
+
+impl ResolvedContext {
+    /// Return the immutable URI suitable for citations and receipts.
+    #[must_use]
+    pub const fn pinned_uri(&self) -> &PinnedRuvUri {
+        &self.pinned_uri
+    }
+
+    /// Return the whole-RVF identity.
+    #[must_use]
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Return alias state when a versionless name was resolved.
+    #[must_use]
+    pub const fn alias(&self) -> Option<&AliasSnapshot> {
+        self.alias.as_ref()
+    }
+
+    /// Return the immutable RVF byte length without disclosing its bytes.
+    #[must_use]
+    pub const fn rvf_len(&self) -> usize {
+        self.rvf_len
+    }
+}
+
+/// One bounded result from a governed search.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextHit {
+    pinned_uri: PinnedRuvUri,
+    revision: Revision,
+    score: u32,
+    alias_generation: Option<AliasGeneration>,
+}
+
+impl ContextHit {
+    /// Return the immutable result URI.
+    #[must_use]
+    pub const fn pinned_uri(&self) -> &PinnedRuvUri {
+        &self.pinned_uri
+    }
+
+    /// Return the whole-RVF identity.
+    #[must_use]
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Return the deterministic conformance score.
+    #[must_use]
+    pub const fn score(&self) -> u32 {
+        self.score
+    }
+
+    /// Return the alias generation used for an unpinned search result.
+    #[must_use]
+    pub const fn alias_generation(&self) -> Option<AliasGeneration> {
+        self.alias_generation
+    }
+}
+
+/// Governed resolver operations available to [`crate::ContextRuntime`].
+///
+/// Every method receives an authorization permit that already binds one actor,
+/// operation, and canonical target and records the pre-call witness sequence.
+pub trait ContextResolver {
+    /// Resolve metadata without returning RVF bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a resolver error for absent, tombstoned, or inconsistent state.
+    fn resolve(&mut self, request: &AuthorizedRequest) -> ContextResult<ResolvedContext>;
+
+    /// List live direct-child aliases below a versionless target.
+    ///
+    /// # Errors
+    ///
+    /// Refuses a zero or oversized bound and inconsistent stored state.
+    fn list(
+        &mut self,
+        request: &AuthorizedRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>>;
+
+    /// Enumerate live descendant aliases below a versionless target.
+    ///
+    /// # Errors
+    ///
+    /// Refuses a zero or oversized bound and inconsistent stored state.
+    fn tree(
+        &mut self,
+        request: &AuthorizedRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>>;
+
+    /// Read a whole immutable RVF object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for absent revisions or tombstones. The governed
+    /// runtime verifies the profile and releases only the requested view.
+    fn read(&mut self, request: &AuthorizedRequest) -> ContextResult<(ResolvedContext, Vec<u8>)>;
+
+    /// Search live alias heads below the authorized target.
+    ///
+    /// # Errors
+    ///
+    /// Refuses empty or oversized queries and invalid result bounds.
+    fn search(
+        &mut self,
+        request: &AuthorizedRequest,
+        query: &[u8],
+        limit: usize,
+    ) -> ContextResult<Vec<ContextHit>>;
+
+    /// Enumerate immutable revisions registered under one live alias.
+    ///
+    /// # Errors
+    ///
+    /// Refuses absent or tombstoned aliases and invalid result bounds.
+    fn history(
+        &mut self,
+        request: &AuthorizedRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>>;
+
+    /// Re-hash and verify one pinned immutable revision without returning it.
+    ///
+    /// # Errors
+    ///
+    /// Refuses absent, tombstoned, forgotten, or corrupt revisions.
+    fn verify(&mut self, request: &AuthorizedRequest) -> ContextResult<(ResolvedContext, Vec<u8>)>;
+
+    /// Register runtime-verified immutable bytes under their pinned identity.
+    ///
+    /// # Errors
+    ///
+    /// Refuses hash mismatch, conflicting bytes, or capacity exhaustion.
+    fn put(&mut self, request: &AuthorizedRequest, rvf: &[u8]) -> ContextResult<ResolvedContext>;
+
+    /// Atomically create or advance one versionless alias.
+    ///
+    /// `expected = None` means the alias must be absent. Otherwise every field
+    /// of the prior snapshot, including generation and revision, must match.
+    ///
+    /// # Errors
+    ///
+    /// Refuses stale snapshots, tombstones, missing revisions, and overflow.
+    fn compare_and_swap_alias(
+        &mut self,
+        request: &AuthorizedRequest,
+        expected: Option<&AliasSnapshot>,
+        next_revision: Revision,
+    ) -> ContextResult<AliasSnapshot>;
+
+    /// Permanently advance an alias to a new immutable tombstone revision.
+    ///
+    /// # Errors
+    ///
+    /// Refuses a stale snapshot, missing alias, repeat forget, or capacity
+    /// exhaustion.
+    fn forget(
+        &mut self,
+        request: &AuthorizedRequest,
+        expected: &AliasSnapshot,
+    ) -> ContextResult<AliasSnapshot>;
+
+    /// Load a pinned executable revision for internal runtime verification.
+    /// The governed runtime returns only an [`crate::ExecutionPermit`] to its
+    /// caller and never releases these bytes through the execute path.
+    ///
+    /// # Errors
+    ///
+    /// Refuses absent, forgotten, tombstoned, or unpinned targets.
+    fn prepare_execute(
+        &mut self,
+        request: &AuthorizedRequest,
+    ) -> ContextResult<(ResolvedContext, Vec<u8>)>;
+}
+
+#[derive(Debug, Clone)]
+struct StoredObject {
+    canonical_uri: RuvUri,
+    revision: Revision,
+    rvf: Vec<u8>,
+    tombstone: bool,
+    forgotten: bool,
+}
+
+#[derive(Debug, Clone)]
+struct StoredAlias {
+    snapshot: AliasSnapshot,
+}
+
+/// Const-bounded in-memory resolver for conformance tests and local use.
+///
+/// Objects are keyed by `(logical name, complete-RVF SHA-256 identity)` so
+/// identical containers can be registered independently in different tenant
+/// scopes without creating a cross-scope existence oracle. Existing bytes are
+/// never replaced. Alias state advances only through generation-checked CAS.
+#[derive(Debug)]
+pub struct MemoryResolver<const OBJECTS: usize = 64, const ALIASES: usize = 64> {
+    objects: Vec<StoredObject>,
+    aliases: Vec<StoredAlias>,
+}
+
+impl<const OBJECTS: usize, const ALIASES: usize> MemoryResolver<OBJECTS, ALIASES> {
+    /// Create an empty resolver.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            objects: Vec::new(),
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Return the number of immutable revision records, including tombstones.
+    #[must_use]
+    pub fn object_count(&self) -> usize {
+        self.objects.len()
+    }
+
+    /// Return the number of versionless aliases.
+    #[must_use]
+    pub fn alias_count(&self) -> usize {
+        self.aliases.len()
+    }
+
+    fn ensure_operation(
+        request: &AuthorizedRequest,
+        expected: ContextOperation,
+    ) -> ContextResult<()> {
+        if request.operation() == expected {
+            Ok(())
+        } else {
+            Err(ContextError::OperationMismatch)
+        }
+    }
+
+    fn object_for(&self, target: &RuvUri, revision: Revision) -> Option<&StoredObject> {
+        self.objects.iter().find(|object| {
+            object.revision == revision && same_logical_name(&object.canonical_uri, target)
+        })
+    }
+
+    fn alias_index(&self, target: &RuvUri) -> Option<usize> {
+        self.aliases
+            .iter()
+            .position(|entry| same_logical_name(entry.snapshot.alias(), target))
+    }
+
+    fn validate_enumeration_limit(limit: usize) -> ContextResult<()> {
+        if limit == 0 || limit > MAX_ENUM_RESULTS {
+            Err(ContextError::InvalidResultLimit)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn enumerate_aliases(
+        &self,
+        target: &RuvUri,
+        limit: usize,
+        recursive: bool,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        Self::validate_enumeration_limit(limit)?;
+        let mut entries = Vec::new();
+        for entry in &self.aliases {
+            let snapshot = &entry.snapshot;
+            let child_depth = snapshot.alias().path().len();
+            let root_depth = target.path().len();
+            let is_descendant = child_depth > root_depth && is_within(target, snapshot.alias());
+            if snapshot.tombstone || !is_descendant || (!recursive && child_depth != root_depth + 1)
+            {
+                continue;
+            }
+            let Some(object) = self.object_for(snapshot.alias(), snapshot.revision) else {
+                continue;
+            };
+            if object.tombstone || object.forgotten {
+                continue;
+            }
+            let pinned = snapshot
+                .alias
+                .clone()
+                .with_revision(snapshot.revision)
+                .map_err(|_| ContextError::InvalidTarget)?;
+            entries.push(ResolvedContext {
+                pinned_uri: pinned,
+                revision: snapshot.revision,
+                alias: Some(snapshot.clone()),
+                rvf_len: object.rvf.len(),
+            });
+        }
+        entries.sort_by(|left, right| left.pinned_uri.cmp(&right.pinned_uri));
+        entries.truncate(limit);
+        Ok(entries)
+    }
+
+    fn score_view(
+        object: &StoredObject,
+        requested: Option<crate::uri::ProgressiveView>,
+        matcher: &QueryMatcher<'_>,
+    ) -> ContextResult<u32> {
+        let profile = VerifiedContextProfile::from_rvf(
+            &object.rvf,
+            object.revision,
+            ProfileTrust::PinnedIdentity,
+            &[],
+        )
+        .map_err(|_| ContextError::RvfVerificationFailed)?;
+        let view = requested.unwrap_or(crate::uri::ProgressiveView::Overview);
+        if profile.profile().view(view).is_none() {
+            return Ok(0);
+        }
+        let payload = profile
+            .payload(&object.rvf, view)
+            .map_err(|_| ContextError::RvfVerificationFailed)?;
+        Ok(matcher.occurrence_count(payload))
+    }
+
+    fn resolved_for(&self, target: &RuvUri) -> ContextResult<(ResolvedContext, usize)> {
+        if let Some(revision) = target.revision() {
+            let (index, object) = self
+                .objects
+                .iter()
+                .enumerate()
+                .find(|(_, object)| {
+                    object.revision == revision && same_logical_name(&object.canonical_uri, target)
+                })
+                .ok_or(ContextError::RevisionNotFound)?;
+            if object.tombstone || object.forgotten {
+                return Err(ContextError::Tombstoned);
+            }
+            let pinned = PinnedRuvUri::try_from(target.clone())
+                .map_err(|_| ContextError::PinnedUriRequired)?;
+            return Ok((
+                ResolvedContext {
+                    pinned_uri: pinned,
+                    revision,
+                    alias: None,
+                    rvf_len: object.rvf.len(),
+                },
+                index,
+            ));
+        }
+
+        let alias_index = self
+            .alias_index(target)
+            .ok_or(ContextError::AliasNotFound)?;
+        let snapshot = self.aliases[alias_index].snapshot.clone();
+        if snapshot.tombstone {
+            return Err(ContextError::Tombstoned);
+        }
+        let (object_index, object) = self
+            .objects
+            .iter()
+            .enumerate()
+            .find(|(_, object)| {
+                object.revision == snapshot.revision
+                    && same_logical_name(&object.canonical_uri, target)
+            })
+            .ok_or(ContextError::RevisionNotFound)?;
+        if object.tombstone || object.forgotten || !same_logical_name(&object.canonical_uri, target)
+        {
+            return Err(if object.tombstone || object.forgotten {
+                ContextError::Tombstoned
+            } else {
+                ContextError::RevisionConflict
+            });
+        }
+        let pinned = target
+            .clone()
+            .with_revision(snapshot.revision)
+            .map_err(|_| ContextError::InvalidTarget)?;
+        Ok((
+            ResolvedContext {
+                pinned_uri: pinned,
+                revision: snapshot.revision,
+                alias: Some(snapshot),
+                rvf_len: object.rvf.len(),
+            },
+            object_index,
+        ))
+    }
+
+    fn insert_tombstone(
+        &mut self,
+        alias: &RuvUri,
+        expected: &AliasSnapshot,
+        generation: AliasGeneration,
+    ) -> ContextResult<Revision> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(TOMBSTONE_DOMAIN);
+        payload.push(0);
+        payload.extend_from_slice(alias.to_string().as_bytes());
+        payload.push(0);
+        payload.extend_from_slice(expected.revision.as_bytes());
+        payload.extend_from_slice(&generation.get().to_le_bytes());
+        let digest = Sha256::digest(&payload);
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&digest);
+        let revision = Revision::from_bytes(bytes);
+
+        if let Some(existing) = self.object_for(alias, revision) {
+            if existing.tombstone && existing.rvf == payload {
+                return Ok(revision);
+            }
+            return Err(ContextError::RevisionConflict);
+        }
+        if self.objects.len() >= OBJECTS {
+            return Err(ContextError::ObjectTableFull);
+        }
+        self.objects.push(StoredObject {
+            canonical_uri: alias.clone(),
+            revision,
+            rvf: payload,
+            tombstone: true,
+            forgotten: false,
+        });
+        Ok(revision)
+    }
+}
+
+impl<const OBJECTS: usize, const ALIASES: usize> Default for MemoryResolver<OBJECTS, ALIASES> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const OBJECTS: usize, const ALIASES: usize> ContextResolver
+    for MemoryResolver<OBJECTS, ALIASES>
+{
+    fn resolve(&mut self, request: &AuthorizedRequest) -> ContextResult<ResolvedContext> {
+        Self::ensure_operation(request, ContextOperation::Resolve)?;
+        self.resolved_for(request.target())
+            .map(|(resolved, _)| resolved)
+    }
+
+    fn list(
+        &mut self,
+        request: &AuthorizedRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        Self::ensure_operation(request, ContextOperation::List)?;
+        self.enumerate_aliases(request.target(), limit, false)
+    }
+
+    fn tree(
+        &mut self,
+        request: &AuthorizedRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        Self::ensure_operation(request, ContextOperation::Tree)?;
+        self.enumerate_aliases(request.target(), limit, true)
+    }
+
+    fn read(&mut self, request: &AuthorizedRequest) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+        Self::ensure_operation(request, ContextOperation::Read)?;
+        let (resolved, object_index) = self.resolved_for(request.target())?;
+        Ok((resolved, self.objects[object_index].rvf.clone()))
+    }
+
+    fn search(
+        &mut self,
+        request: &AuthorizedRequest,
+        query: &[u8],
+        limit: usize,
+    ) -> ContextResult<Vec<ContextHit>> {
+        Self::ensure_operation(request, ContextOperation::Search)?;
+        if query.is_empty() || query.len() > MAX_SEARCH_QUERY_BYTES {
+            return Err(ContextError::InvalidQuery);
+        }
+        if limit == 0 || limit > MAX_SEARCH_RESULTS {
+            return Err(ContextError::InvalidResultLimit);
+        }
+
+        let matcher = QueryMatcher::new(query);
+        let mut hits = Vec::with_capacity(limit);
+        if let Some(revision) = request.target().revision() {
+            if let Some(object) = self.object_for(request.target(), revision) {
+                if !object.tombstone
+                    && !object.forgotten
+                    && same_logical_name(&object.canonical_uri, request.target())
+                {
+                    let score = Self::score_view(object, request.target().view(), &matcher)?;
+                    if score > 0 {
+                        let pinned = PinnedRuvUri::try_from(request.target().clone())
+                            .map_err(|_| ContextError::PinnedUriRequired)?;
+                        push_top_hit(
+                            &mut hits,
+                            limit,
+                            ContextHit {
+                                pinned_uri: pinned,
+                                revision,
+                                score,
+                                alias_generation: None,
+                            },
+                        );
+                    }
+                }
+            }
+        } else {
+            for entry in &self.aliases {
+                let snapshot = &entry.snapshot;
+                if snapshot.tombstone || !is_within(request.target(), snapshot.alias()) {
+                    continue;
+                }
+                let Some(object) = self.object_for(snapshot.alias(), snapshot.revision) else {
+                    continue;
+                };
+                if object.tombstone || object.forgotten {
+                    continue;
+                }
+                let score = Self::score_view(object, request.target().view(), &matcher)?;
+                if score == 0 {
+                    continue;
+                }
+                let pinned = snapshot
+                    .alias
+                    .clone()
+                    .with_revision(snapshot.revision)
+                    .map_err(|_| ContextError::InvalidTarget)?;
+                push_top_hit(
+                    &mut hits,
+                    limit,
+                    ContextHit {
+                        pinned_uri: pinned,
+                        revision: snapshot.revision,
+                        score,
+                        alias_generation: Some(snapshot.generation),
+                    },
+                );
+            }
+        }
+        hits.sort_by(compare_hits);
+        Ok(hits)
+    }
+
+    fn history(
+        &mut self,
+        request: &AuthorizedRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        Self::ensure_operation(request, ContextOperation::History)?;
+        Self::validate_enumeration_limit(limit)?;
+        let alias_index = self
+            .alias_index(request.target())
+            .ok_or(ContextError::AliasNotFound)?;
+        if self.aliases[alias_index].snapshot.tombstone {
+            return Err(ContextError::Tombstoned);
+        }
+
+        let mut entries = Vec::new();
+        for object in &self.objects {
+            if object.tombstone
+                || object.forgotten
+                || !same_logical_name(&object.canonical_uri, request.target())
+            {
+                continue;
+            }
+            let pinned = request
+                .target()
+                .clone()
+                .with_revision(object.revision)
+                .map_err(|_| ContextError::InvalidTarget)?;
+            entries.push(ResolvedContext {
+                pinned_uri: pinned,
+                revision: object.revision,
+                alias: None,
+                rvf_len: object.rvf.len(),
+            });
+        }
+        entries.sort_by_key(ResolvedContext::revision);
+        entries.truncate(limit);
+        Ok(entries)
+    }
+
+    fn verify(&mut self, request: &AuthorizedRequest) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+        Self::ensure_operation(request, ContextOperation::Verify)?;
+        let (resolved, object_index) = self.resolved_for(request.target())?;
+        let digest = Sha256::digest(&self.objects[object_index].rvf);
+        if &digest[..] != resolved.revision.as_bytes() {
+            return Err(ContextError::RevisionHashMismatch);
+        }
+        Ok((resolved, self.objects[object_index].rvf.clone()))
+    }
+
+    fn put(&mut self, request: &AuthorizedRequest, rvf: &[u8]) -> ContextResult<ResolvedContext> {
+        Self::ensure_operation(request, ContextOperation::Put)?;
+        if rvf.len() > MAX_RVF_BYTES {
+            return Err(ContextError::ObjectTooLarge);
+        }
+        let pinned = PinnedRuvUri::try_from(request.target().clone())
+            .map_err(|_| ContextError::PinnedUriRequired)?;
+        let revision = pinned.revision();
+        let digest = Sha256::digest(rvf);
+        if digest.as_slice() != revision.as_bytes() {
+            return Err(ContextError::RevisionHashMismatch);
+        }
+
+        if let Some(existing) = self.object_for(request.target(), revision) {
+            if existing.rvf == rvf
+                && !existing.tombstone
+                && !existing.forgotten
+                && same_logical_name(&existing.canonical_uri, request.target())
+            {
+                return Ok(ResolvedContext {
+                    pinned_uri: pinned,
+                    revision,
+                    alias: None,
+                    rvf_len: existing.rvf.len(),
+                });
+            }
+            return Err(ContextError::RevisionConflict);
+        }
+        if self.objects.len() >= OBJECTS {
+            return Err(ContextError::ObjectTableFull);
+        }
+        self.objects.push(StoredObject {
+            canonical_uri: request.target().clone(),
+            revision,
+            rvf: rvf.to_vec(),
+            tombstone: false,
+            forgotten: false,
+        });
+        Ok(ResolvedContext {
+            pinned_uri: pinned,
+            revision,
+            alias: None,
+            rvf_len: rvf.len(),
+        })
+    }
+
+    fn compare_and_swap_alias(
+        &mut self,
+        request: &AuthorizedRequest,
+        expected: Option<&AliasSnapshot>,
+        next_revision: Revision,
+    ) -> ContextResult<AliasSnapshot> {
+        Self::ensure_operation(request, ContextOperation::CompareAndSwapAlias)?;
+        if request.target().is_pinned() {
+            return Err(ContextError::ImmutableRevision);
+        }
+        let next = self
+            .object_for(request.target(), next_revision)
+            .ok_or(ContextError::RevisionNotFound)?;
+        if next.tombstone || next.forgotten {
+            return Err(ContextError::Tombstoned);
+        }
+        if !same_logical_name(&next.canonical_uri, request.target()) {
+            return Err(ContextError::RevisionConflict);
+        }
+
+        if let Some(index) = self.alias_index(request.target()) {
+            let current = &self.aliases[index].snapshot;
+            if current.tombstone {
+                return Err(ContextError::Tombstoned);
+            }
+            if expected != Some(current) {
+                return Err(ContextError::AliasConflict);
+            }
+            let generation = current.generation.next()?;
+            let snapshot = AliasSnapshot {
+                alias: request.target().clone(),
+                revision: next_revision,
+                generation,
+                tombstone: false,
+            };
+            self.aliases[index].snapshot = snapshot.clone();
+            return Ok(snapshot);
+        }
+
+        if expected.is_some() {
+            return Err(ContextError::AliasConflict);
+        }
+        if self.aliases.len() >= ALIASES {
+            return Err(ContextError::AliasTableFull);
+        }
+        let snapshot = AliasSnapshot {
+            alias: request.target().clone(),
+            revision: next_revision,
+            generation: AliasGeneration::INITIAL,
+            tombstone: false,
+        };
+        self.aliases.push(StoredAlias {
+            snapshot: snapshot.clone(),
+        });
+        Ok(snapshot)
+    }
+
+    fn forget(
+        &mut self,
+        request: &AuthorizedRequest,
+        expected: &AliasSnapshot,
+    ) -> ContextResult<AliasSnapshot> {
+        Self::ensure_operation(request, ContextOperation::Forget)?;
+        if request.target().is_pinned() {
+            return Err(ContextError::ImmutableRevision);
+        }
+        let index = self
+            .alias_index(request.target())
+            .ok_or(ContextError::AliasNotFound)?;
+        let current = self.aliases[index].snapshot.clone();
+        if current.tombstone {
+            return Err(ContextError::Tombstoned);
+        }
+        if &current != expected {
+            return Err(ContextError::AliasConflict);
+        }
+        let generation = current.generation.next()?;
+        let tombstone_revision = self.insert_tombstone(request.target(), expected, generation)?;
+
+        // Make every prior revision of this logical object unreachable while
+        // preserving its immutable bytes for a storage layer to key-erase.
+        for object in &mut self.objects {
+            if !object.tombstone && same_logical_name(&object.canonical_uri, request.target()) {
+                object.forgotten = true;
+            }
+        }
+        let snapshot = AliasSnapshot {
+            alias: request.target().clone(),
+            revision: tombstone_revision,
+            generation,
+            tombstone: true,
+        };
+        self.aliases[index].snapshot = snapshot.clone();
+        Ok(snapshot)
+    }
+
+    fn prepare_execute(
+        &mut self,
+        request: &AuthorizedRequest,
+    ) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+        Self::ensure_operation(request, ContextOperation::Execute)?;
+        if !request.target().is_pinned() {
+            return Err(ContextError::PinnedUriRequired);
+        }
+        let (resolved, object_index) = self.resolved_for(request.target())?;
+        Ok((resolved, self.objects[object_index].rvf.clone()))
+    }
+}
+
+pub(crate) fn same_logical_name(left: &RuvUri, right: &RuvUri) -> bool {
+    left.authority() == right.authority()
+        && left.tenant() == right.tenant()
+        && left.subject() == right.subject()
+        && left.collection() == right.collection()
+        && left.path() == right.path()
+}
+
+pub(crate) fn is_within(root: &RuvUri, candidate: &RuvUri) -> bool {
+    root.authority() == candidate.authority()
+        && root.tenant() == candidate.tenant()
+        && root.subject() == candidate.subject()
+        && root.collection() == candidate.collection()
+        && candidate.path().len() >= root.path().len()
+        && &candidate.path()[..root.path().len()] == root.path()
+}
+
+fn compare_hits(left: &ContextHit, right: &ContextHit) -> core::cmp::Ordering {
+    right
+        .score
+        .cmp(&left.score)
+        .then_with(|| left.pinned_uri.cmp(&right.pinned_uri))
+}
+
+fn push_top_hit(hits: &mut Vec<ContextHit>, limit: usize, hit: ContextHit) {
+    if hits.len() < limit {
+        hits.push(hit);
+        return;
+    }
+
+    let worst_index = hits
+        .iter()
+        .enumerate()
+        .max_by(|(_, left), (_, right)| compare_hits(left, right))
+        .map_or(0, |(index, _)| index);
+    if compare_hits(&hit, &hits[worst_index]).is_lt() {
+        hits[worst_index] = hit;
+    }
+}
+
+struct QueryMatcher<'a> {
+    needle: &'a [u8],
+    failure: Vec<usize>,
+}
+
+impl<'a> QueryMatcher<'a> {
+    fn new(needle: &'a [u8]) -> Self {
+        let mut failure = alloc::vec![0; needle.len()];
+        let mut matched = 0;
+        for index in 1..needle.len() {
+            while matched > 0 && needle[index] != needle[matched] {
+                matched = failure[matched - 1];
+            }
+            if needle[index] == needle[matched] {
+                matched += 1;
+                failure[index] = matched;
+            }
+        }
+        Self { needle, failure }
+    }
+
+    fn occurrence_count(&self, haystack: &[u8]) -> u32 {
+        if self.needle.is_empty() || haystack.len() < self.needle.len() {
+            return 0;
+        }
+
+        let mut matched = 0;
+        let mut count = 0u32;
+        for byte in haystack {
+            while matched > 0 && *byte != self.needle[matched] {
+                matched = self.failure[matched - 1];
+            }
+            if *byte == self.needle[matched] {
+                matched += 1;
+                if matched == self.needle.len() {
+                    count = count.saturating_add(1);
+                    matched = self.failure[matched - 1];
+                }
+            }
+        }
+        count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::{
+        CapabilityHandle, ContextAuthority, ContextRequest, ContextScope, ContextViewMask,
+    };
+    use crate::profile::{ContextProfile, DerivedView, ProfileView};
+    use alloc::format;
+    use alloc::vec;
+    use rvm_rvf::{
+        content_hash, sha256, SegmentHeader, SEGMENT_HEADER_SIZE, SEGMENT_MAGIC, SEGMENT_VERSION,
+        SEG_TYPE_PROFILE,
+    };
+    use rvm_types::{CapRights, PartitionId};
+    use rvm_witness::WitnessLog;
+
+    type TestAuthority = ContextAuthority<32, 32>;
+
+    fn alias(path: &str) -> RuvUri {
+        RuvUri::parse(&format!(
+            "ruv://example.com/acme/agent/reader/resources/{path}"
+        ))
+        .unwrap()
+    }
+
+    fn pinned(alias: &RuvUri, bytes: &[u8]) -> PinnedRuvUri {
+        let digest = Sha256::digest(bytes);
+        let mut revision = [0u8; 32];
+        revision.copy_from_slice(&digest);
+        alias
+            .clone()
+            .with_revision(Revision::from_bytes(revision))
+            .unwrap()
+    }
+
+    fn segment(segment_type: u8, segment_id: u64, payload: &[u8]) -> Vec<u8> {
+        let total = SEGMENT_HEADER_SIZE + payload.len();
+        let padded = total.div_ceil(64) * 64;
+        let header = SegmentHeader {
+            magic: SEGMENT_MAGIC,
+            version: SEGMENT_VERSION,
+            seg_type: segment_type,
+            flags: 0,
+            segment_id,
+            payload_length: u64::try_from(payload.len()).unwrap(),
+            timestamp_ns: segment_id,
+            checksum_algo: 2,
+            compression: 0,
+            reserved_0: 0,
+            reserved_1: 0,
+            content_hash: content_hash(2, payload),
+            uncompressed_len: 0,
+            alignment_pad: u32::try_from(padded - total).unwrap(),
+        };
+        let mut bytes = header.to_bytes().to_vec();
+        bytes.extend_from_slice(payload);
+        bytes.resize(padded, 0);
+        bytes
+    }
+
+    fn context_rvf(overview: &[u8], content: &[u8]) -> Vec<u8> {
+        let content_revision = Revision::from_bytes(sha256(content));
+        let profile = ContextProfile::new(vec![
+            ProfileView::content(1, content_revision).unwrap(),
+            ProfileView::derived(
+                crate::uri::ProgressiveView::Overview,
+                2,
+                Revision::from_bytes(sha256(overview)),
+                DerivedView::new(
+                    content_revision,
+                    Revision::from_bytes([2; 32]),
+                    Revision::from_bytes([3; 32]),
+                    Revision::from_bytes([4; 32]),
+                    Revision::from_bytes([5; 32]),
+                )
+                .unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+        let mut bytes = segment(0x07, 1, content);
+        bytes.extend(segment(0x07, 2, overview));
+        bytes.extend(segment(SEG_TYPE_PROFILE, 3, &profile.to_bytes()));
+        bytes.extend(segment(0x05, 4, b"root"));
+        bytes
+    }
+
+    fn content_only_rvf(content: &[u8]) -> Vec<u8> {
+        let profile = ContextProfile::new(vec![ProfileView::content(
+            1,
+            Revision::from_bytes(sha256(content)),
+        )
+        .unwrap()])
+        .unwrap();
+        let mut bytes = segment(0x07, 1, content);
+        bytes.extend(segment(SEG_TYPE_PROFILE, 2, &profile.to_bytes()));
+        bytes.extend(segment(0x05, 3, b"root"));
+        bytes
+    }
+
+    fn authority() -> (TestAuthority, CapabilityHandle, PartitionId) {
+        let owner = PartitionId::new(9);
+        let root = alias("docs");
+        let mut authority = TestAuthority::with_defaults();
+        let handle = authority
+            .issue_root(
+                ContextScope::from_uri(&root, ContextViewMask::ALL),
+                CapRights::READ | CapRights::WRITE | CapRights::EXECUTE | CapRights::PROVE,
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .unwrap();
+        (authority, handle, owner)
+    }
+
+    fn authorized(
+        authority: &TestAuthority,
+        handle: CapabilityHandle,
+        owner: PartitionId,
+        operation: ContextOperation,
+        target: RuvUri,
+        log: &WitnessLog<128>,
+    ) -> AuthorizedRequest {
+        let request = ContextRequest::new(handle, operation, target);
+        authority
+            .authorize(owner, 1, &request, operation, log)
+            .unwrap()
+    }
+
+    #[test]
+    fn immutable_put_is_hash_bound_and_idempotent() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let bytes = b"whole RVF bytes";
+        let target = pinned(&alias("docs/a"), bytes);
+        let permit = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Put,
+            target.clone().into_uri(),
+            &log,
+        );
+        let mut resolver = MemoryResolver::<4, 4>::new();
+        let first = resolver.put(&permit, bytes).unwrap();
+        let second = resolver.put(&permit, bytes).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(resolver.object_count(), 1);
+        assert_eq!(
+            resolver.put(&permit, b"different"),
+            Err(ContextError::RevisionHashMismatch)
+        );
+    }
+
+    #[test]
+    fn identical_revision_is_scoped_by_logical_name_and_tenant() {
+        fn tenant_alias(tenant: &str) -> RuvUri {
+            RuvUri::parse(&format!(
+                "ruv://example.com/{tenant}/agent/reader/resources/docs/a"
+            ))
+            .unwrap()
+        }
+
+        let owner = PartitionId::new(9);
+        let mut authority = TestAuthority::with_defaults();
+        let mut handles = Vec::new();
+        for tenant in ["acme", "beta", "gamma"] {
+            let name = tenant_alias(tenant);
+            handles.push(
+                authority
+                    .issue_root(
+                        ContextScope::from_uri(&name, ContextViewMask::ALL),
+                        CapRights::READ | CapRights::WRITE,
+                        owner,
+                        PartitionId::HYPERVISOR,
+                    )
+                    .unwrap(),
+            );
+        }
+        let bytes = b"identical whole RVF bytes";
+        let acme = pinned(&tenant_alias("acme"), bytes);
+        let beta = pinned(&tenant_alias("beta"), bytes);
+        let gamma = pinned(&tenant_alias("gamma"), bytes);
+        let log = WitnessLog::<128>::new();
+        let mut resolver = MemoryResolver::<8, 4>::new();
+
+        for (handle, target) in [(handles[0], &acme), (handles[1], &beta)] {
+            let put = authorized(
+                &authority,
+                handle,
+                owner,
+                ContextOperation::Put,
+                target.clone().into_uri(),
+                &log,
+            );
+            resolver.put(&put, bytes).unwrap();
+        }
+        assert_eq!(resolver.object_count(), 2);
+
+        for (handle, target) in [(handles[0], acme), (handles[1], beta)] {
+            let resolve = authorized(
+                &authority,
+                handle,
+                owner,
+                ContextOperation::Resolve,
+                target.into_uri(),
+                &log,
+            );
+            assert!(resolver.resolve(&resolve).is_ok());
+        }
+        let unregistered_scope = authorized(
+            &authority,
+            handles[2],
+            owner,
+            ContextOperation::Resolve,
+            gamma.into_uri(),
+            &log,
+        );
+        assert_eq!(
+            resolver.resolve(&unregistered_scope),
+            Err(ContextError::RevisionNotFound)
+        );
+    }
+
+    #[test]
+    fn alias_cas_generation_prevents_aba() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let name = alias("docs/a");
+        let a_bytes = b"rvf A";
+        let b_bytes = b"rvf B";
+        let a = pinned(&name, a_bytes);
+        let b = pinned(&name, b_bytes);
+        let mut resolver = MemoryResolver::<8, 4>::new();
+        for (uri, bytes) in [(&a, a_bytes.as_slice()), (&b, b_bytes.as_slice())] {
+            let put = authorized(
+                &authority,
+                handle,
+                owner,
+                ContextOperation::Put,
+                uri.clone().into_uri(),
+                &log,
+            );
+            resolver.put(&put, bytes).unwrap();
+        }
+
+        let create = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            name.clone(),
+            &log,
+        );
+        let generation_one = resolver
+            .compare_and_swap_alias(&create, None, a.revision())
+            .unwrap();
+        let generation_two = resolver
+            .compare_and_swap_alias(&create, Some(&generation_one), b.revision())
+            .unwrap();
+        let generation_three = resolver
+            .compare_and_swap_alias(&create, Some(&generation_two), a.revision())
+            .unwrap();
+        assert_eq!(generation_three.generation().get(), 3);
+        assert_eq!(
+            resolver.compare_and_swap_alias(&create, Some(&generation_one), b.revision()),
+            Err(ContextError::AliasConflict)
+        );
+    }
+
+    #[test]
+    fn exactly_one_competing_cas_snapshot_wins() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let name = alias("docs/a");
+        let one = pinned(&name, b"one");
+        let two = pinned(&name, b"two");
+        let three = pinned(&name, b"three");
+        let mut resolver = MemoryResolver::<8, 4>::new();
+        for (uri, bytes) in [
+            (&one, b"one".as_slice()),
+            (&two, b"two".as_slice()),
+            (&three, b"three".as_slice()),
+        ] {
+            let put = authorized(
+                &authority,
+                handle,
+                owner,
+                ContextOperation::Put,
+                uri.clone().into_uri(),
+                &log,
+            );
+            resolver.put(&put, bytes).unwrap();
+        }
+        let cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            name,
+            &log,
+        );
+        let initial = resolver
+            .compare_and_swap_alias(&cas, None, one.revision())
+            .unwrap();
+        assert!(resolver
+            .compare_and_swap_alias(&cas, Some(&initial), two.revision())
+            .is_ok());
+        assert_eq!(
+            resolver.compare_and_swap_alias(&cas, Some(&initial), three.revision()),
+            Err(ContextError::AliasConflict)
+        );
+    }
+
+    #[test]
+    fn list_tree_history_and_verify_are_bounded_and_revision_bound() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let direct_name = alias("docs/a");
+        let deep_name = alias("docs/a/deep");
+        let first = pinned(&direct_name, b"first");
+        let second = pinned(&direct_name, b"second");
+        let deep = pinned(&deep_name, b"deep");
+        let mut resolver = MemoryResolver::<8, 4>::new();
+        for (target, bytes) in [
+            (&first, b"first".as_slice()),
+            (&second, b"second".as_slice()),
+            (&deep, b"deep".as_slice()),
+        ] {
+            let put = authorized(
+                &authority,
+                handle,
+                owner,
+                ContextOperation::Put,
+                target.clone().into_uri(),
+                &log,
+            );
+            resolver.put(&put, bytes).unwrap();
+        }
+
+        let direct_cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            direct_name.clone(),
+            &log,
+        );
+        let first_head = resolver
+            .compare_and_swap_alias(&direct_cas, None, first.revision())
+            .unwrap();
+        resolver
+            .compare_and_swap_alias(&direct_cas, Some(&first_head), second.revision())
+            .unwrap();
+        let deep_cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            deep_name,
+            &log,
+        );
+        resolver
+            .compare_and_swap_alias(&deep_cas, None, deep.revision())
+            .unwrap();
+
+        let list = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::List,
+            alias("docs"),
+            &log,
+        );
+        assert_eq!(resolver.list(&list, 8).unwrap().len(), 1);
+        let tree = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Tree,
+            alias("docs"),
+            &log,
+        );
+        assert_eq!(resolver.tree(&tree, 8).unwrap().len(), 2);
+        assert_eq!(
+            resolver.tree(&tree, MAX_ENUM_RESULTS + 1),
+            Err(ContextError::InvalidResultLimit)
+        );
+
+        let history = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::History,
+            direct_name,
+            &log,
+        );
+        assert_eq!(resolver.history(&history, 8).unwrap().len(), 2);
+
+        let verify = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Verify,
+            second.clone().into_uri(),
+            &log,
+        );
+        let (verified, bytes) = resolver.verify(&verify).unwrap();
+        assert_eq!(verified.revision(), second.revision());
+        assert_eq!(bytes, b"second");
+    }
+
+    #[test]
+    fn forget_creates_new_tombstone_and_hides_pinned_history() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let name = alias("docs/a");
+        let object = pinned(&name, b"private");
+        let mut resolver = MemoryResolver::<8, 4>::new();
+        let put = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Put,
+            object.clone().into_uri(),
+            &log,
+        );
+        resolver.put(&put, b"private").unwrap();
+        let cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            name.clone(),
+            &log,
+        );
+        let head = resolver
+            .compare_and_swap_alias(&cas, None, object.revision())
+            .unwrap();
+        let forget = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Forget,
+            name.clone(),
+            &log,
+        );
+        let tombstone = resolver.forget(&forget, &head).unwrap();
+        assert!(tombstone.is_tombstone());
+        assert_ne!(tombstone.revision(), head.revision());
+
+        let resolve_alias = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Resolve,
+            name,
+            &log,
+        );
+        assert_eq!(
+            resolver.resolve(&resolve_alias),
+            Err(ContextError::Tombstoned)
+        );
+        let read_old = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Read,
+            object.into_uri(),
+            &log,
+        );
+        assert_eq!(resolver.read(&read_old), Err(ContextError::Tombstoned));
+    }
+
+    #[test]
+    fn search_enumerates_only_live_descendant_aliases_and_is_bounded() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let name = alias("docs/a");
+        let bytes = context_rvf(b"alpha alpha beta", b"content-only secret");
+        let object = pinned(&name, &bytes);
+        let mut resolver = MemoryResolver::<8, 4>::new();
+        let put = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Put,
+            object.clone().into_uri(),
+            &log,
+        );
+        resolver.put(&put, &bytes).unwrap();
+        let cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            name,
+            &log,
+        );
+        resolver
+            .compare_and_swap_alias(&cas, None, object.revision())
+            .unwrap();
+
+        let content_only_name = alias("docs/b");
+        let content_only_bytes = content_only_rvf(b"content-only alpha");
+        let content_only_object = pinned(&content_only_name, &content_only_bytes);
+        let content_only_put = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Put,
+            content_only_object.clone().into_uri(),
+            &log,
+        );
+        resolver
+            .put(&content_only_put, &content_only_bytes)
+            .unwrap();
+        let content_only_cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            content_only_name,
+            &log,
+        );
+        resolver
+            .compare_and_swap_alias(&content_only_cas, None, content_only_object.revision())
+            .unwrap();
+
+        let search = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Search,
+            alias("docs"),
+            &log,
+        );
+        let hits = resolver.search(&search, b"alpha", 4).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].score(), 2);
+        assert!(resolver
+            .search(&search, b"content-only", 4)
+            .unwrap()
+            .is_empty());
+
+        let content_search = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Search,
+            RuvUri::parse("ruv://example.com/acme/agent/reader/resources/docs?view=content")
+                .unwrap(),
+            &log,
+        );
+        assert_eq!(
+            resolver
+                .search(&content_search, b"secret", 4)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            resolver.search(&search, b"alpha", MAX_SEARCH_RESULTS + 1),
+            Err(ContextError::InvalidResultLimit)
+        );
+    }
+
+    #[test]
+    fn search_applies_limit_after_global_score_ordering() {
+        let (authority, handle, owner) = authority();
+        let log = WitnessLog::<128>::new();
+        let mut resolver = MemoryResolver::<8, 4>::new();
+
+        let low_name = alias("docs/first");
+        let low_bytes = context_rvf(b"needle", b"low content");
+        let low_object = pinned(&low_name, &low_bytes);
+        let low_put = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Put,
+            low_object.clone().into_uri(),
+            &log,
+        );
+        resolver.put(&low_put, &low_bytes).unwrap();
+        let low_cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            low_name,
+            &log,
+        );
+        resolver
+            .compare_and_swap_alias(&low_cas, None, low_object.revision())
+            .unwrap();
+
+        let high_name = alias("docs/second");
+        let high_bytes = context_rvf(b"needle needle needle", b"high content");
+        let high_object = pinned(&high_name, &high_bytes);
+        let high_put = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Put,
+            high_object.clone().into_uri(),
+            &log,
+        );
+        resolver.put(&high_put, &high_bytes).unwrap();
+        let high_cas = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::CompareAndSwapAlias,
+            high_name,
+            &log,
+        );
+        resolver
+            .compare_and_swap_alias(&high_cas, None, high_object.revision())
+            .unwrap();
+
+        let search = authorized(
+            &authority,
+            handle,
+            owner,
+            ContextOperation::Search,
+            alias("docs"),
+            &log,
+        );
+        let hits = resolver.search(&search, b"needle", 1).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].pinned_uri(), &high_object);
+        assert_eq!(hits[0].score(), 3);
+    }
+
+    #[test]
+    fn query_matcher_is_linear_and_preserves_overlapping_scores() {
+        let matcher = QueryMatcher::new(b"aaa");
+        assert_eq!(matcher.occurrence_count(b"aaaaa"), 3);
+        assert_eq!(matcher.occurrence_count(b"aa"), 0);
+        assert_eq!(QueryMatcher::new(b"aba").occurrence_count(b"abababa"), 3);
+    }
+}

--- a/crates/rvm-context/src/runtime.rs
+++ b/crates/rvm-context/src/runtime.rs
@@ -1,0 +1,1177 @@
+//! Governed runtime ordering authorization, resolver access, and witnessing.
+//!
+//! Every entry point first mints a private [`AuthorizedRequest`] through the
+//! live capability authority. Resolver results are then checked against the
+//! authorized URI before any bytes or enumeration results reach the caller.
+//! A P1 allow/deny decision is witnessed before backend access; operation
+//! actions are emitted only after successful completion and validation.
+
+use crate::capability::{
+    AuthorizedRequest, CapabilityHandle, ContextAuthority, ContextOperation, ContextRequest,
+    ContextScope, MAX_SEARCH_RESULTS,
+};
+use crate::error::{ContextError, ContextResult};
+use crate::profile::{ProfileTrust, VerifiedContextProfile};
+use crate::receipt::{ContextEpochReceipt, SignedContextEpochReceipt};
+use crate::resolver::{
+    is_within, same_logical_name, AliasGeneration, AliasSnapshot, ContextHit, ContextResolver,
+    ResolvedContext, MAX_ENUM_RESULTS, MAX_RVF_BYTES, MAX_SEARCH_QUERY_BYTES,
+};
+use crate::uri::{PinnedRuvUri, ProgressiveView, Revision};
+use alloc::vec::Vec;
+use rvm_proof::WitnessSigner;
+use rvm_types::{CapRights, PartitionId, WitnessRecord};
+use rvm_witness::{WitnessCheckpoint, WitnessLog};
+
+/// Trusted source of witness timestamps for one actor-bound runtime.
+///
+/// Implementations are supplied by the kernel or host dispatch layer, never by
+/// request payloads. Values should be monotonic. Receipt integrity relies on
+/// sequence and chain coordinates even if an imported clock observation moves
+/// backwards.
+pub trait ContextClock {
+    /// Return the next trusted witness timestamp in nanoseconds.
+    fn timestamp_ns(&mut self) -> u64;
+}
+
+impl<F> ContextClock for F
+where
+    F: FnMut() -> u64,
+{
+    fn timestamp_ns(&mut self) -> u64 {
+        self()
+    }
+}
+
+/// Deterministic monotonic logical clock used by the default runtime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LogicalContextClock {
+    next_timestamp_ns: u64,
+}
+
+impl LogicalContextClock {
+    /// Create a logical clock beginning at zero.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            next_timestamp_ns: 0,
+        }
+    }
+
+    /// Create a logical clock at an authenticated resume value.
+    #[must_use]
+    pub const fn trusted_resume(next_timestamp_ns: u64) -> Self {
+        Self { next_timestamp_ns }
+    }
+}
+
+impl ContextClock for LogicalContextClock {
+    fn timestamp_ns(&mut self) -> u64 {
+        let timestamp_ns = self.next_timestamp_ns;
+        self.next_timestamp_ns = self.next_timestamp_ns.saturating_add(1);
+        timestamp_ns
+    }
+}
+
+/// A one-operation authorization to execute one pinned skill revision.
+///
+/// The permit intentionally contains no RVF bytes and is not `Clone`: read
+/// authority and execute authority remain distinct, and callers must hand the
+/// permit to their execution boundary rather than treating it as content.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ExecutionPermit {
+    actor: PartitionId,
+    pinned_uri: PinnedRuvUri,
+    revision: Revision,
+    capability_hash: u32,
+    witness_sequence: u64,
+}
+
+/// Persistent cursor for the runtime-owned context receipt chain.
+///
+/// The runtime derives every new receipt's checkpoint, epoch identifier, and
+/// previous-receipt link from this state. Callers cannot select those values at
+/// seal time. Persist this state atomically with each durable signed receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReceiptChainState {
+    next_checkpoint: WitnessCheckpoint,
+    next_epoch_id: u64,
+    previous_receipt_id: [u8; 32],
+}
+
+impl ReceiptChainState {
+    fn genesis(next_checkpoint: WitnessCheckpoint) -> Self {
+        debug_assert_eq!(next_checkpoint.next_sequence(), 0);
+        debug_assert_eq!(next_checkpoint.chain_hash(), 0);
+        Self {
+            next_checkpoint,
+            next_epoch_id: 0,
+            previous_receipt_id: [0; 32],
+        }
+    }
+
+    /// Reconstruct persisted receipt-chain state at a trusted resume boundary.
+    ///
+    /// This is an administrative recovery API. The caller must authenticate
+    /// the checkpoint and receipt ID against durable receipt storage before
+    /// constructing the state; ordinary context requests never supply it.
+    #[must_use]
+    pub const fn trusted_resume(
+        next_checkpoint: WitnessCheckpoint,
+        next_epoch_id: u64,
+        previous_receipt_id: [u8; 32],
+    ) -> Self {
+        Self {
+            next_checkpoint,
+            next_epoch_id,
+            previous_receipt_id,
+        }
+    }
+
+    /// Return the exact witness boundary at which the next epoch begins.
+    #[must_use]
+    pub const fn next_checkpoint(self) -> WitnessCheckpoint {
+        self.next_checkpoint
+    }
+
+    /// Return the epoch identifier the runtime will assign to the next receipt.
+    #[must_use]
+    pub const fn next_epoch_id(self) -> u64 {
+        self.next_epoch_id
+    }
+
+    /// Return the signed receipt ID that the next receipt must link to.
+    #[must_use]
+    pub const fn previous_receipt_id(self) -> [u8; 32] {
+        self.previous_receipt_id
+    }
+}
+
+impl ExecutionPermit {
+    /// Return the partition authorized to execute the revision.
+    #[must_use]
+    pub const fn actor(&self) -> PartitionId {
+        self.actor
+    }
+
+    /// Return the exact immutable skill URI.
+    #[must_use]
+    pub const fn pinned_uri(&self) -> &PinnedRuvUri {
+        &self.pinned_uri
+    }
+
+    /// Return the verified complete-RVF identity.
+    #[must_use]
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Return the non-secret truncated capability identifier.
+    #[must_use]
+    pub const fn capability_hash(&self) -> u32 {
+        self.capability_hash
+    }
+
+    /// Return the sequence of the successful execute-authorization witness.
+    #[must_use]
+    pub const fn witness_sequence(&self) -> u64 {
+        self.witness_sequence
+    }
+}
+
+/// Capability-gated facade over one context resolver and witness ring.
+pub struct ContextRuntime<
+    R,
+    const CAPABILITIES: usize,
+    const GRANTS: usize,
+    const WITNESSES: usize,
+    CLOCK = LogicalContextClock,
+> {
+    actor: PartitionId,
+    authority: ContextAuthority<CAPABILITIES, GRANTS>,
+    resolver: R,
+    witness: WitnessLog<WITNESSES>,
+    receipt_chain: ReceiptChainState,
+    clock: CLOCK,
+}
+
+impl<R, const C: usize, const G: usize, const W: usize>
+    ContextRuntime<R, C, G, W, LogicalContextClock>
+{
+    /// Create an actor-bound runtime with a new empty witness ring.
+    ///
+    /// `actor` comes from the trusted kernel dispatch context. It is immutable
+    /// for the lifetime of this runtime and is never selected by request data.
+    #[must_use]
+    pub fn new(actor: PartitionId, authority: ContextAuthority<C, G>, resolver: R) -> Self {
+        Self::with_clock(actor, authority, resolver, LogicalContextClock::new())
+    }
+}
+
+impl<R, const C: usize, const G: usize, const W: usize, CLOCK: ContextClock>
+    ContextRuntime<R, C, G, W, CLOCK>
+{
+    /// Create an actor-bound runtime with an injected trusted host clock.
+    #[must_use]
+    pub fn with_clock(
+        actor: PartitionId,
+        authority: ContextAuthority<C, G>,
+        resolver: R,
+        clock: CLOCK,
+    ) -> Self {
+        let witness = WitnessLog::new();
+        let receipt_chain = ReceiptChainState::genesis(witness.checkpoint());
+        Self {
+            actor,
+            authority,
+            resolver,
+            witness,
+            receipt_chain,
+            clock,
+        }
+    }
+
+    /// Resume a runtime around an existing witness ring and trusted chain state.
+    ///
+    /// The state must have been authenticated against durable receipt storage.
+    /// A fresh runtime should use [`Self::new`] so genesis is fixed to epoch and
+    /// sequence zero with an all-zero previous-receipt link.
+    #[must_use]
+    pub const fn with_witness(
+        actor: PartitionId,
+        authority: ContextAuthority<C, G>,
+        resolver: R,
+        witness: WitnessLog<W>,
+        receipt_chain: ReceiptChainState,
+        clock: CLOCK,
+    ) -> Self {
+        Self {
+            actor,
+            authority,
+            resolver,
+            witness,
+            receipt_chain,
+            clock,
+        }
+    }
+
+    /// Return the authenticated partition bound by trusted kernel dispatch.
+    #[must_use]
+    pub const fn actor(&self) -> PartitionId {
+        self.actor
+    }
+
+    /// Return trusted capability administration access.
+    #[must_use]
+    pub const fn authority(&self) -> &ContextAuthority<C, G> {
+        &self.authority
+    }
+
+    /// Return mutable trusted capability administration access.
+    #[must_use]
+    pub fn authority_mut(&mut self) -> &mut ContextAuthority<C, G> {
+        &mut self.authority
+    }
+
+    /// Return read-only resolver access for metrics and inspection.
+    #[must_use]
+    pub const fn resolver(&self) -> &R {
+        &self.resolver
+    }
+
+    /// Return the append-only witness ring.
+    #[must_use]
+    pub const fn witness_log(&self) -> &WitnessLog<W> {
+        &self.witness
+    }
+
+    /// Return the receipt cursor that must be persisted with durable receipts.
+    #[must_use]
+    pub const fn receipt_chain_state(&self) -> ReceiptChainState {
+        self.receipt_chain
+    }
+
+    /// Consume the runtime and return its owned components.
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        PartitionId,
+        ContextAuthority<C, G>,
+        R,
+        WitnessLog<W>,
+        ReceiptChainState,
+        CLOCK,
+    ) {
+        (
+            self.actor,
+            self.authority,
+            self.resolver,
+            self.witness,
+            self.receipt_chain,
+            self.clock,
+        )
+    }
+
+    fn authorize(
+        &mut self,
+        request: &ContextRequest,
+        operation: ContextOperation,
+    ) -> ContextResult<AuthorizedRequest> {
+        let timestamp_ns = self.clock.timestamp_ns();
+        self.authority
+            .authorize(self.actor, timestamp_ns, request, operation, &self.witness)
+    }
+
+    fn reject_resolver<T>(&self, request: &AuthorizedRequest) -> ContextResult<T> {
+        let _ = ContextAuthority::<C, G>::record_resolver_rejection(request, &self.witness);
+        Err(ContextError::ResolverScopeViolation)
+    }
+
+    fn complete(&self, request: &AuthorizedRequest) -> u64 {
+        ContextAuthority::<C, G>::record_success(request, &self.witness)
+    }
+}
+
+impl<R: ContextResolver, const C: usize, const G: usize, const W: usize, CLOCK: ContextClock>
+    ContextRuntime<R, C, G, W, CLOCK>
+{
+    /// Resolve an alias or pinned target to immutable metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns authorization, resolver, or scope-validation failures.
+    pub fn resolve(&mut self, request: &ContextRequest) -> ContextResult<ResolvedContext> {
+        let authorized = self.authorize(request, ContextOperation::Resolve)?;
+        let resolved = self.resolver.resolve(&authorized)?;
+        if !valid_exact_result(authorized.target(), &resolved) {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(resolved)
+    }
+
+    /// List live direct-child aliases with a bounded result count.
+    ///
+    /// # Errors
+    ///
+    /// Refuses invalid bounds, unauthorized calls, and out-of-scope results.
+    pub fn list(
+        &mut self,
+        request: &ContextRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        let authorized = self.authorize(request, ContextOperation::List)?;
+        validate_enum_limit(limit)?;
+        let entries = self.resolver.list(&authorized, limit)?;
+        if !valid_enumeration(authorized.target(), &entries, limit, false) {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(entries)
+    }
+
+    /// Traverse all live descendant aliases with a bounded result count.
+    ///
+    /// # Errors
+    ///
+    /// Refuses invalid bounds, unauthorized calls, and out-of-scope results.
+    pub fn tree(
+        &mut self,
+        request: &ContextRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        let authorized = self.authorize(request, ContextOperation::Tree)?;
+        validate_enum_limit(limit)?;
+        let entries = self.resolver.tree(&authorized, limit)?;
+        if !valid_enumeration(authorized.target(), &entries, limit, true) {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(entries)
+    }
+
+    /// Read one verified progressive representation.
+    ///
+    /// With no explicit `view`, this returns the profile-bound content segment.
+    /// An explicit view returns only that profile-bound segment payload. The
+    /// complete container is never released through the read API.
+    ///
+    /// # Errors
+    ///
+    /// Refuses unauthorized access, invalid RVF/profile bytes, and resolver
+    /// identity or scope violations.
+    pub fn read(&mut self, request: &ContextRequest) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+        let authorized = self.authorize(request, ContextOperation::Read)?;
+        let (resolved, rvf) = self.resolver.read(&authorized)?;
+        if !valid_exact_result(authorized.target(), &resolved) || resolved.rvf_len() != rvf.len() {
+            return self.reject_resolver(&authorized);
+        }
+        let profile = verify_profile(&rvf, resolved.revision())?;
+        let view = authorized
+            .target()
+            .view()
+            .unwrap_or(ProgressiveView::Content);
+        let output = profile
+            .payload(&rvf, view)
+            .map_err(|_| ContextError::RvfVerificationFailed)?
+            .to_vec();
+        let _ = self.complete(&authorized);
+        Ok((resolved, output))
+    }
+
+    /// Search live context aliases with bounded input and output.
+    ///
+    /// # Errors
+    ///
+    /// Refuses invalid bounds, unauthorized calls, and out-of-scope results.
+    pub fn search(
+        &mut self,
+        request: &ContextRequest,
+        query: &[u8],
+        limit: usize,
+    ) -> ContextResult<Vec<ContextHit>> {
+        let authorized = self.authorize(request, ContextOperation::Search)?;
+        if query.is_empty() || query.len() > MAX_SEARCH_QUERY_BYTES {
+            return Err(ContextError::InvalidQuery);
+        }
+        if limit == 0 || limit > MAX_SEARCH_RESULTS {
+            return Err(ContextError::InvalidResultLimit);
+        }
+        let hits = self.resolver.search(&authorized, query, limit)?;
+        if !valid_hits(authorized.target(), &hits, limit) {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(hits)
+    }
+
+    /// Enumerate immutable revisions registered under one live alias.
+    ///
+    /// # Errors
+    ///
+    /// Refuses invalid bounds, tombstones, unauthorized calls, and invalid
+    /// resolver results.
+    pub fn history(
+        &mut self,
+        request: &ContextRequest,
+        limit: usize,
+    ) -> ContextResult<Vec<ResolvedContext>> {
+        let authorized = self.authorize(request, ContextOperation::History)?;
+        validate_enum_limit(limit)?;
+        let entries = self.resolver.history(&authorized, limit)?;
+        if entries.len() > limit
+            || entries.iter().any(|entry| {
+                !valid_result_integrity(entry)
+                    || !same_logical_name(authorized.target(), entry.pinned_uri().as_uri())
+            })
+            || has_duplicate_results(&entries)
+        {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(entries)
+    }
+
+    /// Verify a pinned complete RVF and its context profile without returning
+    /// any bytes.
+    ///
+    /// # Errors
+    ///
+    /// Refuses unauthorized access, corrupt RVF/profile bytes, or a resolver
+    /// identity mismatch.
+    pub fn verify(&mut self, request: &ContextRequest) -> ContextResult<ResolvedContext> {
+        let authorized = self.authorize(request, ContextOperation::Verify)?;
+        let (resolved, rvf) = self.resolver.verify(&authorized)?;
+        if !valid_exact_result(authorized.target(), &resolved) || resolved.rvf_len() != rvf.len() {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = verify_profile(&rvf, resolved.revision())?;
+        let _ = self.complete(&authorized);
+        Ok(resolved)
+    }
+
+    /// Verify and register a new immutable complete RVF revision.
+    ///
+    /// # Errors
+    ///
+    /// Refuses unverified RVF/profile bytes before backend mutation, as well
+    /// as authorization, capacity, identity, and scope failures.
+    pub fn put(&mut self, request: &ContextRequest, rvf: &[u8]) -> ContextResult<ResolvedContext> {
+        let authorized = self.authorize(request, ContextOperation::Put)?;
+        let revision = authorized
+            .target()
+            .revision()
+            .ok_or(ContextError::PinnedUriRequired)?;
+        let _ = verify_profile(rvf, revision)?;
+        let resolved = self.resolver.put(&authorized, rvf)?;
+        if !valid_exact_result(authorized.target(), &resolved) || resolved.rvf_len() != rvf.len() {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(resolved)
+    }
+
+    /// Atomically create or advance a versionless alias.
+    ///
+    /// # Errors
+    ///
+    /// Refuses stale/full snapshots, unauthorized mutation, absent revisions,
+    /// and invalid resolver results.
+    pub fn compare_and_swap_alias(
+        &mut self,
+        request: &ContextRequest,
+        expected: Option<&AliasSnapshot>,
+        next_revision: Revision,
+    ) -> ContextResult<AliasSnapshot> {
+        let authorized = self.authorize(request, ContextOperation::CompareAndSwapAlias)?;
+        if expected.is_some_and(|snapshot| {
+            snapshot.is_tombstone() || !same_logical_name(snapshot.alias(), authorized.target())
+        }) {
+            return Err(ContextError::InvalidTarget);
+        }
+        let snapshot =
+            self.resolver
+                .compare_and_swap_alias(&authorized, expected, next_revision)?;
+        let expected_generation = expected.map_or(Some(AliasGeneration::INITIAL), |prior| {
+            prior
+                .generation()
+                .get()
+                .checked_add(1)
+                .and_then(AliasGeneration::new)
+        });
+        if snapshot.is_tombstone()
+            || !same_logical_name(snapshot.alias(), authorized.target())
+            || snapshot.revision() != next_revision
+            || Some(snapshot.generation()) != expected_generation
+        {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(snapshot)
+    }
+
+    /// Permanently advance an alias to an immutable tombstone revision.
+    ///
+    /// # Errors
+    ///
+    /// Refuses stale snapshots, repeat forget, unauthorized mutation, and
+    /// invalid resolver results.
+    pub fn forget(
+        &mut self,
+        request: &ContextRequest,
+        expected: &AliasSnapshot,
+    ) -> ContextResult<AliasSnapshot> {
+        let authorized = self.authorize(request, ContextOperation::Forget)?;
+        if expected.is_tombstone() || !same_logical_name(expected.alias(), authorized.target()) {
+            return Err(ContextError::InvalidTarget);
+        }
+        let snapshot = self.resolver.forget(&authorized, expected)?;
+        let expected_generation = expected
+            .generation()
+            .get()
+            .checked_add(1)
+            .and_then(AliasGeneration::new);
+        if !snapshot.is_tombstone()
+            || !same_logical_name(snapshot.alias(), authorized.target())
+            || snapshot.revision() == expected.revision()
+            || Some(snapshot.generation()) != expected_generation
+        {
+            return self.reject_resolver(&authorized);
+        }
+        let _ = self.complete(&authorized);
+        Ok(snapshot)
+    }
+
+    /// Verify a pinned executable skill and return a byte-free permit.
+    ///
+    /// # Errors
+    ///
+    /// Requires separate `EXECUTE` authority, a pinned Skills URI, a verified
+    /// RVF/profile, and an executable content segment.
+    pub fn authorize_execute(
+        &mut self,
+        request: &ContextRequest,
+    ) -> ContextResult<ExecutionPermit> {
+        let authorized = self.authorize(request, ContextOperation::Execute)?;
+        let (resolved, rvf) = self.resolver.prepare_execute(&authorized)?;
+        if !valid_exact_result(authorized.target(), &resolved) || resolved.rvf_len() != rvf.len() {
+            return self.reject_resolver(&authorized);
+        }
+        let profile = verify_profile(&rvf, resolved.revision())?;
+        if !profile.is_executable(ProgressiveView::Content) {
+            return Err(ContextError::InvalidTarget);
+        }
+        let witness_sequence = self.complete(&authorized);
+        Ok(ExecutionPermit {
+            actor: authorized.actor(),
+            pinned_uri: resolved.pinned_uri().clone(),
+            revision: resolved.revision(),
+            capability_hash: authorized.capability_hash(),
+            witness_sequence,
+        })
+    }
+
+    /// Delegate an equal-or-narrower context capability after authorization.
+    ///
+    /// # Errors
+    ///
+    /// Refuses missing `GRANT`, owner mismatch, stale handles, scope or rights
+    /// widening, and bounded table exhaustion.
+    pub fn grant(
+        &mut self,
+        request: &ContextRequest,
+        child_scope: ContextScope,
+        requested_rights: CapRights,
+        target_owner: PartitionId,
+    ) -> ContextResult<CapabilityHandle> {
+        let source = request.capability();
+        let authorized = self.authorize(request, ContextOperation::Grant)?;
+        let handle = self.authority.delegate(
+            source,
+            child_scope,
+            requested_rights,
+            target_owner,
+            self.actor,
+        )?;
+        let _ = self.complete(&authorized);
+        Ok(handle)
+    }
+
+    /// Revoke a context capability lineage after authorization.
+    ///
+    /// # Errors
+    ///
+    /// Refuses missing `REVOKE`, owner mismatch, or a stale capability.
+    pub fn revoke(&mut self, request: &ContextRequest) -> ContextResult<usize> {
+        let handle = request.capability();
+        let authorized = self.authorize(request, ContextOperation::Revoke)?;
+        let count = self.authority.revoke(handle)?;
+        let _ = self.complete(&authorized);
+        Ok(count)
+    }
+
+    /// Snapshot, seal, sign, and anchor one complete witness epoch.
+    ///
+    /// The pinned request target must equal `rvf_identity`. The successful
+    /// `ContextEpochSeal` record is appended only after signing, placing it in
+    /// the next epoch and preventing a failed seal from claiming success.
+    ///
+    /// # Errors
+    ///
+    /// Refuses missing `PROVE`, an identity mismatch, wrapped or incomplete
+    /// witness snapshots, invalid record chains, and empty epochs.
+    #[allow(clippy::too_many_arguments)]
+    pub fn seal_epoch<S: WitnessSigner>(
+        &mut self,
+        request: &ContextRequest,
+        scratch: &mut [WitnessRecord],
+        namespace_root: [u8; 32],
+        rvf_identity: [u8; 32],
+        policy_hash: [u8; 32],
+        detail_root: [u8; 32],
+        signer: &S,
+    ) -> ContextResult<(SignedContextEpochReceipt, WitnessCheckpoint)> {
+        let authorized = self.authorize(request, ContextOperation::SealReceipt)?;
+        let following_epoch_id = self
+            .receipt_chain
+            .next_epoch_id
+            .checked_add(1)
+            .ok_or(ContextError::ReceiptSealFailed)?;
+        if authorized
+            .target()
+            .revision()
+            .map(|revision| *revision.as_bytes())
+            != Some(rvf_identity)
+        {
+            return Err(ContextError::InvalidTarget);
+        }
+        let (receipt, next_checkpoint) = ContextEpochReceipt::seal_from_log(
+            self.receipt_chain.next_epoch_id,
+            &self.witness,
+            self.receipt_chain.next_checkpoint,
+            scratch,
+            self.receipt_chain.previous_receipt_id,
+            namespace_root,
+            rvf_identity,
+            policy_hash,
+            detail_root,
+        )
+        .map_err(|_| ContextError::ReceiptSealFailed)?;
+        let signed_receipt = receipt.sign(signer);
+        let receipt_id = signed_receipt.receipt_id();
+        {
+            let verified = signed_receipt
+                .verify(signer)
+                .map_err(|_| ContextError::ReceiptSealFailed)?;
+            let seal_timestamp_ns = self.clock.timestamp_ns();
+            let _ = verified.emit_seal(
+                &self.witness,
+                authorized.actor().as_u32(),
+                authorized.capability_hash(),
+                seal_timestamp_ns,
+            );
+        }
+        self.receipt_chain = ReceiptChainState {
+            next_checkpoint,
+            next_epoch_id: following_epoch_id,
+            previous_receipt_id: receipt_id,
+        };
+        Ok((signed_receipt, next_checkpoint))
+    }
+}
+
+fn verify_profile(rvf: &[u8], revision: Revision) -> ContextResult<VerifiedContextProfile> {
+    if rvf.len() > MAX_RVF_BYTES {
+        return Err(ContextError::ObjectTooLarge);
+    }
+    VerifiedContextProfile::from_rvf(rvf, revision, ProfileTrust::PinnedIdentity, &[])
+        .map_err(|_| ContextError::RvfVerificationFailed)
+}
+
+fn validate_enum_limit(limit: usize) -> ContextResult<()> {
+    if limit == 0 || limit > MAX_ENUM_RESULTS {
+        Err(ContextError::InvalidResultLimit)
+    } else {
+        Ok(())
+    }
+}
+
+fn valid_result_integrity(result: &ResolvedContext) -> bool {
+    let alias_is_valid = match result.alias() {
+        Some(alias) => {
+            !alias.is_tombstone()
+                && alias.revision() == result.revision()
+                && same_logical_name(alias.alias(), result.pinned_uri().as_uri())
+        }
+        None => true,
+    };
+    result.rvf_len() <= MAX_RVF_BYTES
+        && result.pinned_uri().revision() == result.revision()
+        && alias_is_valid
+}
+
+fn valid_exact_result(target: &crate::uri::RuvUri, result: &ResolvedContext) -> bool {
+    valid_result_integrity(result)
+        && same_logical_name(target, result.pinned_uri().as_uri())
+        && target.revision().map_or_else(
+            || result.alias().is_some(),
+            |revision| revision == result.revision(),
+        )
+}
+
+fn valid_enumeration(
+    root: &crate::uri::RuvUri,
+    entries: &[ResolvedContext],
+    limit: usize,
+    recursive: bool,
+) -> bool {
+    entries.len() <= limit
+        && !has_duplicate_results(entries)
+        && entries.iter().all(|entry| {
+            let candidate = entry.pinned_uri().as_uri();
+            valid_result_integrity(entry)
+                && entry.alias().is_some()
+                && is_within(root, candidate)
+                && candidate.path().len() > root.path().len()
+                && (recursive || candidate.path().len() == root.path().len() + 1)
+        })
+}
+
+fn has_duplicate_results(entries: &[ResolvedContext]) -> bool {
+    entries.iter().enumerate().any(|(index, entry)| {
+        entries[..index]
+            .iter()
+            .any(|prior| prior.pinned_uri() == entry.pinned_uri())
+    })
+}
+
+fn valid_hits(root: &crate::uri::RuvUri, hits: &[ContextHit], limit: usize) -> bool {
+    hits.len() <= limit
+        && hits.iter().enumerate().all(|(index, hit)| {
+            let candidate = hit.pinned_uri().as_uri();
+            hit.revision() == hit.pinned_uri().revision()
+                && if let Some(revision) = root.revision() {
+                    same_logical_name(root, candidate) && hit.revision() == revision
+                } else {
+                    is_within(root, candidate)
+                }
+                && !hits[..index]
+                    .iter()
+                    .any(|prior| prior.pinned_uri() == hit.pinned_uri())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::{CapabilityHandle, ContextScope, ContextViewMask};
+    use crate::profile::{ContextProfile, ProfileView};
+    use crate::resolver::MemoryResolver;
+    use crate::uri::RuvUri;
+    use alloc::format;
+    use alloc::vec;
+    use rvm_proof::HmacSha256WitnessSigner;
+    use rvm_rvf::{
+        content_hash, sha256, SegmentHeader, SEGMENT_HEADER_SIZE, SEGMENT_MAGIC, SEGMENT_VERSION,
+        SEG_TYPE_PROFILE,
+    };
+    use rvm_types::ActionKind;
+    use sha2::{Digest, Sha256};
+
+    #[derive(Default)]
+    struct SpyResolver {
+        calls: usize,
+    }
+
+    impl SpyResolver {
+        fn called<T>(&mut self) -> ContextResult<T> {
+            self.calls += 1;
+            Err(ContextError::RevisionNotFound)
+        }
+    }
+
+    impl ContextResolver for SpyResolver {
+        fn resolve(&mut self, _: &AuthorizedRequest) -> ContextResult<ResolvedContext> {
+            self.called()
+        }
+
+        fn list(&mut self, _: &AuthorizedRequest, _: usize) -> ContextResult<Vec<ResolvedContext>> {
+            self.called()
+        }
+
+        fn tree(&mut self, _: &AuthorizedRequest, _: usize) -> ContextResult<Vec<ResolvedContext>> {
+            self.called()
+        }
+
+        fn read(&mut self, _: &AuthorizedRequest) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+            self.called()
+        }
+
+        fn search(
+            &mut self,
+            _: &AuthorizedRequest,
+            _: &[u8],
+            _: usize,
+        ) -> ContextResult<Vec<ContextHit>> {
+            self.called()
+        }
+
+        fn history(
+            &mut self,
+            _: &AuthorizedRequest,
+            _: usize,
+        ) -> ContextResult<Vec<ResolvedContext>> {
+            self.called()
+        }
+
+        fn verify(&mut self, _: &AuthorizedRequest) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+            self.called()
+        }
+
+        fn put(&mut self, _: &AuthorizedRequest, _: &[u8]) -> ContextResult<ResolvedContext> {
+            self.called()
+        }
+
+        fn compare_and_swap_alias(
+            &mut self,
+            _: &AuthorizedRequest,
+            _: Option<&AliasSnapshot>,
+            _: Revision,
+        ) -> ContextResult<AliasSnapshot> {
+            self.called()
+        }
+
+        fn forget(
+            &mut self,
+            _: &AuthorizedRequest,
+            _: &AliasSnapshot,
+        ) -> ContextResult<AliasSnapshot> {
+            self.called()
+        }
+
+        fn prepare_execute(
+            &mut self,
+            _: &AuthorizedRequest,
+        ) -> ContextResult<(ResolvedContext, Vec<u8>)> {
+            self.called()
+        }
+    }
+
+    type TestRuntime = ContextRuntime<SpyResolver, 16, 16, 32>;
+
+    fn root() -> RuvUri {
+        RuvUri::parse("ruv://example.com/acme/user/alice/resources/docs").unwrap()
+    }
+
+    fn target() -> RuvUri {
+        RuvUri::parse("ruv://example.com/acme/user/alice/resources/docs/item").unwrap()
+    }
+
+    fn runtime_as(
+        rights: CapRights,
+        runtime_actor: PartitionId,
+    ) -> (TestRuntime, CapabilityHandle, PartitionId) {
+        let owner = PartitionId::new(41);
+        let mut authority = ContextAuthority::<16, 16>::with_defaults();
+        let handle = authority
+            .issue_root(
+                ContextScope::from_uri(&root(), ContextViewMask::ALL),
+                rights,
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .unwrap();
+        (
+            ContextRuntime::new(runtime_actor, authority, SpyResolver::default()),
+            handle,
+            owner,
+        )
+    }
+
+    fn runtime(rights: CapRights) -> (TestRuntime, CapabilityHandle, PartitionId) {
+        let owner = PartitionId::new(41);
+        runtime_as(rights, owner)
+    }
+
+    fn request(
+        handle: CapabilityHandle,
+        operation: ContextOperation,
+        target: RuvUri,
+    ) -> ContextRequest {
+        ContextRequest::new(handle, operation, target)
+    }
+
+    fn segment(segment_type: u8, segment_id: u64, payload: &[u8]) -> Vec<u8> {
+        let total = SEGMENT_HEADER_SIZE + payload.len();
+        let padded = total.div_ceil(64) * 64;
+        let header = SegmentHeader {
+            magic: SEGMENT_MAGIC,
+            version: SEGMENT_VERSION,
+            seg_type: segment_type,
+            flags: 0,
+            segment_id,
+            payload_length: u64::try_from(payload.len()).unwrap(),
+            timestamp_ns: segment_id,
+            checksum_algo: 2,
+            compression: 0,
+            reserved_0: 0,
+            reserved_1: 0,
+            content_hash: content_hash(2, payload),
+            uncompressed_len: 0,
+            alignment_pad: u32::try_from(padded - total).unwrap(),
+        };
+        let mut bytes = header.to_bytes().to_vec();
+        bytes.extend_from_slice(payload);
+        bytes.resize(padded, 0);
+        bytes
+    }
+
+    fn content_only_rvf(content: &[u8]) -> Vec<u8> {
+        let profile = ContextProfile::new(vec![ProfileView::content(
+            1,
+            Revision::from_bytes(sha256(content)),
+        )
+        .unwrap()])
+        .unwrap();
+        let mut bytes = segment(0x07, 1, content);
+        bytes.extend(segment(SEG_TYPE_PROFILE, 2, &profile.to_bytes()));
+        bytes.extend(segment(0x05, 3, b"root"));
+        bytes
+    }
+
+    #[test]
+    fn runtime_bound_actor_cannot_use_another_partitions_handle() {
+        let outsider = PartitionId::new(42);
+        let (mut runtime, handle, owner) = runtime_as(CapRights::READ, outsider);
+        assert_ne!(runtime.actor(), owner);
+        let list_request = request(handle, ContextOperation::List, root());
+        assert_eq!(
+            runtime.list(&list_request, 8),
+            Err(ContextError::AccessDenied)
+        );
+        let search_request = request(handle, ContextOperation::Search, root());
+        assert_eq!(
+            runtime.search(&search_request, b"needle", 8),
+            Err(ContextError::AccessDenied)
+        );
+        assert_eq!(runtime.resolver().calls, 0);
+        assert_eq!(runtime.witness_log().total_emitted(), 2);
+    }
+
+    #[test]
+    fn receipt_state_is_runtime_owned_and_timestamp_extremes_do_not_block_sealing() {
+        let (mut runtime, handle, _) = runtime(CapRights::PROVE);
+        let mut rejected = WitnessRecord::zeroed();
+        rejected.action_kind = ActionKind::ProofRejected as u8;
+        rejected.timestamp_ns = u64::MAX;
+        let _ = runtime.witness_log().append(rejected);
+
+        let mut normal = WitnessRecord::zeroed();
+        normal.action_kind = ActionKind::ContextRead as u8;
+        normal.timestamp_ns = 0;
+        let _ = runtime.witness_log().append(normal);
+
+        let rvf_identity = [9; 32];
+        let pinned = target()
+            .with_revision(Revision::from_bytes(rvf_identity))
+            .unwrap()
+            .into_uri();
+        let seal_request = request(handle, ContextOperation::SealReceipt, pinned);
+        let signer = HmacSha256WitnessSigner::new([0x66; 32]);
+        let mut scratch = [WitnessRecord::zeroed(); 16];
+        let (first, first_checkpoint) = runtime
+            .seal_epoch(
+                &seal_request,
+                &mut scratch,
+                [1; 32],
+                rvf_identity,
+                [2; 32],
+                [3; 32],
+                &signer,
+            )
+            .unwrap();
+        let first_verified = first.verify(&signer).unwrap();
+        first_verified.verify_genesis().unwrap();
+        assert_eq!(first.receipt().started_ns(), 0);
+        assert_eq!(first.receipt().ended_ns(), u64::MAX);
+        assert_eq!(
+            runtime.receipt_chain_state().next_checkpoint(),
+            first_checkpoint
+        );
+        assert_eq!(runtime.receipt_chain_state().next_epoch_id(), 1);
+        assert_eq!(
+            runtime.receipt_chain_state().previous_receipt_id(),
+            first.receipt_id()
+        );
+
+        let (second, second_checkpoint) = runtime
+            .seal_epoch(
+                &seal_request,
+                &mut scratch,
+                [4; 32],
+                rvf_identity,
+                [5; 32],
+                [6; 32],
+                &signer,
+            )
+            .unwrap();
+        let second_verified = second.verify(&signer).unwrap();
+        second_verified.verify_successor(&first_verified).unwrap();
+        assert_eq!(second.receipt().epoch_id(), 1);
+        assert_eq!(
+            runtime.receipt_chain_state().next_checkpoint(),
+            second_checkpoint
+        );
+        assert_eq!(runtime.receipt_chain_state().next_epoch_id(), 2);
+        assert_eq!(
+            runtime.receipt_chain_state().previous_receipt_id(),
+            second.receipt_id()
+        );
+    }
+
+    #[test]
+    fn operation_mismatch_is_denied_before_backend() {
+        let (mut runtime, handle, _) = runtime(CapRights::READ);
+        let request = request(handle, ContextOperation::Read, root());
+        let result = runtime.search(&request, b"needle", 1);
+        assert_eq!(result, Err(ContextError::OperationMismatch));
+        assert_eq!(runtime.resolver().calls, 0);
+    }
+
+    #[test]
+    fn failed_backend_call_has_allow_but_no_operation_success_record() {
+        let (mut runtime, handle, _) = runtime(CapRights::READ);
+        let request = request(handle, ContextOperation::Resolve, target());
+        assert_eq!(
+            runtime.resolve(&request),
+            Err(ContextError::RevisionNotFound)
+        );
+        assert_eq!(runtime.resolver().calls, 1);
+        let mut records = [WitnessRecord::zeroed(); 4];
+        assert_eq!(runtime.witness_log().snapshot(&mut records), 1);
+        assert_eq!(records[0].action_kind, ActionKind::ProofVerifiedP1 as u8);
+    }
+
+    #[test]
+    fn failed_alias_cas_never_claims_alias_update() {
+        let (mut runtime, handle, _) = runtime(CapRights::WRITE);
+        let request = request(handle, ContextOperation::CompareAndSwapAlias, target());
+        assert_eq!(
+            runtime.compare_and_swap_alias(&request, None, Revision::from_bytes([9; 32])),
+            Err(ContextError::RevisionNotFound)
+        );
+        let mut records = [WitnessRecord::zeroed(); 4];
+        assert_eq!(runtime.witness_log().snapshot(&mut records), 1);
+        assert_eq!(records[0].action_kind, ActionKind::ProofVerifiedP1 as u8);
+        assert_ne!(records[0].action_kind, ActionKind::ContextAliasUpdate as u8);
+    }
+
+    #[test]
+    fn default_read_releases_content_segment_not_whole_rvf() {
+        let owner = PartitionId::new(41);
+        let name = target();
+        let content = b"released content only";
+        let rvf = content_only_rvf(content);
+        let revision = Revision::from_bytes(sha256(&rvf));
+        let pinned = name.clone().with_revision(revision).unwrap();
+        let mut authority = ContextAuthority::<16, 16>::with_defaults();
+        let handle = authority
+            .issue_root(
+                ContextScope::from_uri(&root(), ContextViewMask::ALL),
+                CapRights::READ | CapRights::WRITE,
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .unwrap();
+        let mut runtime = ContextRuntime::<MemoryResolver<8, 8>, 16, 16, 16>::new(
+            owner,
+            authority,
+            MemoryResolver::new(),
+        );
+
+        let put = request(handle, ContextOperation::Put, pinned.clone().into_uri());
+        runtime.put(&put, &rvf).unwrap();
+        let cas = request(handle, ContextOperation::CompareAndSwapAlias, name.clone());
+        runtime
+            .compare_and_swap_alias(&cas, None, revision)
+            .unwrap();
+        let read = request(handle, ContextOperation::Read, name);
+        let (_, released) = runtime.read(&read).unwrap();
+        assert_eq!(released, content);
+        assert_ne!(released, rvf);
+    }
+
+    #[test]
+    fn invalid_rvf_is_rejected_before_put_backend() {
+        let (mut runtime, handle, _) = runtime(CapRights::WRITE);
+        let bytes = b"not an RVF";
+        let digest = Sha256::digest(bytes);
+        let mut revision_bytes = [0u8; 32];
+        revision_bytes.copy_from_slice(&digest);
+        let revision = Revision::sha256(revision_bytes);
+        let pinned = target().with_revision(revision).unwrap().into_uri();
+        let request = request(handle, ContextOperation::Put, pinned);
+        assert_eq!(
+            runtime.put(&request, bytes),
+            Err(ContextError::RvfVerificationFailed)
+        );
+        assert_eq!(runtime.resolver().calls, 0);
+    }
+
+    #[test]
+    fn read_right_does_not_reach_execute_backend() {
+        let (mut runtime, handle, _) = runtime(CapRights::READ);
+        let skill = RuvUri::parse(&format!(
+            "ruv://example.com/acme/user/alice/skills/tool?rev=sha256:{}",
+            "22".repeat(32)
+        ))
+        .unwrap();
+        let request = request(handle, ContextOperation::Execute, skill);
+        assert_eq!(
+            runtime.authorize_execute(&request),
+            Err(ContextError::AccessDenied)
+        );
+        assert_eq!(runtime.resolver().calls, 0);
+    }
+}

--- a/crates/rvm-context/src/uri.rs
+++ b/crates/rvm-context/src/uri.rs
@@ -1,0 +1,1415 @@
+//! Strict, canonical parsing and formatting for the `ruv://` namespace.
+//!
+//! A `ruv://` URI is a name, not an authority token. This module deliberately
+//! accepts only one spelling for every name so that policy scopes, witness
+//! records, signatures, and caches cannot disagree about URI equivalence.
+
+use alloc::{string::String, vec::Vec};
+use core::{fmt, str::FromStr};
+
+const SCHEME: &str = "ruv://";
+const MAX_URI_BYTES: usize = 2_048;
+const MAX_AUTHORITY_BYTES: usize = 253;
+const MAX_DNS_LABEL_BYTES: usize = 63;
+const MAX_IDENTIFIER_BYTES: usize = 63;
+const MAX_PATH_SEGMENT_BYTES: usize = 128;
+const MAX_PATH_SEGMENTS: usize = 32;
+const MAX_PATH_BYTES: usize = 1_024;
+
+/// A failure to parse or construct a canonical `ruv://` URI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UriError {
+    /// The complete URI exceeds 2,048 bytes.
+    UriTooLong,
+    /// The URI contains a non-ASCII byte.
+    NonAscii,
+    /// The scheme is not exactly lowercase `ruv://`.
+    InvalidScheme,
+    /// Percent encoding is forbidden by the v1 canonical contract.
+    PercentEncodingNotAllowed,
+    /// URI fragments are forbidden.
+    FragmentNotAllowed,
+    /// User information or credentials appear in the authority.
+    CredentialsNotAllowed,
+    /// An authority port is present.
+    PortNotAllowed,
+    /// The DNS authority is empty, malformed, noncanonical, or too long.
+    InvalidAuthority,
+    /// The tenant identifier is not a canonical lowercase slug.
+    InvalidTenant,
+    /// The subject kind is not one of the registered lowercase values.
+    InvalidSubjectKind,
+    /// The subject identifier is not a canonical lowercase slug.
+    InvalidSubjectId,
+    /// The collection is not one of the registered lowercase values.
+    InvalidCollection,
+    /// A required hierarchy component is missing.
+    MissingComponent,
+    /// A hierarchy component between slashes is empty.
+    EmptyPathSegment,
+    /// The hierarchical path has a trailing slash.
+    TrailingSlash,
+    /// A path contains the `.` or `..` traversal segment.
+    DotSegment,
+    /// A path segment contains a forbidden character or exceeds 128 bytes.
+    InvalidPathSegment,
+    /// More than 32 optional path segments were supplied.
+    TooManyPathSegments,
+    /// The optional path exceeds 1,024 bytes including separators.
+    PathTooLong,
+    /// The query is empty or structurally malformed.
+    InvalidQuery,
+    /// The query contains a key other than `rev` or `view`.
+    UnknownQueryKey,
+    /// A query key occurs more than once.
+    DuplicateQueryKey,
+    /// Query keys are not in canonical `rev` then `view` order.
+    QueryOrder,
+    /// A revision is not `sha256:` followed by 64 lowercase hexadecimal digits.
+    InvalidRevision,
+    /// A progressive view is not `abstract`, `overview`, or `content`.
+    InvalidView,
+    /// Conversion to [`PinnedRuvUri`] was requested without a revision.
+    RevisionRequired,
+}
+
+impl fmt::Display for UriError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::UriTooLong => "ruv URI exceeds 2048 bytes",
+            Self::NonAscii => "ruv URI must contain ASCII only",
+            Self::InvalidScheme => "scheme must be exactly ruv://",
+            Self::PercentEncodingNotAllowed => "percent encoding is not allowed",
+            Self::FragmentNotAllowed => "URI fragments are not allowed",
+            Self::CredentialsNotAllowed => "authority credentials are not allowed",
+            Self::PortNotAllowed => "authority ports are not allowed",
+            Self::InvalidAuthority => "invalid canonical DNS authority",
+            Self::InvalidTenant => "invalid canonical tenant slug",
+            Self::InvalidSubjectKind => "invalid subject kind",
+            Self::InvalidSubjectId => "invalid canonical subject slug",
+            Self::InvalidCollection => "invalid collection",
+            Self::MissingComponent => "required URI component is missing",
+            Self::EmptyPathSegment => "empty path segment is not allowed",
+            Self::TrailingSlash => "trailing slash is not allowed",
+            Self::DotSegment => "dot path segments are not allowed",
+            Self::InvalidPathSegment => "invalid canonical path segment",
+            Self::TooManyPathSegments => "too many path segments",
+            Self::PathTooLong => "path exceeds 1024 bytes",
+            Self::InvalidQuery => "invalid canonical query",
+            Self::UnknownQueryKey => "unknown query key",
+            Self::DuplicateQueryKey => "duplicate query key",
+            Self::QueryOrder => "query keys are not in canonical order",
+            Self::InvalidRevision => "invalid SHA-256 revision",
+            Self::InvalidView => "invalid progressive view",
+            Self::RevisionRequired => "a pinned ruv URI requires a revision",
+        };
+        f.write_str(message)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UriError {}
+
+fn reject_forbidden_octets(value: &str) -> Result<(), UriError> {
+    if !value.is_ascii() {
+        return Err(UriError::NonAscii);
+    }
+    if value.as_bytes().contains(&b'%') {
+        return Err(UriError::PercentEncodingNotAllowed);
+    }
+    if value.as_bytes().contains(&b'#') {
+        return Err(UriError::FragmentNotAllowed);
+    }
+    Ok(())
+}
+
+fn is_slug(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= MAX_IDENTIFIER_BYTES
+        && is_ascii_lowercase_or_digit(bytes[0])
+        && is_ascii_lowercase_or_digit(bytes[bytes.len() - 1])
+        && bytes
+            .iter()
+            .all(|byte| is_ascii_lowercase_or_digit(*byte) || *byte == b'-')
+}
+
+fn is_ascii_lowercase_or_digit(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit()
+}
+
+/// A canonical lowercase DNS authority without credentials or a port.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Authority(String);
+
+impl Authority {
+    /// Validates and constructs an authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError`] when `value` is not canonical lowercase DNS text
+    /// or contains credentials, a port, percent encoding, or non-ASCII bytes.
+    pub fn new(value: &str) -> Result<Self, UriError> {
+        reject_forbidden_octets(value)?;
+        if value.as_bytes().contains(&b'@') {
+            return Err(UriError::CredentialsNotAllowed);
+        }
+        if value.as_bytes().contains(&b':') {
+            return Err(UriError::PortNotAllowed);
+        }
+        if value.is_empty() || value.len() > MAX_AUTHORITY_BYTES {
+            return Err(UriError::InvalidAuthority);
+        }
+        for label in value.split('.') {
+            let bytes = label.as_bytes();
+            if bytes.is_empty()
+                || bytes.len() > MAX_DNS_LABEL_BYTES
+                || !is_ascii_lowercase_or_digit(bytes[0])
+                || !is_ascii_lowercase_or_digit(bytes[bytes.len() - 1])
+                || !bytes
+                    .iter()
+                    .all(|byte| is_ascii_lowercase_or_digit(*byte) || *byte == b'-')
+            {
+                return Err(UriError::InvalidAuthority);
+            }
+        }
+        Ok(Self(String::from(value)))
+    }
+
+    /// Returns the canonical authority text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for Authority {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for Authority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Authority {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for Authority {
+    type Error = UriError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// A canonical tenant slug.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TenantId(String);
+
+impl TenantId {
+    /// Validates and constructs a tenant identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError`] when `value` is not a lowercase slug of at most
+    /// 63 bytes or contains a globally forbidden URI byte.
+    pub fn new(value: &str) -> Result<Self, UriError> {
+        reject_forbidden_octets(value)?;
+        if !is_slug(value) {
+            return Err(UriError::InvalidTenant);
+        }
+        Ok(Self(String::from(value)))
+    }
+
+    /// Returns the canonical tenant slug.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for TenantId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TenantId {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for TenantId {
+    type Error = UriError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// A canonical subject slug.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SubjectId(String);
+
+impl SubjectId {
+    /// Validates and constructs a subject identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError`] when `value` is not a lowercase slug of at most
+    /// 63 bytes or contains a globally forbidden URI byte.
+    pub fn new(value: &str) -> Result<Self, UriError> {
+        reject_forbidden_octets(value)?;
+        if !is_slug(value) {
+            return Err(UriError::InvalidSubjectId);
+        }
+        Ok(Self(String::from(value)))
+    }
+
+    /// Returns the canonical subject slug.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for SubjectId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for SubjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SubjectId {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for SubjectId {
+    type Error = UriError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// The principal category named by a context URI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SubjectKind {
+    /// An autonomous or user-directed agent.
+    Agent,
+    /// A human user.
+    User,
+    /// A service principal.
+    Service,
+    /// A team principal.
+    Team,
+}
+
+impl SubjectKind {
+    /// Returns the registered lowercase spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::User => "user",
+            Self::Service => "service",
+            Self::Team => "team",
+        }
+    }
+}
+
+impl fmt::Display for SubjectKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SubjectKind {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "agent" => Ok(Self::Agent),
+            "user" => Ok(Self::User),
+            "service" => Ok(Self::Service),
+            "team" => Ok(Self::Team),
+            _ => Err(UriError::InvalidSubjectKind),
+        }
+    }
+}
+
+/// A typed subject identity.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Subject {
+    kind: SubjectKind,
+    id: SubjectId,
+}
+
+impl Subject {
+    /// Constructs a subject from already validated components.
+    #[must_use]
+    pub const fn new(kind: SubjectKind, id: SubjectId) -> Self {
+        Self { kind, id }
+    }
+
+    /// Returns the subject category.
+    #[must_use]
+    pub const fn kind(&self) -> SubjectKind {
+        self.kind
+    }
+
+    /// Returns the subject identifier.
+    #[must_use]
+    pub const fn id(&self) -> &SubjectId {
+        &self.id
+    }
+}
+
+/// A top-level context collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Collection {
+    /// Durable or episodic agent memory.
+    Memory,
+    /// Readable context resources.
+    Resources,
+    /// Discoverable or executable skill artifacts.
+    Skills,
+}
+
+impl Collection {
+    /// Returns the registered lowercase spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::Resources => "resources",
+            Self::Skills => "skills",
+        }
+    }
+}
+
+impl fmt::Display for Collection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Collection {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "memory" => Ok(Self::Memory),
+            "resources" => Ok(Self::Resources),
+            "skills" => Ok(Self::Skills),
+            _ => Err(UriError::InvalidCollection),
+        }
+    }
+}
+
+/// One case-sensitive ASCII-unreserved segment below a collection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PathSegment(String);
+
+impl PathSegment {
+    /// Validates and constructs a path segment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError`] when `value` is empty, a dot segment, longer than
+    /// 128 bytes, non-ASCII, or contains a character outside the unreserved
+    /// set.
+    pub fn new(value: &str) -> Result<Self, UriError> {
+        reject_forbidden_octets(value)?;
+        if value.is_empty() {
+            return Err(UriError::EmptyPathSegment);
+        }
+        if value == "." || value == ".." {
+            return Err(UriError::DotSegment);
+        }
+        if value.len() > MAX_PATH_SEGMENT_BYTES
+            || !value.as_bytes().iter().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(*byte, b'-' | b'.' | b'_' | b'~')
+            })
+        {
+            return Err(UriError::InvalidPathSegment);
+        }
+        Ok(Self(String::from(value)))
+    }
+
+    /// Returns the exact case-sensitive segment text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for PathSegment {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PathSegment {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for PathSegment {
+    type Error = UriError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// A whole-container SHA-256 RVF identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Revision([u8; 32]);
+
+impl Revision {
+    /// Constructs a SHA-256 revision from its digest bytes.
+    #[must_use]
+    pub const fn sha256(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Constructs a revision from a SHA-256 digest.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self::sha256(bytes)
+    }
+
+    /// Returns the raw SHA-256 digest.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for Revision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut encoded = [0_u8; 71];
+        encoded[..7].copy_from_slice(b"sha256:");
+        for (index, byte) in self.0.iter().copied().enumerate() {
+            encoded[7 + index * 2] = HEX[usize::from(byte >> 4)];
+            encoded[8 + index * 2] = HEX[usize::from(byte & 0x0f)];
+        }
+        let text = core::str::from_utf8(&encoded).map_err(|_| fmt::Error)?;
+        f.write_str(text)
+    }
+}
+
+impl FromStr for Revision {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let hex = value
+            .strip_prefix("sha256:")
+            .ok_or(UriError::InvalidRevision)?;
+        if hex.len() != 64
+            || !hex
+                .as_bytes()
+                .iter()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+        {
+            return Err(UriError::InvalidRevision);
+        }
+        let mut digest = [0_u8; 32];
+        for (index, byte) in digest.iter_mut().enumerate() {
+            let offset = index * 2;
+            *byte =
+                (hex_nibble(hex.as_bytes()[offset]) << 4) | hex_nibble(hex.as_bytes()[offset + 1]);
+        }
+        Ok(Self(digest))
+    }
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => 0,
+    }
+}
+
+/// A progressively more detailed view of a context object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ProgressiveView {
+    /// A compact L0 abstract.
+    Abstract,
+    /// An L1 overview.
+    Overview,
+    /// Full L2 content.
+    Content,
+}
+
+impl ProgressiveView {
+    /// Returns the registered lowercase spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Abstract => "abstract",
+            Self::Overview => "overview",
+            Self::Content => "content",
+        }
+    }
+}
+
+impl fmt::Display for ProgressiveView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ProgressiveView {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "abstract" => Ok(Self::Abstract),
+            "overview" => Ok(Self::Overview),
+            "content" => Ok(Self::Content),
+            _ => Err(UriError::InvalidView),
+        }
+    }
+}
+
+/// A validated canonical `ruv://` URI.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RuvUri {
+    authority: Authority,
+    tenant: TenantId,
+    subject: Subject,
+    collection: Collection,
+    path: Vec<PathSegment>,
+    revision: Option<Revision>,
+    view: Option<ProgressiveView>,
+}
+
+impl RuvUri {
+    /// Parses a URI while requiring its input to already be canonical.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError`] for every noncanonical spelling, malformed
+    /// component, forbidden construct, or exceeded resource limit.
+    pub fn parse(value: &str) -> Result<Self, UriError> {
+        value.parse()
+    }
+
+    /// Starts a builder from validated required components.
+    #[must_use]
+    pub fn builder(
+        authority: Authority,
+        tenant: TenantId,
+        subject: Subject,
+        collection: Collection,
+    ) -> RuvUriBuilder {
+        RuvUriBuilder::new(authority, tenant, subject, collection)
+    }
+
+    /// Returns the DNS authority.
+    #[must_use]
+    pub const fn authority(&self) -> &Authority {
+        &self.authority
+    }
+
+    /// Returns the tenant identifier.
+    #[must_use]
+    pub const fn tenant(&self) -> &TenantId {
+        &self.tenant
+    }
+
+    /// Returns the typed subject.
+    #[must_use]
+    pub const fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    /// Returns the top-level collection.
+    #[must_use]
+    pub const fn collection(&self) -> Collection {
+        self.collection
+    }
+
+    /// Returns optional path segments below the collection.
+    #[must_use]
+    pub fn path(&self) -> &[PathSegment] {
+        &self.path
+    }
+
+    /// Returns the immutable RVF revision when this name is pinned.
+    #[must_use]
+    pub const fn revision(&self) -> Option<Revision> {
+        self.revision
+    }
+
+    /// Returns the requested progressive view.
+    #[must_use]
+    pub const fn view(&self) -> Option<ProgressiveView> {
+        self.view
+    }
+
+    /// Reports whether this URI includes an immutable revision.
+    #[must_use]
+    pub const fn is_pinned(&self) -> bool {
+        self.revision.is_some()
+    }
+
+    /// Returns a pinned copy of this URI.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError::UriTooLong`] if adding the revision would exceed
+    /// the complete URI byte limit.
+    pub fn with_revision(mut self, revision: Revision) -> Result<PinnedRuvUri, UriError> {
+        self.revision = Some(revision);
+        validate_complete(&self)?;
+        Ok(PinnedRuvUri {
+            uri: self,
+            revision,
+        })
+    }
+
+    /// Returns a copy with the requested progressive view.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError::UriTooLong`] if adding the view would exceed the
+    /// complete URI byte limit.
+    pub fn with_view(mut self, view: ProgressiveView) -> Result<Self, UriError> {
+        self.view = Some(view);
+        validate_complete(&self)?;
+        Ok(self)
+    }
+
+    fn optional_path_bytes(&self) -> usize {
+        self.path
+            .iter()
+            .map(|segment| segment.as_str().len())
+            .sum::<usize>()
+            + self.path.len().saturating_sub(1)
+    }
+
+    fn canonical_len(&self) -> usize {
+        let mut length = SCHEME.len()
+            + self.authority.as_str().len()
+            + 4
+            + self.tenant.as_str().len()
+            + self.subject.kind().as_str().len()
+            + self.subject.id().as_str().len()
+            + self.collection.as_str().len();
+        length += self
+            .path
+            .iter()
+            .map(|segment| 1 + segment.as_str().len())
+            .sum::<usize>();
+        if self.revision.is_some() {
+            length += 1 + 4 + 7 + 64;
+        }
+        if let Some(view) = self.view {
+            length += 1 + 5 + view.as_str().len();
+        }
+        length
+    }
+}
+
+fn validate_complete(uri: &RuvUri) -> Result<(), UriError> {
+    if uri.path.len() > MAX_PATH_SEGMENTS {
+        return Err(UriError::TooManyPathSegments);
+    }
+    if uri.optional_path_bytes() > MAX_PATH_BYTES {
+        return Err(UriError::PathTooLong);
+    }
+    if uri.canonical_len() > MAX_URI_BYTES {
+        return Err(UriError::UriTooLong);
+    }
+    Ok(())
+}
+
+impl FromStr for RuvUri {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.len() > MAX_URI_BYTES {
+            return Err(UriError::UriTooLong);
+        }
+        reject_forbidden_octets(value)?;
+        let after_scheme = value.strip_prefix(SCHEME).ok_or(UriError::InvalidScheme)?;
+        let (hierarchy, query) = match after_scheme.split_once('?') {
+            Some((hierarchy, query)) => (hierarchy, Some(query)),
+            None => (after_scheme, None),
+        };
+        if hierarchy.ends_with('/') {
+            return Err(UriError::TrailingSlash);
+        }
+
+        let mut components = [""; 5 + MAX_PATH_SEGMENTS];
+        let mut component_count = 0_usize;
+        let mut has_empty_component = false;
+        for component in hierarchy.split('/') {
+            has_empty_component |= component.is_empty();
+            if component_count < components.len() {
+                components[component_count] = component;
+            }
+            component_count += 1;
+        }
+        if component_count < 5 {
+            return Err(UriError::MissingComponent);
+        }
+        if has_empty_component {
+            return Err(UriError::EmptyPathSegment);
+        }
+
+        let authority = Authority::new(components[0])?;
+        let tenant = TenantId::new(components[1])?;
+        let subject_kind = components[2].parse()?;
+        let subject_id = SubjectId::new(components[3])?;
+        let collection = components[4].parse()?;
+        let path_count = component_count - 5;
+        if path_count > MAX_PATH_SEGMENTS {
+            return Err(UriError::TooManyPathSegments);
+        }
+        let path_parts = &components[5..component_count];
+        let path_bytes =
+            path_parts.iter().map(|part| part.len()).sum::<usize>() + path_count.saturating_sub(1);
+        if path_bytes > MAX_PATH_BYTES {
+            return Err(UriError::PathTooLong);
+        }
+        let path = path_parts
+            .iter()
+            .map(|part| PathSegment::new(part))
+            .collect::<Result<Vec<_>, _>>()?;
+        let (revision, view) = parse_query(query)?;
+
+        let uri = Self {
+            authority,
+            tenant,
+            subject: Subject::new(subject_kind, subject_id),
+            collection,
+            path,
+            revision,
+            view,
+        };
+        validate_complete(&uri)?;
+        Ok(uri)
+    }
+}
+
+fn parse_query(
+    query: Option<&str>,
+) -> Result<(Option<Revision>, Option<ProgressiveView>), UriError> {
+    let Some(query) = query else {
+        return Ok((None, None));
+    };
+    if query.is_empty() {
+        return Err(UriError::InvalidQuery);
+    }
+
+    let mut entries = query.split('&');
+    let first = entries.next().ok_or(UriError::InvalidQuery)?;
+    let second = entries.next();
+    if entries.next().is_some() || first.is_empty() || second == Some("") {
+        return Err(UriError::InvalidQuery);
+    }
+    let mut revision = None;
+    let mut view = None;
+    let mut saw_view = false;
+
+    for entry in [Some(first), second].into_iter().flatten() {
+        let (key, value) = entry.split_once('=').ok_or(UriError::InvalidQuery)?;
+        if key.is_empty() || value.is_empty() || value.as_bytes().contains(&b'=') {
+            return Err(UriError::InvalidQuery);
+        }
+        match key {
+            "rev" => {
+                if revision.is_some() {
+                    return Err(UriError::DuplicateQueryKey);
+                }
+                if saw_view {
+                    return Err(UriError::QueryOrder);
+                }
+                revision = Some(value.parse()?);
+            }
+            "view" => {
+                if view.is_some() {
+                    return Err(UriError::DuplicateQueryKey);
+                }
+                saw_view = true;
+                view = Some(value.parse()?);
+            }
+            _ => return Err(UriError::UnknownQueryKey),
+        }
+    }
+    Ok((revision, view))
+}
+
+impl fmt::Display for RuvUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{SCHEME}{}/{}/{}/{}/{}",
+            self.authority,
+            self.tenant,
+            self.subject.kind(),
+            self.subject.id(),
+            self.collection
+        )?;
+        for segment in &self.path {
+            write!(f, "/{segment}")?;
+        }
+        if let Some(revision) = self.revision {
+            write!(f, "?rev={revision}")?;
+        }
+        if let Some(view) = self.view {
+            if self.revision.is_some() {
+                write!(f, "&view={view}")?;
+            } else {
+                write!(f, "?view={view}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<&str> for RuvUri {
+    type Error = UriError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+/// A `ruv://` URI guaranteed to contain an immutable RVF revision.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PinnedRuvUri {
+    uri: RuvUri,
+    revision: Revision,
+}
+
+impl PinnedRuvUri {
+    /// Returns the underlying validated URI.
+    #[must_use]
+    pub const fn as_uri(&self) -> &RuvUri {
+        &self.uri
+    }
+
+    /// Returns the required immutable revision.
+    #[must_use]
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Consumes the wrapper and returns the underlying URI.
+    #[must_use]
+    pub fn into_uri(self) -> RuvUri {
+        self.uri
+    }
+}
+
+impl TryFrom<RuvUri> for PinnedRuvUri {
+    type Error = UriError;
+
+    fn try_from(uri: RuvUri) -> Result<Self, Self::Error> {
+        let revision = uri.revision.ok_or(UriError::RevisionRequired)?;
+        Ok(Self { uri, revision })
+    }
+}
+
+impl From<PinnedRuvUri> for RuvUri {
+    fn from(uri: PinnedRuvUri) -> Self {
+        uri.into_uri()
+    }
+}
+
+impl FromStr for PinnedRuvUri {
+    type Err = UriError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::try_from(RuvUri::parse(value)?)
+    }
+}
+
+impl fmt::Display for PinnedRuvUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.uri.fmt(f)
+    }
+}
+
+/// Builder for a validated canonical `ruv://` URI.
+#[derive(Debug, Clone)]
+pub struct RuvUriBuilder {
+    authority: Authority,
+    tenant: TenantId,
+    subject: Subject,
+    collection: Collection,
+    path: Vec<PathSegment>,
+    revision: Option<Revision>,
+    view: Option<ProgressiveView>,
+}
+
+impl RuvUriBuilder {
+    /// Starts a builder from validated required components.
+    #[must_use]
+    pub const fn new(
+        authority: Authority,
+        tenant: TenantId,
+        subject: Subject,
+        collection: Collection,
+    ) -> Self {
+        Self {
+            authority,
+            tenant,
+            subject,
+            collection,
+            path: Vec::new(),
+            revision: None,
+            view: None,
+        }
+    }
+
+    /// Appends one validated path segment.
+    #[must_use]
+    pub fn path_segment(mut self, segment: PathSegment) -> Self {
+        self.path.push(segment);
+        self
+    }
+
+    /// Replaces the optional path with validated segments.
+    #[must_use]
+    pub fn path(mut self, path: Vec<PathSegment>) -> Self {
+        self.path = path;
+        self
+    }
+
+    /// Pins the name to an immutable RVF revision.
+    #[must_use]
+    pub const fn revision(mut self, revision: Revision) -> Self {
+        self.revision = Some(revision);
+        self
+    }
+
+    /// Selects a progressive context view.
+    #[must_use]
+    pub const fn view(mut self, view: ProgressiveView) -> Self {
+        self.view = Some(view);
+        self
+    }
+
+    /// Validates aggregate limits and constructs the URI.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError`] if the optional path or complete URI exceeds its
+    /// aggregate limit.
+    pub fn build(self) -> Result<RuvUri, UriError> {
+        let uri = RuvUri {
+            authority: self.authority,
+            tenant: self.tenant,
+            subject: self.subject,
+            collection: self.collection,
+            path: self.path,
+            revision: self.revision,
+            view: self.view,
+        };
+        validate_complete(&uri)?;
+        Ok(uri)
+    }
+
+    /// Validates aggregate limits and constructs a pinned URI.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UriError::RevisionRequired`] if no revision was supplied, or
+    /// a resource-limit error if an aggregate URI limit is exceeded.
+    pub fn build_pinned(self) -> Result<PinnedRuvUri, UriError> {
+        PinnedRuvUri::try_from(self.build()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{format, string::ToString, vec};
+    use proptest::prelude::*;
+
+    const ZERO_REVISION: &str =
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+    #[test]
+    fn minimal_uri_round_trips() {
+        let text = "ruv://context.example/acme/agent/researcher/memory";
+        let uri = RuvUri::parse(text).unwrap();
+        assert_eq!(uri.to_string(), text);
+        assert_eq!(uri.authority().as_str(), "context.example");
+        assert_eq!(uri.tenant().as_str(), "acme");
+        assert_eq!(uri.subject().kind(), SubjectKind::Agent);
+        assert_eq!(uri.subject().id().as_str(), "researcher");
+        assert_eq!(uri.collection(), Collection::Memory);
+        assert!(uri.path().is_empty());
+        assert!(!uri.is_pinned());
+    }
+
+    #[test]
+    fn full_uri_round_trips_and_preserves_path_case() {
+        let text = format!(
+            "ruv://context.example/acme/team/core/resources/Specs/API_v1?rev={ZERO_REVISION}&view=overview"
+        );
+        let uri = RuvUri::parse(&text).unwrap();
+        assert_eq!(uri.to_string(), text);
+        assert_eq!(uri.path()[0].as_str(), "Specs");
+        assert_eq!(uri.path()[1].as_str(), "API_v1");
+        assert_eq!(uri.view(), Some(ProgressiveView::Overview));
+        assert!(uri.is_pinned());
+        assert_eq!(uri.revision().unwrap().as_bytes(), &[0; 32]);
+    }
+
+    #[test]
+    fn accepts_each_canonical_query_shape() {
+        let base = "ruv://a/t/user/u/skills";
+        for suffix in [
+            "",
+            "?view=abstract",
+            "?view=overview",
+            "?view=content",
+            &format!("?rev={ZERO_REVISION}"),
+            &format!("?rev={ZERO_REVISION}&view=content"),
+        ] {
+            let text = format!("{base}{suffix}");
+            assert_eq!(RuvUri::parse(&text).unwrap().to_string(), text);
+        }
+    }
+
+    #[test]
+    fn all_registered_enums_are_exact_and_lowercase() {
+        for (text, kind) in [
+            ("agent", SubjectKind::Agent),
+            ("user", SubjectKind::User),
+            ("service", SubjectKind::Service),
+            ("team", SubjectKind::Team),
+        ] {
+            assert_eq!(text.parse::<SubjectKind>().unwrap(), kind);
+            assert_eq!(kind.to_string(), text);
+        }
+        for (text, collection) in [
+            ("memory", Collection::Memory),
+            ("resources", Collection::Resources),
+            ("skills", Collection::Skills),
+        ] {
+            assert_eq!(text.parse::<Collection>().unwrap(), collection);
+            assert_eq!(collection.to_string(), text);
+        }
+        assert_eq!(
+            "Agent".parse::<SubjectKind>(),
+            Err(UriError::InvalidSubjectKind)
+        );
+        assert_eq!(
+            "Memory".parse::<Collection>(),
+            Err(UriError::InvalidCollection)
+        );
+        assert_eq!(
+            "Overview".parse::<ProgressiveView>(),
+            Err(UriError::InvalidView)
+        );
+    }
+
+    #[test]
+    fn authority_enforces_dns_limits_and_canonical_form() {
+        assert!(Authority::new("a").is_ok());
+        assert!(Authority::new(&"a".repeat(63)).is_ok());
+        assert_eq!(
+            Authority::new(&"a".repeat(64)),
+            Err(UriError::InvalidAuthority)
+        );
+        assert_eq!(
+            Authority::new("-a.example"),
+            Err(UriError::InvalidAuthority)
+        );
+        assert_eq!(
+            Authority::new("a-.example"),
+            Err(UriError::InvalidAuthority)
+        );
+        assert_eq!(
+            Authority::new("a..example"),
+            Err(UriError::InvalidAuthority)
+        );
+        assert_eq!(Authority::new("A.example"), Err(UriError::InvalidAuthority));
+        assert_eq!(
+            Authority::new("a.example."),
+            Err(UriError::InvalidAuthority)
+        );
+
+        let longest = [
+            "a".repeat(63),
+            "b".repeat(63),
+            "c".repeat(63),
+            "d".repeat(61),
+        ]
+        .join(".");
+        assert_eq!(longest.len(), 253);
+        assert!(Authority::new(&longest).is_ok());
+        let too_long = format!("{longest}.e");
+        assert_eq!(Authority::new(&too_long), Err(UriError::InvalidAuthority));
+    }
+
+    #[test]
+    fn identifiers_are_bounded_lowercase_slugs() {
+        for valid in ["a", "0", "agent-42", &"z".repeat(63)] {
+            assert!(TenantId::new(valid).is_ok());
+            assert!(SubjectId::new(valid).is_ok());
+        }
+        for invalid in [
+            "",
+            "Agent",
+            "-agent",
+            "agent-",
+            "agent_name",
+            &"a".repeat(64),
+        ] {
+            assert!(TenantId::new(invalid).is_err());
+            assert!(SubjectId::new(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn path_segments_are_ascii_unreserved_and_case_sensitive() {
+        for valid in ["A", "readme.md", "API_v1", "x~y", &"z".repeat(128)] {
+            assert_eq!(PathSegment::new(valid).unwrap().as_str(), valid);
+        }
+        for invalid in ["", ".", "..", "a b", "a+b", "a:b", "a?b", &"z".repeat(129)] {
+            assert!(PathSegment::new(invalid).is_err(), "accepted {invalid:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_ascii_percent_fragments_credentials_and_ports() {
+        let cases = [
+            (
+                "ruv://context.example/acmé/agent/a/memory",
+                UriError::NonAscii,
+            ),
+            (
+                "ruv://context.example/acme/agent/a/memory/%2e%2e",
+                UriError::PercentEncodingNotAllowed,
+            ),
+            (
+                "ruv://context.example/acme/agent/a/memory#fragment",
+                UriError::FragmentNotAllowed,
+            ),
+            (
+                "ruv://user@context.example/acme/agent/a/memory",
+                UriError::CredentialsNotAllowed,
+            ),
+            (
+                "ruv://context.example:443/acme/agent/a/memory",
+                UriError::PortNotAllowed,
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(RuvUri::parse(text), Err(expected), "case {text}");
+        }
+    }
+
+    #[test]
+    fn rejects_missing_empty_trailing_and_dot_paths() {
+        assert_eq!(
+            RuvUri::parse("ruv://a/t/agent/id"),
+            Err(UriError::MissingComponent)
+        );
+        assert_eq!(
+            RuvUri::parse("ruv://a/t/agent/id/memory/"),
+            Err(UriError::TrailingSlash)
+        );
+        assert_eq!(
+            RuvUri::parse("ruv://a/t/agent/id/memory//x"),
+            Err(UriError::EmptyPathSegment)
+        );
+        assert_eq!(
+            RuvUri::parse("ruv://a/t/agent/id/memory/.."),
+            Err(UriError::DotSegment)
+        );
+    }
+
+    #[test]
+    fn rejects_noncanonical_scheme_and_structural_case() {
+        for text in [
+            "RUV://a/t/agent/id/memory",
+            "ruv:/a/t/agent/id/memory",
+            "ruv://A/t/agent/id/memory",
+            "ruv://a/T/agent/id/memory",
+            "ruv://a/t/Agent/id/memory",
+            "ruv://a/t/agent/ID/memory",
+            "ruv://a/t/agent/id/Memory",
+        ] {
+            assert!(RuvUri::parse(text).is_err(), "accepted {text}");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_duplicate_reordered_or_malformed_query() {
+        let base = "ruv://a/t/agent/id/memory";
+        for suffix in [
+            "?",
+            "?rev",
+            "?rev=",
+            "?view=",
+            "?other=x",
+            "?view=abstract&view=content",
+            &format!("?rev={ZERO_REVISION}&rev={ZERO_REVISION}"),
+            &format!("?view=overview&rev={ZERO_REVISION}"),
+            &format!("?rev={ZERO_REVISION}&"),
+            &format!("?rev={ZERO_REVISION}&view=overview&other=x"),
+        ] {
+            assert!(
+                RuvUri::parse(&format!("{base}{suffix}")).is_err(),
+                "accepted {suffix}"
+            );
+        }
+    }
+
+    #[test]
+    fn revision_requires_exact_lowercase_sha256_encoding() {
+        assert!(ZERO_REVISION.parse::<Revision>().is_ok());
+        for invalid in [
+            "SHA256:0000000000000000000000000000000000000000000000000000000000000000",
+            "sha256:0000",
+            "sha256:000000000000000000000000000000000000000000000000000000000000000G",
+            "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "sha512:0000000000000000000000000000000000000000000000000000000000000000",
+        ] {
+            assert_eq!(invalid.parse::<Revision>(), Err(UriError::InvalidRevision));
+        }
+        let digest = Revision::from_bytes([0xab; 32]);
+        assert_eq!(
+            digest.to_string(),
+            "sha256:abababababababababababababababababababababababababababababababab"
+        );
+    }
+
+    #[test]
+    fn builder_and_pinned_wrapper_preserve_invariants() {
+        let uri = RuvUriBuilder::new(
+            Authority::new("context.example").unwrap(),
+            TenantId::new("acme").unwrap(),
+            Subject::new(SubjectKind::Service, SubjectId::new("indexer").unwrap()),
+            Collection::Resources,
+        )
+        .path_segment(PathSegment::new("Docs").unwrap())
+        .revision(Revision::from_bytes([7; 32]))
+        .view(ProgressiveView::Content)
+        .build_pinned()
+        .unwrap();
+        assert_eq!(uri.revision(), Revision::from_bytes([7; 32]));
+        assert_eq!(uri.as_uri().path()[0].as_str(), "Docs");
+
+        let unpinned = RuvUri::parse("ruv://a/t/team/core/skills").unwrap();
+        assert_eq!(
+            PinnedRuvUri::try_from(unpinned),
+            Err(UriError::RevisionRequired)
+        );
+    }
+
+    #[test]
+    fn aggregate_path_limits_are_enforced() {
+        let base = "ruv://a/t/agent/id/memory";
+        let too_many = format!("{base}/{}", vec!["x"; 33].join("/"));
+        assert_eq!(RuvUri::parse(&too_many), Err(UriError::TooManyPathSegments));
+
+        let long_segments = vec!["x".repeat(128); 9];
+        let too_long = format!("{base}/{}", long_segments.join("/"));
+        assert_eq!(RuvUri::parse(&too_long), Err(UriError::PathTooLong));
+
+        let exactly = vec!["x".repeat(127); 8].join("/");
+        assert_eq!(exactly.len(), 1_023);
+        assert!(RuvUri::parse(&format!("{base}/{exactly}")).is_ok());
+    }
+
+    #[test]
+    fn complete_uri_limit_is_checked_before_other_parsing() {
+        let oversized = format!("ruv://{}", "a".repeat(MAX_URI_BYTES));
+        assert_eq!(RuvUri::parse(&oversized), Err(UriError::UriTooLong));
+    }
+
+    proptest! {
+        #[test]
+        fn canonical_generated_uris_round_trip(
+            tenant in "[a-z0-9](?:[a-z0-9-]{0,14}[a-z0-9])?",
+            subject_id in "[a-z0-9](?:[a-z0-9-]{0,14}[a-z0-9])?",
+            path in prop::collection::vec("[A-Za-z0-9_~-]{1,16}", 0..8),
+            digest in any::<[u8; 32]>(),
+            pinned in any::<bool>(),
+            view_index in 0_u8..4,
+        ) {
+            let mut builder = RuvUriBuilder::new(
+                Authority::new("context.example").unwrap(),
+                TenantId::new(&tenant).unwrap(),
+                Subject::new(SubjectKind::Agent, SubjectId::new(&subject_id).unwrap()),
+                Collection::Memory,
+            );
+            for segment in path {
+                builder = builder.path_segment(PathSegment::new(&segment).unwrap());
+            }
+            if pinned {
+                builder = builder.revision(Revision::from_bytes(digest));
+            }
+            if let Some(view) = match view_index {
+                0 => None,
+                1 => Some(ProgressiveView::Abstract),
+                2 => Some(ProgressiveView::Overview),
+                _ => Some(ProgressiveView::Content),
+            } {
+                builder = builder.view(view);
+            }
+            let uri = builder.build().unwrap();
+            let text = uri.to_string();
+            prop_assert_eq!(RuvUri::parse(&text), Ok(uri));
+        }
+
+        #[test]
+        fn percent_is_rejected_at_every_path_position(
+            prefix in "[A-Za-z0-9_~-]{0,16}",
+            suffix in "[A-Za-z0-9_~-]{0,16}",
+        ) {
+            let text = format!("ruv://a/t/agent/id/memory/{prefix}%2f{suffix}");
+            prop_assert_eq!(RuvUri::parse(&text), Err(UriError::PercentEncodingNotAllowed));
+        }
+    }
+}

--- a/crates/rvm-memory/src/allocator.rs
+++ b/crates/rvm-memory/src/allocator.rs
@@ -113,9 +113,7 @@ impl<const TOTAL_PAGES: usize, const BITMAP_WORDS: usize>
     /// split on demand during allocation.
     fn init_free_all(&mut self) {
         // Clear entire bitmap first.
-        for word in &mut self.bitmap {
-            *word = 0;
-        }
+        self.bitmap.fill(0);
 
         // Mark all blocks at the maximum possible order as free.
         let max_usable_order = Self::max_usable_order();

--- a/crates/rvm-memory/src/reconstruction.rs
+++ b/crates/rvm-memory/src/reconstruction.rs
@@ -129,9 +129,7 @@ impl<const MAX_DELTAS: usize> ReconstructionPipeline<MAX_DELTAS> {
 
     /// Clear all buffered deltas.
     pub fn clear(&mut self) {
-        for slot in &mut self.deltas {
-            *slot = None;
-        }
+        self.deltas.fill(None);
         self.delta_count = 0;
     }
 

--- a/crates/rvm-proof/Cargo.toml
+++ b/crates/rvm-proof/Cargo.toml
@@ -21,7 +21,7 @@ spin = { workspace = true }
 sha2 = { version = "0.10", default-features = false, optional = true }
 subtle = { workspace = true }
 hmac = { version = "0.12", default-features = false, optional = true }
-ed25519-dalek = { version = "2.1", default-features = false, optional = true }
+ed25519-dalek = { version = "=2.1.1", default-features = false, optional = true }
 
 [features]
 default = ["crypto-sha256", "strict-signing"]

--- a/crates/rvm-rvf/src/format.rs
+++ b/crates/rvm-rvf/src/format.rs
@@ -65,6 +65,10 @@ pub const SEG_TYPE_MANIFEST: u8 = 0x05;
 /// `SegmentType::Meta`: arbitrary key-value metadata, where capability
 /// declarations live.
 pub const SEG_TYPE_META: u8 = 0x07;
+/// `SegmentType::Witness`: capability manifests, proofs, and audit trails.
+pub const SEG_TYPE_WITNESS: u8 = 0x0A;
+/// `SegmentType::Profile`: domain profile declarations.
+pub const SEG_TYPE_PROFILE: u8 = 0x0B;
 /// `SegmentType::Kernel`: an embedded kernel image.
 pub const SEG_TYPE_KERNEL: u8 = 0x0E;
 /// `SegmentType::Ebpf`: an embedded eBPF program.
@@ -406,6 +410,15 @@ mod tests {
         }
         assert!(!is_executable(SEG_TYPE_META));
         assert!(!is_executable(0xEE));
+    }
+
+    #[test]
+    fn context_uses_the_canonical_rvf_profile_and_witness_discriminants() {
+        // These values are assigned by the RVF v1 registry in RuVector.  Keep
+        // the RVM reader aligned rather than inventing context-only segment
+        // types that another RVF implementation would not understand.
+        assert_eq!(SEG_TYPE_WITNESS, 0x0A);
+        assert_eq!(SEG_TYPE_PROFILE, 0x0B);
     }
 
     #[test]

--- a/crates/rvm-rvf/src/lib.rs
+++ b/crates/rvm-rvf/src/lib.rs
@@ -113,7 +113,7 @@ pub use error::{RvfError, RvfResult};
 pub use format::{
     is_executable, SegmentClass, SegmentHeader, SignatureFooter, EXECUTABLE_SEGMENT_TYPES,
     MAX_SEGMENT_PAYLOAD, SEGMENT_ALIGNMENT, SEGMENT_HEADER_SIZE, SEGMENT_MAGIC,
-    SEGMENT_MAGIC_BYTES, SEGMENT_VERSION,
+    SEGMENT_MAGIC_BYTES, SEGMENT_VERSION, SEG_TYPE_PROFILE, SEG_TYPE_WITNESS,
 };
 pub use hash::{content_hash, sha256, verify_content_hash};
 pub use policy::{tally, SizePolicy, SizeTally, SizeViolation};

--- a/crates/rvm-rvf/src/verify.rs
+++ b/crates/rvm-rvf/src/verify.rs
@@ -395,7 +395,11 @@ fn signature_record(data: &[u8], seg: &ParsedSegment, opts: &VerifyOptions) -> V
     if footer.sig_algo != SIG_ALGO_ED25519 || footer.sig_length != ED25519_SIGNATURE_LENGTH {
         return segment_record(
             CheckKind::Signature,
-            Outcome::Skip,
+            if seg.is_executable() {
+                Outcome::Fail
+            } else {
+                Outcome::Skip
+            },
             seg,
             DetailCode::UnsupportedSignatureAlgorithm,
         );
@@ -403,7 +407,11 @@ fn signature_record(data: &[u8], seg: &ParsedSegment, opts: &VerifyOptions) -> V
     if opts.trusted_keys.is_empty() {
         return segment_record(
             CheckKind::Signature,
-            Outcome::Skip,
+            if seg.is_executable() && !opts.allow_unsigned_executable {
+                Outcome::Fail
+            } else {
+                Outcome::Skip
+            },
             seg,
             DetailCode::NoTrustedKey,
         );

--- a/crates/rvm-rvf/src/verify_tests.rs
+++ b/crates/rvm-rvf/src/verify_tests.rs
@@ -142,7 +142,7 @@ fn a_tampered_signed_payload_fails_both_hash_and_signature() {
 }
 
 #[test]
-fn a_signature_is_skipped_not_passed_when_no_key_is_trusted() {
+fn a_signed_executable_is_refused_when_no_key_is_trusted() {
     let kp = TestKeypair::deterministic(7);
     let mut data = manifest_only();
     data.extend(signed_segment(SEG_TYPE_WASM, b"\0asm", 5, &kp));
@@ -152,8 +152,29 @@ fn a_signature_is_skipped_not_passed_when_no_key_is_trusted() {
         record_for(&report, CheckKind::Signature).detail,
         DetailCode::NoTrustedKey
     );
-    // A skip is not a failure, and the executable is signed, so this passes.
-    assert!(report.ok, "{:?}", report.failures());
+    assert_eq!(
+        record_for(&report, CheckKind::Signature).outcome,
+        Outcome::Fail
+    );
+    assert!(!report.ok);
+}
+
+#[test]
+fn an_unsupported_executable_signature_algorithm_is_refused() {
+    let kp = TestKeypair::deterministic(7);
+    let mut data = manifest_only();
+    data.extend(signed_segment(SEG_TYPE_WASM, b"\0asm", 5, &kp));
+
+    // The root manifest occupies the first 128 bytes. The executable payload
+    // starts at 192 and is four bytes long, so its footer algorithm begins at
+    // byte 196. Changing the footer does not change the payload content hash.
+    data[196..198].copy_from_slice(&99u16.to_le_bytes());
+    let report = verify(&data, &VerifyOptions::with_trusted_keys(vec![kp.public])).unwrap();
+
+    let signature = record_for(&report, CheckKind::Signature);
+    assert_eq!(signature.outcome, Outcome::Fail);
+    assert_eq!(signature.detail, DetailCode::UnsupportedSignatureAlgorithm);
+    assert!(!report.ok);
 }
 
 #[test]

--- a/crates/rvm-rvf/src/witness.rs
+++ b/crates/rvm-rvf/src/witness.rs
@@ -178,8 +178,9 @@ mod tests {
     fn a_skip_is_recorded_as_escalated_not_as_a_pass() {
         let kp = TestKeypair::deterministic(7);
         let mut data = manifest_only();
-        data.extend(signed_segment(SEG_TYPE_WASM, b"\0asm", 2, &kp));
-        // No trusted key, so the signature check skips.
+        data.extend(signed_segment(SEG_TYPE_META, b"metadata", 2, &kp));
+        // A non-executable signature with no trusted key remains an explicit
+        // skip; executable signatures fail closed under the same posture.
         let report = verify(&data, &VerifyOptions::default()).unwrap();
 
         let skipped = report

--- a/crates/rvm-types/src/capability.rs
+++ b/crates/rvm-types/src/capability.rs
@@ -56,6 +56,8 @@ pub enum CapType {
     Vcpu = 7,
     /// Authority over a coherence observer.
     Coherence = 8,
+    /// Authority over a governed `ruv://` context scope.
+    Context = 9,
 }
 
 /// Unique identifier for a capability in the system-wide capability space.

--- a/crates/rvm-types/src/witness.rs
+++ b/crates/rvm-types/src/witness.rs
@@ -315,6 +315,24 @@ pub enum ActionKind {
     /// assurance level it was produced under and does not acquire the
     /// witness chain's guarantees (ADR-285 discipline).
     AnchorExternalReceipt = 0xB0,
+
+    // --- Governed context namespace (0xC0-0xCF) ---
+    /// A versionless `ruv://` name was resolved to an immutable RVF revision.
+    ContextResolve = 0xC0,
+    /// A progressive context representation was read.
+    ContextRead = 0xC1,
+    /// An authorized context search enumerated candidate results.
+    ContextSearch = 0xC2,
+    /// A new immutable context revision was registered.
+    ContextPut = 0xC3,
+    /// A versionless alias was changed with compare-and-swap.
+    ContextAliasUpdate = 0xC4,
+    /// A context alias was tombstoned and its payload became unreachable.
+    ContextForget = 0xC5,
+    /// Execution of pinned context content was authorized.
+    ContextExecute = 0xC6,
+    /// A cryptographic receipt sealed a context witness epoch.
+    ContextEpochSeal = 0xC7,
 }
 
 impl ActionKind {
@@ -324,7 +342,7 @@ impl ActionKind {
     /// 0 = partition, 1 = capability, 2 = memory, 3 = communication,
     /// 4 = device, 5 = proof, 6 = scheduler, 7 = recovery,
     /// 8 = boot, 9 = graph, 0xA = VMID management,
-    /// 0xB = external anchoring.
+    /// 0xB = external anchoring, 0xC = governed context.
     #[must_use]
     pub const fn subsystem(self) -> u8 {
         (self as u8) >> 4

--- a/crates/rvm-witness/src/lib.rs
+++ b/crates/rvm-witness/src/lib.rs
@@ -49,12 +49,13 @@ mod signer;
 
 pub use emit::WitnessEmitter;
 pub use hash::{compute_chain_hash, compute_record_hash, fnv1a_64};
-pub use log::WitnessLog;
+pub use log::{SnapshotSinceError, WitnessCheckpoint, WitnessLog, WitnessSnapshot};
 pub use record::{ActionKind, WitnessRecord};
 pub use replay::{
-    query_by_action_kind, query_by_partition, query_by_time_range, verify_chain,
+    query_by_action_kind, query_by_partition, query_by_time_range, verify_chain, verify_chain_from,
     ChainIntegrityError,
 };
+pub use signer::record_to_bytes;
 #[cfg(any(test, feature = "null-signer"))]
 #[allow(deprecated)]
 pub use signer::NullSigner;

--- a/crates/rvm-witness/src/log.rs
+++ b/crates/rvm-witness/src/log.rs
@@ -31,6 +31,86 @@ struct WitnessLogInner<const N: usize> {
     total_emitted: u64,
 }
 
+/// An atomic boundary in a witness log.
+///
+/// The sequence is the next record that will be written. The full internal
+/// chain hash is retained so a later epoch can be verified without pretending
+/// it began at genesis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WitnessCheckpoint {
+    next_sequence: u64,
+    chain_hash: u64,
+}
+
+/// Complete result of an atomic checkpoint-relative snapshot.
+///
+/// `end_checkpoint` was captured under the same lock as the copied range, so
+/// it is the only safe boundary for the next epoch. Records appended after
+/// the lock is released belong to that next epoch rather than falling between
+/// two independently captured checkpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WitnessSnapshot {
+    count: usize,
+    end_checkpoint: WitnessCheckpoint,
+}
+
+impl WitnessSnapshot {
+    /// Number of records copied into the caller's output slice.
+    #[must_use]
+    pub const fn count(self) -> usize {
+        self.count
+    }
+
+    /// Atomic boundary at which the following epoch must begin.
+    #[must_use]
+    pub const fn end_checkpoint(self) -> WitnessCheckpoint {
+        self.end_checkpoint
+    }
+}
+
+impl WitnessCheckpoint {
+    /// Sequence number of the first record after this checkpoint.
+    #[must_use]
+    pub const fn next_sequence(self) -> u64 {
+        self.next_sequence
+    }
+
+    /// Full internal chain hash immediately before the next record.
+    #[must_use]
+    pub const fn chain_hash(self) -> u64 {
+        self.chain_hash
+    }
+}
+
+/// Why a checkpoint-relative snapshot could not be produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotSinceError {
+    /// The checkpoint refers to a sequence later than the current log head.
+    FutureCheckpoint,
+    /// At least one requested record has already been overwritten by the ring.
+    RecordsOverwritten,
+    /// The caller's output slice cannot hold the complete epoch.
+    OutputTooSmall {
+        /// Number of records required to return the epoch atomically.
+        required: usize,
+    },
+    /// A retained ring slot did not carry the expected sequence.
+    SequenceMismatch,
+}
+
+impl core::fmt::Display for SnapshotSinceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::FutureCheckpoint => f.write_str("witness checkpoint is ahead of the log"),
+            Self::RecordsOverwritten => f.write_str("witness records were overwritten"),
+            Self::OutputTooSmall { required } => {
+                write!(f, "witness output needs {required} records")
+            }
+            Self::SequenceMismatch => f.write_str("witness ring sequence mismatch"),
+        }
+    }
+}
+
 impl<const N: usize> WitnessLog<N> {
     /// Compile-time assertion: N must be greater than zero.
     ///
@@ -137,6 +217,75 @@ impl<const N: usize> WitnessLog<N> {
     /// Returns the total number of records ever emitted.
     pub fn total_emitted(&self) -> u64 {
         self.inner.lock().total_emitted
+    }
+
+    /// Capture the current sequence and full chain hash under one lock.
+    #[must_use]
+    pub fn checkpoint(&self) -> WitnessCheckpoint {
+        let inner = self.inner.lock();
+        WitnessCheckpoint {
+            next_sequence: inner.sequence,
+            chain_hash: inner.chain_hash,
+        }
+    }
+
+    /// Copy every record emitted after `checkpoint` in sequence order.
+    ///
+    /// This operation is all or nothing. It refuses partial output and refuses
+    /// epochs whose earliest records have wrapped out of the ring, because
+    /// either condition would make a cryptographic epoch receipt incomplete.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotSinceError::FutureCheckpoint`] for an impossible
+    /// boundary, [`SnapshotSinceError::RecordsOverwritten`] after ring wrap,
+    /// [`SnapshotSinceError::OutputTooSmall`] when `out` is undersized, or
+    /// [`SnapshotSinceError::SequenceMismatch`] if retained state is corrupt.
+    pub fn snapshot_since(
+        &self,
+        checkpoint: WitnessCheckpoint,
+        out: &mut [WitnessRecord],
+    ) -> Result<WitnessSnapshot, SnapshotSinceError> {
+        let inner = self.inner.lock();
+        if checkpoint.next_sequence > inner.sequence {
+            return Err(SnapshotSinceError::FutureCheckpoint);
+        }
+
+        let capacity = u64::try_from(N).map_err(|_| SnapshotSinceError::RecordsOverwritten)?;
+        let retained_start = inner.sequence.saturating_sub(capacity);
+        if checkpoint.next_sequence < retained_start {
+            return Err(SnapshotSinceError::RecordsOverwritten);
+        }
+
+        let required_u64 = inner.sequence - checkpoint.next_sequence;
+        let required =
+            usize::try_from(required_u64).map_err(|_| SnapshotSinceError::RecordsOverwritten)?;
+        if out.len() < required {
+            return Err(SnapshotSinceError::OutputTooSmall { required });
+        }
+
+        for (offset, slot) in out.iter_mut().enumerate().take(required) {
+            let offset =
+                u64::try_from(offset).map_err(|_| SnapshotSinceError::RecordsOverwritten)?;
+            let sequence = checkpoint
+                .next_sequence
+                .checked_add(offset)
+                .ok_or(SnapshotSinceError::SequenceMismatch)?;
+            let ring_index = usize::try_from(sequence % capacity)
+                .map_err(|_| SnapshotSinceError::SequenceMismatch)?;
+            let record = inner.records[ring_index];
+            if record.sequence != sequence {
+                return Err(SnapshotSinceError::SequenceMismatch);
+            }
+            *slot = record;
+        }
+        Ok(WitnessSnapshot {
+            count: required,
+            end_checkpoint: WitnessCheckpoint {
+                next_sequence: inner.sequence,
+                chain_hash: inner.chain_hash,
+            },
+        })
     }
 
     /// Returns the number of records currently in the buffer.
@@ -346,5 +495,49 @@ mod tests {
         stored.actor_partition_id = 999;
         // Verify should fail.
         assert!(!signer.verify(&stored));
+    }
+
+    #[test]
+    fn checkpoint_snapshot_is_contiguous_and_complete() {
+        let log = WitnessLog::<8>::new();
+        log.append(make_record(ActionKind::ContextRead, 1, 1, 1));
+        let checkpoint = log.checkpoint();
+        log.append(make_record(ActionKind::ContextResolve, 1, 2, 2));
+        log.append(make_record(ActionKind::ContextRead, 1, 3, 3));
+
+        let mut out = [WitnessRecord::zeroed(); 4];
+        let snapshot = log.snapshot_since(checkpoint, &mut out).unwrap();
+        assert_eq!(snapshot.count(), 2);
+        assert_eq!(snapshot.end_checkpoint(), log.checkpoint());
+        assert_eq!(out[0].sequence, checkpoint.next_sequence());
+        assert_eq!(out[1].sequence, checkpoint.next_sequence() + 1);
+    }
+
+    #[test]
+    fn checkpoint_snapshot_refuses_partial_output() {
+        let log = WitnessLog::<8>::new();
+        let checkpoint = log.checkpoint();
+        log.append(make_record(ActionKind::ContextRead, 1, 1, 1));
+        log.append(make_record(ActionKind::ContextRead, 1, 2, 2));
+
+        let mut out = [WitnessRecord::zeroed(); 1];
+        assert_eq!(
+            log.snapshot_since(checkpoint, &mut out),
+            Err(SnapshotSinceError::OutputTooSmall { required: 2 })
+        );
+    }
+
+    #[test]
+    fn checkpoint_snapshot_detects_ring_wrap() {
+        let log = WitnessLog::<2>::new();
+        let checkpoint = log.checkpoint();
+        for target in 0..3 {
+            log.append(make_record(ActionKind::ContextRead, 1, target, target));
+        }
+        let mut out = [WitnessRecord::zeroed(); 3];
+        assert_eq!(
+            log.snapshot_since(checkpoint, &mut out),
+            Err(SnapshotSinceError::RecordsOverwritten)
+        );
     }
 }

--- a/crates/rvm-witness/src/replay.rs
+++ b/crates/rvm-witness/src/replay.rs
@@ -43,13 +43,40 @@ impl core::fmt::Display for ChainIntegrityError {
 /// Returns [`ChainIntegrityError::RecordCorrupted`] if a record hash does not match.
 #[allow(clippy::cast_possible_truncation)]
 pub fn verify_chain(records: &[WitnessRecord]) -> Result<usize, ChainIntegrityError> {
+    verify_chain_from(records, 0, 0)
+}
+
+/// Verify a contiguous witness epoch beginning at a non-genesis checkpoint.
+///
+/// `initial_chain_hash` is the full internal hash captured immediately before
+/// `expected_first_sequence`. In addition to hash linkage, this variant checks
+/// that every sequence is contiguous, which prevents omission and reordering
+/// inside a sealed epoch.
+///
+/// # Errors
+///
+/// Returns [`ChainIntegrityError::EmptyLog`] for an empty slice,
+/// [`ChainIntegrityError::ChainBreak`] for a sequence or previous-hash
+/// mismatch, or [`ChainIntegrityError::RecordCorrupted`] for a bad self hash.
+#[allow(clippy::cast_possible_truncation)]
+pub fn verify_chain_from(
+    records: &[WitnessRecord],
+    initial_chain_hash: u64,
+    expected_first_sequence: u64,
+) -> Result<usize, ChainIntegrityError> {
     if records.is_empty() {
         return Err(ChainIntegrityError::EmptyLog);
     }
 
-    let mut prev_chain_hash: u64 = 0;
+    let mut prev_chain_hash = initial_chain_hash;
+    let mut expected_sequence = expected_first_sequence;
 
     for record in records {
+        if record.sequence != expected_sequence {
+            return Err(ChainIntegrityError::ChainBreak {
+                sequence: record.sequence,
+            });
+        }
         let expected_prev = fold_u64_to_u32(prev_chain_hash);
         if record.prev_hash != expected_prev {
             return Err(ChainIntegrityError::ChainBreak {
@@ -65,6 +92,7 @@ pub fn verify_chain(records: &[WitnessRecord]) -> Result<usize, ChainIntegrityEr
         }
 
         prev_chain_hash = chain;
+        expected_sequence = expected_sequence.wrapping_add(1);
     }
 
     Ok(records.len())
@@ -153,6 +181,37 @@ mod tests {
     #[test]
     fn test_verify_empty() {
         assert_eq!(verify_chain(&[]), Err(ChainIntegrityError::EmptyLog));
+    }
+
+    #[test]
+    fn verifies_a_checkpoint_relative_epoch() {
+        let log = WitnessLog::<16>::new();
+        log.append(WitnessRecord::zeroed());
+        let checkpoint = log.checkpoint();
+        for _ in 0..3 {
+            log.append(WitnessRecord::zeroed());
+        }
+        let mut records = [WitnessRecord::zeroed(); 3];
+        let snapshot = log.snapshot_since(checkpoint, &mut records).unwrap();
+        assert_eq!(snapshot.count(), 3);
+        assert_eq!(
+            verify_chain_from(
+                &records,
+                checkpoint.chain_hash(),
+                checkpoint.next_sequence()
+            ),
+            Ok(3)
+        );
+    }
+
+    #[test]
+    fn checkpoint_verification_rejects_an_omitted_sequence() {
+        let records = build_chain(4);
+        let omitted = [records[0], records[2], records[3]];
+        assert!(matches!(
+            verify_chain_from(&omitted, 0, 0),
+            Err(ChainIntegrityError::ChainBreak { .. })
+        ));
     }
 
     #[test]

--- a/crates/rvm-witness/src/signer.rs
+++ b/crates/rvm-witness/src/signer.rs
@@ -88,7 +88,8 @@ impl WitnessSigner for StrictSigner {
 ///
 /// We manually serialise the fields in layout order to avoid depending
 /// on `repr(C)` padding semantics across platforms.
-fn record_to_bytes(r: &WitnessRecord) -> [u8; 64] {
+#[must_use]
+pub fn record_to_bytes(r: &WitnessRecord) -> [u8; 64] {
     let mut buf = [0u8; 64];
     buf[0..8].copy_from_slice(&r.sequence.to_le_bytes());
     buf[8..16].copy_from_slice(&r.timestamp_ns.to_le_bytes());

--- a/docs/adr/ADR-157-ruv-context-namespace.md
+++ b/docs/adr/ADR-157-ruv-context-namespace.md
@@ -1,0 +1,738 @@
+# ADR-157: Capability-Governed `ruv://` Context Namespace
+
+**Status**: Proposed
+**Date**: 2026-08-22
+**Authors**: RVM Contributors
+**Supersedes**: None
+**Related**: ADR-134 (Witness Schema), ADR-149 (RVF Integration), ADR-155
+(RVF Execution Contract), ADR-156 (External Receipt Anchoring)
+
+---
+
+## Context
+
+Agents need one stable way to name resources, memories, and skills without
+turning a path into ambient authority. A useful context name must work across
+processes and hosts, cite immutable bytes when reproducibility matters, support
+human-friendly mutable aliases, expose progressively larger representations,
+and remain safe when the named content is hostile.
+
+OpenViking demonstrates several useful product patterns: one inspectable
+context hierarchy for resources, memories, and skills; progressively disclosed
+representations; directory-aware retrieval; and observable retrieval paths.
+Those patterns motivate this work. This repository does not import, translate,
+or derive code from OpenViking. The implementation is a clean RVM-native design
+under this repository's MIT OR Apache-2.0 license. This separation is
+intentional because the main OpenViking repository is AGPL-3.0 licensed.
+
+The RVM and RVF boundaries impose stronger requirements than a virtual
+filesystem alone:
+
+1. A name cannot grant access. RVM capabilities are the authority.
+2. Authorization must happen before a RuVector or other retrieval backend can
+   enumerate candidates. Filtering an already searched shared index is not an
+   authorization boundary.
+3. A reproducible citation must bind all bytes in the RVF, not a mutable path
+   or a truncated segment hash.
+4. Inspecting or reading a skill must never execute it. Execution is a distinct
+   operation with distinct authority.
+5. Mutable names need an atomic compare-and-swap rule. In-place updates would
+   permit lost updates, rollback, and alias races.
+6. Every allow and denial must enter the RVM witness trail before a resolver or
+   retrieval backend is called.
+7. The 64-byte RVM witness ring is bounded. A durable context audit story must
+   seal ranges into signed receipts before the ring wraps.
+
+The current RVF segment registry has suitable `PROFILE` (`0x0B`) and `WITNESS`
+(`0x0A`) segment types, but no ratified generic context, tree, or representation
+wire discriminants. RVM must not invent private segment numbers that canonical
+RVF readers do not understand. The RVF root also contains a one-byte
+`profile_id` used by existing hardware and domain profiles, so assigning a new
+root profile number in this repository would create a cross-repository
+collision risk.
+
+## Decision
+
+RVM adds a `no_std`, safe-Rust crate named `rvm-context`. It defines a strict
+`ruv://` name, a versioned context profile carried inside the existing RVF
+`PROFILE` segment, capability-scoped operations, a bounded in-memory reference
+resolver, immutable RVF revisions, compare-and-swap aliases, progressive
+representations, explicit execution permits, and signed epoch receipts.
+
+`ruv://` is a logical identifier, not a transport protocol and not a public URI
+scheme registration. Network discovery, federation, persistent resolver
+storage, and IANA registration are outside this decision.
+
+## Specification
+
+The version 1 contract has five load-bearing invariants:
+
+1. One byte string has at most one namespace interpretation; the parser never
+   repairs or normalizes noncanonical input.
+2. A URI is a name only. Live RVM capability state and a trusted context grant
+   are the authority.
+3. Immutable identity is SHA-256 over the complete RVF bytes. A mutable alias
+   is an explicit, generation-bearing pointer to that identity.
+4. Authorization and its witness record precede every resolver call, including
+   search candidate enumeration.
+5. Reading and executing are independent operations. Execution requires an
+   immutable target and explicit `EXECUTE` authority.
+
+### 1. Canonical URI Grammar
+
+The version 1 grammar is:
+
+```text
+ruv-uri = "ruv://" authority "/" tenant "/" subject-kind "/"
+          subject-id "/" collection [ "/" path ] [ "?" query ]
+
+subject-kind = "agent" | "user" | "service" | "team"
+collection   = "memory" | "resources" | "skills"
+path         = path-segment *( "/" path-segment )
+query        = revision
+             | view
+             | revision "&" view
+revision     = "rev=sha256:" 64-lowercase-hex
+view         = "view=abstract" | "view=overview" | "view=content"
+```
+
+Example alias:
+
+```text
+ruv://context.cognitum.one/acme/agent/researcher/skills/web-search?view=overview
+```
+
+Example immutable citation:
+
+```text
+ruv://context.cognitum.one/acme/agent/researcher/skills/web-search?rev=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&view=overview
+```
+
+Canonicalization is deliberately strict rather than corrective:
+
+| Component | Rule |
+|---|---|
+| Scheme | Exactly lowercase `ruv://` |
+| Authority | Lowercase ASCII DNS form, 1 through 253 bytes; labels are 1 through 63 bytes, start and end with `[a-z0-9]`, and may contain interior `-` |
+| Tenant and subject ID | Lowercase ASCII slug, 1 through 63 bytes, start and end with `[a-z0-9]`, interior characters `[a-z0-9-]` |
+| Subject kind | Exactly `agent`, `user`, `service`, or `team` |
+| Collection | Exactly `memory`, `resources`, or `skills` |
+| Path | 1 through 32 optional segments; each segment is 1 through 128 bytes from ASCII unreserved `[A-Za-z0-9._~-]`; case is preserved; joined path is at most 1,024 bytes including separators |
+| Revision | Exactly `sha256:` followed by 64 lowercase hexadecimal characters; it is the SHA-256 identity of the complete RVF byte stream |
+| View | `abstract`, `overview`, or `content` |
+| Query ordering | `rev` precedes `view`; no other ordering is canonical |
+| Total length | At most 2,048 bytes |
+
+The parser rejects non-ASCII input, percent encoding, fragments, credentials,
+ports, empty or trailing path segments, literal `.` and `..` segments, unknown
+or duplicate query parameters, empty keys or values, uppercase structural
+tokens, uppercase revision hex, and `view` before `rev`. Rejection of every
+percent sign prevents encoded separators, double decoding, encoded NUL, and
+normalization disagreement from entering the namespace.
+
+The same valid string always parses to the same typed `RuvUri`, and serializing
+that value reproduces the same canonical string. Callers do not receive a
+"mostly equivalent" normalized name.
+
+### 2. Names and Authority Are Separate
+
+A `RuvUri` contains no token, credential, secret, or grant. Authority is
+carried out of band by an `AuthorizedRequest`, which references a
+kernel-resident context capability and a context grant.
+
+A grant binds all of the following:
+
+1. Exact authority.
+2. Exact tenant.
+3. Exact subject kind and subject ID.
+4. Exact collection.
+5. A path-segment prefix, not a raw string prefix.
+6. The allowed progressive views.
+7. The RVM rights and revocation state represented by the capability.
+
+This creates a new `CapType::Context`. A grant is narrower than its parent and
+cannot infer authority from a URI. Context grant tables are const-bounded, as
+are resolver object and alias tables, so worst-case memory use remains explicit
+in `no_std` deployments.
+
+The operation-to-rights mapping is total and default-deny:
+
+| Context operation | Required RVM rights |
+|---|---|
+| Resolve, List, Tree, Read, Search, History | `READ` |
+| Verify | `READ | PROVE` |
+| Put, CompareAndSwapAlias, Forget | `WRITE` |
+| Execute | `EXECUTE` |
+| Grant | `GRANT` |
+| Revoke | `REVOKE` |
+| SealReceipt | `PROVE` |
+
+`Execute` intentionally does not imply `READ`, and `READ` does not imply
+`EXECUTE`. A runtime can authorize execution of a pinned artifact without
+disclosing its content bytes, while an inspector can read a skill without
+obtaining permission to run it.
+
+Every allow or denial is appended to the RVM witness trail before the runtime
+calls `ContextResolver`. In particular, `Search` authorizes the complete scope
+before candidate enumeration. An unauthorized caller therefore cannot use
+result counts, candidate identifiers, or backend-specific errors as an
+existence oracle.
+
+### 3. Immutable Revisions and Mutable Aliases
+
+The `rev` value is the SHA-256 digest of the complete RVF byte stream. A URI
+with `rev` is a `PinnedRuvUri`. Pinned references are required for `Put`,
+`Execute`, receipts, durable citations, and mutation parents. Registered bytes
+under a pinned revision are never overwritten.
+
+A URI without `rev` is a mutable alias. Resolution returns both the current
+revision and an `AliasGeneration`. Alias mutation uses compare-and-swap against
+the complete prior `AliasSnapshot`, including its revision and generation:
+
+```text
+compare_and_swap(alias, expected_snapshot, new_revision):
+    require WRITE on alias scope
+    require alias has no rev
+    witness authorization decision
+    current = resolver.read_alias(alias)
+    if current != expected_snapshot:
+        return Conflict
+    next_generation = checked_add(current.generation, 1)
+    resolver.replace_alias(alias, new_revision, next_generation)
+```
+
+The first alias generation is 1. Checked generation increment rejects wrap.
+Comparing generation and revision prevents an ABA sequence from making a stale
+snapshot look current. Two writers racing from the same snapshot can produce
+at most one winner.
+
+`Forget` does not rewrite a pinned object. It appends a domain-separated
+tombstone object as a new immutable revision and compare-and-swap advances the
+versionless alias to that revision. Subsequent alias resolution reports the
+tombstone. Cryptographic erasure of payload keys, removal from replicas, and
+purging derived indexes are storage-adapter responsibilities and remain release
+gates for a production multi-tenant service.
+
+### 4. RVF Context Profile Without a Format Fork
+
+The context contract reuses canonical RVF v1 segment discriminants:
+
+| Existing RVF segment | Context use |
+|---|---|
+| `PROFILE` (`0x0B`) | Carries the versioned `ContextProfile` descriptor |
+| `VEC` and `INDEX` | Rebuildable semantic retrieval material |
+| Existing data segments | Hold bytes selected by profile view references; `rvm-context` treats them as inert data |
+| `META` | Optional non-authoritative labels and provenance hints |
+| `WITNESS` (`0x0A`) | Canonical 73-byte entries committing signed receipt sidecars |
+| `MANIFEST` | Canonical RVF segment inventory and root state |
+| `CRYPTO` | RVF trust material where supplied by the producer |
+
+No `CONTENT`, `TREE`, `REPRESENTATION`, or private context segment number is
+added by this ADR. No new value is written into the root `profile_id` byte.
+That keeps ordinary RVF readers forward-compatible and avoids creating an RVM
+fork of the canonical registry.
+
+`ContextProfile` has its own payload magic and version inside `PROFILE`. It
+describes progressive views by segment ordinal and payload digest. The profile
+does not duplicate a whole-file identity field: `VerifiedContextProfile` binds
+the decoded profile to the caller-supplied expected revision and to the full
+RVF identity in a passing `rvm-rvf` report. `DerivedView` provenance binds a
+derived representation to its source digest, generator identity, model
+identity, prompt digest, and policy digest. A generated abstract or overview
+therefore cannot silently replace source content or be reused under a
+different generation policy.
+
+Profile verification follows this order:
+
+```text
+verify_profile(rvf_bytes, claimed_revision):
+    reject len(rvf_bytes) > MAX_RVF_BYTES
+    report = rvm_rvf.verify(rvf_bytes, expected_identity = claimed_revision)
+    require report has no failed check
+    locate exactly one supported ContextProfile in a PROFILE segment
+    parse only inert profile bytes
+    bind profile to claimed_revision == report.rvf_identity == sha256(rvf_bytes)
+    apply TrustedSignature or PinnedIdentity trust posture explicitly
+    verify each declared view reference and digest
+    return VerifiedContextProfile(profile, report.rvf_identity)
+```
+
+Exactly one unencrypted, uncompressed `PROFILE` segment is accepted. The
+profile must contain one `content` view and may contain one `abstract` and one
+`overview` view. Referenced view segments are unique and uncompressed;
+non-content derived views cannot reference executable segments. Under
+`TrustedSignature`, the profile segment must have a passing trusted Ed25519
+signature check in the verification report. Under `PinnedIdentity`, an
+unsigned profile is acceptable only because the complete RVF identity was
+authenticated out of band and supplied as the expected revision. The trust
+posture is always explicit.
+
+The current reference ceiling is `MAX_RVF_BYTES = 16 MiB`. This is a context
+ingress bound, not a new RVF wire-format maximum. Larger artifacts require a
+different deployment policy or a future streaming profile.
+
+The pinned complete-file identity is the reliable cross-repository integrity
+binding. A signature proves publisher identity, not content safety, and the
+presence of a signed executable never bypasses an RVM execution check.
+
+### 5. Progressive Views
+
+Version 1 exposes three semantic views:
+
+| View | Intended use |
+|---|---|
+| `abstract` | Small routing summary used to decide whether the object is relevant |
+| `overview` | Structured navigation context, relationships, and a fuller summary |
+| `content` | The selected source or full representation referenced by the profile |
+
+These are semantic representations, not mutable sibling files and not three
+hard-coded storage tiers. Each view is independently capability-scoped. A grant
+may allow `abstract` while denying `content`.
+
+When no `view` is present, version 1 uses the operation's least documented
+representation: Resolve, List, Tree, History, and Verify require manifest
+metadata; Read requires content; Search requires overview. Mutation,
+execution, delegation, revocation, and receipt sealing accept no view selector.
+
+The resolver does not rank or generate representations. Context compilers
+produce them, RVF binds them, RuVector or another authorized backend retrieves
+them, and RVM decides whether the requested view may be observed or executed.
+
+## Architecture
+
+The implementation divides responsibility so no storage or retrieval adapter
+can accidentally become the policy authority:
+
+| Component | Owns | Does not own |
+|---|---|---|
+| `RuvUri` and typed components | Strict parsing, canonical formatting, pinned-versus-alias shape | Credentials, network transport, discovery |
+| `ContextGrantTable` | Trusted binding from live Context capabilities to exact scopes and views | Artifact storage or ranking |
+| `ContextRuntime` | Immutable authenticated actor, trusted clock, receipt-chain cursor, operation-to-rights mapping, request-shape rules, authorize/witness/call ordering | RVF parsing or backend enumeration |
+| `ContextResolver` | Immutable objects, alias snapshots and CAS, history, scoped retrieval | Capability decisions or execution |
+| `VerifiedContextProfile` | Full-RVF identity and progressive-view integrity binding | Publisher trust beyond the selected posture, semantic safety |
+| Epoch receipt bridge | Contiguous RVM range commitments, signatures, RVF witness entry | A second runtime audit truth or automatic durable storage |
+
+### 6. Resolver and Runtime Boundaries
+
+`ContextResolver` owns immutable registration, alias lookup, scoped listing,
+history, and candidate retrieval. The reference implementation is
+`MemoryResolver<MAX_OBJECTS, MAX_ALIASES>`. It is deterministic and bounded,
+but is not presented as durable or distributed storage.
+
+`ContextRuntime` owns ordering:
+
+```text
+handle(request):
+    actor = runtime.authenticated_actor
+    observed_time = runtime.trusted_clock.next()
+    uri = parse_canonical(request.uri)
+    operation = request.operation
+    capability = grant_table.lookup(request.capability_handle)
+    decision = authorize(capability, uri, operation, requested_view)
+    witness(decision, uri_commitment, operation)
+    if decision is Deny:
+        return AccessDenied
+
+    if operation is Search:
+        require request.limit <= MAX_SEARCH_RESULTS
+
+    return resolver.perform(operation, uri)
+```
+
+Runtime construction is the trusted kernel-dispatch boundary. The actor is
+authenticated out of band and bound immutably for the runtime's lifetime; its
+clock is likewise runtime-owned. An untrusted `ContextRequest` contains only a
+capability handle, operation, and canonical target. It cannot select an actor
+or witness timestamp, and neither has a request-facing setter. Authorization,
+witness actor fields, delegation callers, and execution permits all use the
+runtime-bound actor.
+
+`MAX_SEARCH_RESULTS` is 64. The limit applies before allocation and before the
+resolver call. Resolver errors do not widen authority. API layers should map
+forbidden and hidden-object outcomes to the same externally observable class
+unless the caller has audit authority.
+
+`Put` requires a pinned URI and a verified profile whose full RVF identity
+equals the revision. Compare-and-swap and Forget require a versionless alias.
+`Execute` requires a pinned URI and returns an `ExecutionPermit`; it does not
+execute bytes inside the resolver. The existing RVF verify-before-load and RVM
+launch boundaries remain responsible for actual execution.
+
+### 7. Witnessing and Epoch Receipts
+
+The governed namespace uses the `0xC0` through `0xCF` witness subsystem:
+
+| Action kind | Meaning |
+|---|---|
+| `ContextResolve` (`0xC0`) | Resolve, list, tree, history, or verify authorization |
+| `ContextRead` (`0xC1`) | Progressive view read authorization |
+| `ContextSearch` (`0xC2`) | Search authorization before enumeration |
+| `ContextPut` (`0xC3`) | Immutable registration authorization |
+| `ContextAliasUpdate` (`0xC4`) | Compare-and-swap authorization |
+| `ContextForget` (`0xC5`) | Tombstone-and-advance authorization |
+| `ContextExecute` (`0xC6`) | Execution-permit authorization |
+| `ContextEpochSeal` (`0xC7`) | Signed receipt commitment for a witness range |
+
+Witness records contain commitments, stable discriminants, and bounded
+coordinates, not context plaintext, query text, credentials, or personal data.
+Allowed requests use the operation action above. Denials use the existing
+`ProofRejected` action with the requested operation in the flags field. Both
+are evidence and are recorded before returning or calling the resolver.
+
+The ring retention horizon is `N / event_rate` seconds for
+`WitnessLog<N>`. The `rvm-witness` library constant
+`DEFAULT_RING_CAPACITY = 262,144` is 16 MiB at 64 bytes per record and wraps in
+approximately 262 seconds at 1,000 events per second. The current integrated
+`rvm-kernel` log uses `WitnessLog<256>`, which wraps in approximately 0.256
+seconds at the same rate. A deployment must size and drain the actual `N`; the
+library default is not a service guarantee.
+
+`ContextEpochReceipt` binds a runtime-derived epoch ID; first and last sequence;
+record count; minimum and maximum observed timestamps; the full RVM chain hash
+immediately before the range; previous signed-receipt ID; namespace root; full
+RVF identity; policy hash; optional encrypted-detail root; and a SHA-256 Merkle
+root of the canonical 64-byte RVM records. A `WitnessSigner` signs a
+domain-separated digest that also binds its 32-byte signer ID. The canonical
+signed encoding is 352 bytes and carries a 64-byte signature. Sealing also
+returns the next checkpoint captured under the same witness-log lock as the
+snapshot, preventing a concurrent append from falling between epochs.
+
+The public runtime owns a `ReceiptChainState` containing the exact next
+checkpoint, next epoch ID, and previous signed-receipt ID. Genesis is fixed to
+epoch 0, sequence 0, zero initial chain hash, and a zero previous-receipt link.
+`seal_epoch` derives all three coordinates from that state; request payloads
+cannot provide them. The state advances only after the receipt is signed and
+its signature verifies, and must be persisted atomically with the durable
+receipt. Recovery uses the explicit `trusted_resume` administrative boundary
+after authenticating persisted state.
+
+The full signed receipt is retained as durable sidecar evidence. Its canonical
+73-byte RVF witness entry contains the preceding entry hash, a SHAKE-256
+commitment to the signed receipt, the maximum observed timestamp, and the
+existing RVF computation-witness type. This entry is stored in the existing
+RVF `WITNESS` segment; no new segment discriminant is needed.
+`ContextEpochSeal` is emitted only through an authenticated receipt typestate
+into the next RVM epoch, so the receipt never claims to cover its own seal. Its
+recorded tier is the actual P1 authorization; signature verification alone is
+not mislabeled as P2 policy assurance. Sealing refuses an empty,
+discontinuous, corrupt, partially
+overwritten, already wrapped, or larger-than-262,144-record range. Merkle
+construction reduces one leaf vector in place, bounding its largest permitted
+leaf allocation at 8 MiB.
+
+Sequence and chain coordinates are the ordering authority. Timestamps are
+non-authoritative observed metadata, so a backwards or extreme observation
+does not make a valid range unsealable; the receipt commits the recomputed
+minimum and maximum as defense in depth. Offline verified typestate checks
+genesis or an exact successor: signed-receipt link, checked epoch increment,
+exact sequence adjacency, and the full chain hash obtained by applying
+`rvm_witness::compute_chain_hash` across every sequence of the prior receipt.
+
+The bridge preserves assurance honesty:
+
+1. RVM records remain the runtime decision log.
+2. The RVF receipt is durable sidecar evidence over a specific RVM range.
+3. Anchoring does not upgrade service-side evidence to hardware-backed
+   evidence.
+4. Verification recomputes the sequence, RVM chain, Merkle root, signer
+   identity, and signature offline.
+5. A seal must complete before the covered records are overwritten.
+
+High-volume search traces should commit one bounded trajectory or epoch rather
+than emit one kernel record per vector candidate. Authorization decisions
+remain individually witnessed; the receipt's namespace and detail roots bind
+post-operation state and any separately retained encrypted trajectory detail.
+
+### 8. Threat Model
+
+| Threat | Control in this decision | Residual risk |
+|---|---|---|
+| Traversal, encoded separators, Unicode ambiguity, parser differentials | ASCII-only strict parser; all percent encoding, dot segments, fragments, credentials, and non-canonical query order rejected | Future Unicode or URL-library adapters require separate conformance work |
+| Cross-tenant search leakage | Capability scope checked and witnessed before resolver call or candidate enumeration | A backend that bypasses `ContextRuntime` is non-conforming |
+| Actor or timestamp spoofing in requests | Actor and clock are immutable/runtime-owned trusted dispatch state; request payload contains only handle, operation, and target | Trusted kernel or host construction must authenticate the actor and clock source |
+| URI used as a bearer credential | No credentials in URI; capability handle and grant are out of band | Application logs must still protect URI-derived business identifiers |
+| Mutable alias race or rollback | Full-snapshot CAS, generation starts at 1, checked increment, immutable revisions | Distributed persistence must provide linearizable CAS |
+| Hash or segment substitution | Revision is full RVF SHA-256; verified profile is paired with that report identity; per-view digests verified | SHA-256 is fixed for contract v1 and requires a versioned migration to change |
+| Signed malicious skill | Inspection and read do not execute; `Execute` requires a pinned URI and `EXECUTE` capability | RVM constrains authority, but cannot establish semantic truth or remove prompt injection |
+| Grant confused across scopes | Exact structured fields and segment-prefix comparison | Incorrect grant issuance remains an operator risk |
+| Search amplification or memory exhaustion | Const-bounded tables, URI and path limits, 64-result top-K buffer, linear-time matcher, 16 MiB context RVF ceiling | Persistent adapters need quotas, rate limits, and admission control |
+| Audit loss on ring wrap | Signed contiguous epoch receipts sealed before overwrite | Drainer outage can exhaust the retention window; production needs backpressure |
+| Personal data retained by immutable history | Tombstone alias and digest-only witnesses | Key destruction, replica purge, backup retention, and derived-index deletion are not implemented by the reference resolver |
+| Existence leakage through errors | Deny before resolver and recommend uniform external errors | Timing isolation across shared physical infrastructure requires service-level testing |
+| Receipt replay, truncation, or partial ring snapshot | Runtime-owned chain state, verified genesis/successor checks, domain separation, explicit range coordinates, previous-receipt link, chain and Merkle commitments, signer verification, fail-closed wrap detection | Durable receipt ordering across multiple hosts is future federation work |
+
+### 9. Reference Limits
+
+| Limit | Value | Reason |
+|---|---:|---|
+| URI bytes | 2,048 | Bounds parser work and log-safe identifiers |
+| Authority bytes | 253 | DNS maximum textual length |
+| Authority label bytes | 63 | DNS label maximum |
+| Tenant or subject slug bytes | 63 | Fixed operational identifier bound |
+| Path segments | 32 | Bounds prefix checks and resolver traversal |
+| Path segment bytes | 128 | Bounds per-component work |
+| Joined path bytes | 1,024 | Bounds canonical URI storage |
+| Search results | 64 | Prevents unbounded result allocation and enumeration |
+| Search query bytes | 4,096 | Bounds the reference conformance scan; hosted adapters may tighten it |
+| Context RVF bytes | 16 MiB | Reference in-memory verifier ceiling |
+| Progressive views per profile | At most 3 | At most one each of abstract, overview, and content; content is required |
+| Reference resolver objects | 64 by default | Const-generic `MemoryResolver` object capacity |
+| Reference resolver aliases | 64 by default | Const-generic `MemoryResolver` alias capacity |
+| `rvm-witness` library default records | 262,144 | 16 MiB reference ring; actual `WitnessLog<N>` may differ |
+| Context epoch receipt records | 262,144 | Bounds direct sealing and in-place Merkle leaf allocation to 8 MiB |
+| Current integrated `rvm-kernel` records | 256 | Existing kernel choice; requires a correspondingly shorter drain interval |
+
+Persistent or hosted adapters may tighten these limits. They must not silently
+widen them for a contract-v1 request.
+
+## Pseudocode Summary
+
+### Resolve or read
+
+```text
+resolve(request):
+    uri = parse(request.uri)
+    require request.operation in {Resolve, List, Tree, Read, Search, History}
+    grant = grants.lookup(request.capability_handle)
+    decision = grant.authorize(uri, READ, uri.view)
+    witness_before_resolver(decision)
+    require decision == Allow
+
+    pinned = if uri.rev exists:
+        resolver.resolve_pinned(uri)
+    else:
+        snapshot = resolver.resolve_alias(uri)
+        uri.with_revision(snapshot.revision)
+
+    require resolved RVF identity == pinned.rev
+    return pinned result
+```
+
+### Put and alias advance
+
+```text
+put_and_advance(pinned_uri, rvf, alias, expected):
+    require pinned_uri.rev exists
+    authorize_and_witness(WRITE, pinned_uri)
+    profile = verify_profile(rvf, pinned_uri.rev)
+    resolver.put_immutable(pinned_uri, profile)
+
+    require alias.rev is absent
+    authorize_and_witness(WRITE, alias)
+    resolver.compare_and_swap(alias, expected, pinned_uri.rev)
+```
+
+The immutable put and alias CAS are separate observable operations. If CAS
+loses a race, the new pinned object remains valid but is not the alias head.
+Garbage collection of unreachable immutable objects is a storage policy, not a
+namespace mutation.
+
+### Execute
+
+```text
+permit_execution(request):
+    uri = parse(request.uri)
+    require uri.rev exists
+    authorize_and_witness(EXECUTE, uri)
+    resolved = resolver.resolve_pinned(uri)
+    require resolved.profile is verified
+    return ExecutionPermit(uri, resolved.rvf_identity, capability_commitment)
+```
+
+Producing `ExecutionPermit` still does not map or invoke an executable segment.
+The RVF loader and launch path consume the permit under ADR-155.
+
+## Requirements-to-Evidence Matrix
+
+This matrix defines planned acceptance evidence. It does not assert that the
+commands or tests have passed in this proposal.
+
+| Requirement | Planned automated evidence | Release evidence |
+|---|---|---|
+| Canonical valid URIs round-trip exactly | URI table tests and parse-format-parse property test | Cross-language conformance vectors |
+| Hostile bytes never panic or become a second name | Property test over arbitrary byte strings; explicit percent, NUL, dot-segment, duplicate-query, and case vectors | One million randomized parser cases with zero acceptance ambiguity |
+| Full RVF identity is the revision | One-bit RVF tamper and claimed-revision mismatch tests | Independent host resolves same pinned URI to same digest |
+| Pinned bytes are immutable | Duplicate put with different profile or bytes is refused | Store replay shows no overwrite for an existing revision |
+| Alias updates are atomic and ABA-safe | Stale snapshot, generation mismatch, simulated two-writer, and generation-wrap tests | Linearizability test against persistent adapter |
+| URI never grants access | Missing, wrong-type, revoked, expired, cross-tenant, cross-subject, wrong-prefix, and wrong-view grant tests | Mixed-scope red-team run with zero unauthorized success |
+| Authorization precedes enumeration | Spy resolver asserts zero calls after denied Search, List, Tree, and History | Backend traces show no candidate enumeration on denial |
+| Operation mapping is total | Exhaustive operation-to-rights tests | API conformance report |
+| Read and execute are independent | READ-only skill can be inspected but not executed; EXECUTE-only request yields a permit without content disclosure | Malicious-skill scenario cannot execute under READ grant |
+| Derived views bind provenance | Tamper source, generator, model, prompt, and policy fields independently | Offline verifier reproduces view commitment |
+| Every allow and denial is witnessed first | Sequence and spy-resolver ordering tests for each operation | Witness query correlates all request outcomes |
+| Receipt covers an exact contiguous range | Round-trip, wrong range, chain tamper, Merkle tamper, signer mismatch, signature tamper, truncation, and wrap-refusal tests | Offline receipt plus full record-range verification after ring drain |
+| Tombstone does not overwrite pinned bytes | Forget creates new revision; stale CAS and pinned historic lookup tests | Storage erasure and derived-index purge report |
+| Resource limits fail closed | Boundary tests for every table in section 9 | Load test records bounded memory and result count |
+| No RVF wire discriminant fork | Fixture uses canonical `PROFILE` and `WITNESS` types and rejects unknown context profile version | RuVector reader preserves the artifact byte-for-byte |
+| `no_std`, safe Rust, and MSRV remain valid | `cargo check -p rvm-context --no-default-features`, clippy, unsafe-code lint, and Rust 1.77 build | CI artifacts attached to the release |
+
+Planned workspace gates are:
+
+```text
+cargo fmt --all --check
+cargo check --workspace --locked
+cargo test --workspace --locked
+cargo clippy --workspace --locked -- -D warnings
+cargo clippy -p rvm-context --all-targets --locked -- -D warnings
+cargo check --target aarch64-unknown-none -p rvm-context --no-default-features --locked
+cargo +1.77.2 check -p rvm-context --all-features --locked
+cargo audit
+```
+
+Benchmarks must measure canonical URI parsing, rejected maximum-length input,
+authorization plus witness emission, pinned resolution, alias CAS, profile
+verification, and receipt sealing. A same-host Criterion baseline is required;
+the existing nightly script has no committed historical baseline and cannot by
+itself establish that this change caused no regression.
+
+## Rejected Alternatives
+
+### Copy or embed OpenViking
+
+Rejected. It would create license coupling and make RVM depend on another
+project's storage, authentication, and execution assumptions. We adopt useful
+patterns through an independent contract, not its code.
+
+### Make the URI a capability
+
+Rejected. URLs routinely enter logs, prompts, telemetry, and chat transcripts.
+Embedding bearer authority would turn ordinary context sharing into credential
+leakage and make revocation difficult.
+
+### Authorize after vector search
+
+Rejected. Post-filtering can leak candidate existence, timing, counts, and
+shared-index structure. The backend must not observe an unauthorized query.
+
+### Treat every name as mutable
+
+Rejected. Reproducible citations, receipts, checkpoints, and execution permits
+need stable bytes. Mutable aliases exist only as explicit pointers to immutable
+revisions.
+
+### Update aliases with last-write-wins
+
+Rejected. It loses concurrent writes and permits rollback and ABA errors. Full
+snapshot compare-and-swap provides a deterministic conflict.
+
+### Make READ imply EXECUTE
+
+Rejected. Context is untrusted input. Inspection must remain safe, and a signed
+skill proves publisher identity rather than safety.
+
+### Add private RVF segment types
+
+Rejected. New discriminants in RVM alone would fork the canonical RVF format.
+The context profile is versioned inside the existing `PROFILE` payload, and
+receipts use the existing `WITNESS` segment.
+
+### Put the context profile in the RVF root `profile_id`
+
+Rejected. Existing hardware and domain profile enums share that byte. A new
+value requires cross-repository format governance, not a unilateral RVM change.
+
+### Write one RVF witness entry per candidate
+
+Rejected. Audit volume would scale with internal retrieval work and exhaust the
+RVM ring rapidly. RVM witnesses decisions and mutations, then seals bounded
+detail into epoch receipts.
+
+### Accept general URL normalization
+
+Rejected. Percent decoding, Unicode normalization, default ports, and query
+reordering vary across libraries. Contract v1 uses a strict ASCII language and
+rejects all alternative spellings.
+
+## Rollout
+
+### Phase 1: Reference contract
+
+Land `rvm-context`, its in-memory resolver, profile verifier, capability and
+witness bindings, epoch receipt types, conformance vectors, and this ADR. Keep
+the ADR Proposed while interoperability evidence is collected.
+
+### Phase 2: Hosted integration
+
+Connect an authorized RuVector adapter and an RVF context compiler. Verify that
+denied searches do not reach ANN enumeration. Add an HTTPS gateway and MCP/CLI
+surfaces that preserve the canonical URI unchanged. Hosted isolation must be
+described as operating-system sandbox plus WASM, not bare-metal partition
+assurance.
+
+### Phase 3: Durable service
+
+Add a linearizable persistent alias store, KMS-backed per-object encryption,
+receipt draining with backpressure, replica and cache purge, tenant-isolated
+indexes, recovery tests, quotas, and service-level timing analysis.
+
+### Phase 4: Interoperability and registration
+
+Publish language-neutral conformance vectors and independent implementations.
+Only after durable cross-vendor use exists should the project consider an IANA
+provisional URI scheme registration. Until then, `ruv://` remains an
+experimental rUv ecosystem identifier with HTTPS as the network transport.
+
+### Rollback
+
+Disable external resolver and alias-write surfaces, revoke their Context
+capabilities, and retain pinned RVFs plus signed receipts for audit. Because
+version 1 adds no RVF segment discriminant or root profile ID, ordinary RVF
+readers can preserve the artifacts while ignoring the versioned profile
+payload. A rollback never rewrites a pinned revision or reuses an alias
+generation. Re-enabling the feature starts from the last valid alias snapshots
+or from explicitly reconstructed aliases under a new witnessed policy epoch.
+
+## Consequences
+
+### Positive
+
+1. A context citation can bind exact RVF bytes across hosts.
+2. Human-friendly aliases remain available without weakening immutable
+   references.
+3. Cross-tenant authorization is centralized and testable before retrieval.
+4. Skills can be inspected without creating an execution surface.
+5. Progressive views reduce disclosure and token use while retaining explicit
+   provenance.
+6. Audit volume has a bounded path from runtime records to durable RVF
+   receipts.
+7. The implementation does not fork RVF's segment registry or copy AGPL code.
+
+### Negative
+
+1. Contract v1 is intentionally strict and ASCII-only.
+2. SHA-256 is fixed in the URI revision syntax for version 1; algorithm
+   agility needs a future contract version.
+3. Compare-and-swap makes concurrent alias conflicts visible to callers.
+4. A 16 MiB in-memory RVF ceiling excludes large context artifacts until a
+   streaming profile is specified.
+5. Every decision adds witness pressure, so production deployment requires a
+   receipt drainer and backpressure.
+6. The reference resolver is neither persistent nor distributed.
+
+### Residual Risks
+
+1. This contract governs authority and integrity, not semantic truth. Prompt
+   injection and poisoned memories remain application risks.
+2. A capability issuer can still grant an overly broad scope.
+3. Cryptographic erasure, replicas, backups, caches, and derived indexes are
+   not solved by an alias tombstone alone.
+4. Service-level timing may reveal shared-infrastructure load even when result
+   errors are uniform.
+5. RVF manifest-signature enforcement is not uniform across every current
+   reader. Pinned full-file identity is therefore the required integrity
+   binding; deployments must not claim stronger publisher authentication than
+   they actually verify.
+6. An RVM-only implementation would risk ecosystem fragmentation. MCP, HTTPS,
+   public vectors, and independent implementations are needed before the
+   namespace is a broadly useful protocol.
+
+## Planned Acceptance
+
+The ADR may move from Proposed to Accepted only when two independent hosts can
+resolve the same pinned `ruv://` URI to the same RVF and view digests; one-bit
+tampering is refused; a denied search invokes no retrieval backend; READ can
+inspect but cannot execute a malicious skill; EXECUTE returns a permit only for
+a pinned revision; two writers racing one alias snapshot produce exactly one
+winner; a tombstone advances the alias without changing historic pinned bytes;
+and a signed epoch receipt verifies offline after its RVM witness range has
+been drained.

--- a/userguide/05-capabilities-proofs.md
+++ b/userguide/05-capabilities-proofs.md
@@ -41,6 +41,7 @@ Each capability targets a specific kind of kernel object:
 | `Proof` | 6 | Escalation, deep proof verification |
 | `Vcpu` | 7 | Virtual CPU control |
 | `Coherence` | 8 | Coherence observer operations |
+| `Context` | 9 | Capability-governed `ruv://` namespace scopes |
 
 ### The `CapToken` Struct
 

--- a/userguide/15-glossary.md
+++ b/userguide/15-glossary.md
@@ -36,8 +36,13 @@ evaluation. Defined in `rvm-types::capability`. See [Capabilities and
 Proofs](05-capabilities-proofs.md).
 
 **CapType** -- The kind of kernel object a capability authorizes access to:
-`Partition`, `Region`, `Device`, `CommEdge`, `Witness`. See [Capabilities and
-Proofs](05-capabilities-proofs.md).
+`Partition`, `Region`, `Device`, `CommEdge`, `Witness`, `Proof`, `Vcpu`,
+`Coherence`, and `Context`. See [Capabilities and Proofs](05-capabilities-proofs.md).
+
+**Context Capability** -- A live `CapType::Context` capability paired with a
+trusted binding to an exact `ruv://` authority, tenant, subject, collection,
+path-segment prefix, and progressive-view mask. A context URI is only a name;
+the capability is the authority. See [Governed ruv Context](16-ruv-context.md).
 
 **Coherence** -- A measure of how tightly coupled a partition is to its
 communication neighbors. Derived from the weighted communication graph.

--- a/userguide/16-ruv-context.md
+++ b/userguide/16-ruv-context.md
@@ -1,0 +1,405 @@
+# Governed `ruv://` Context
+
+RVM uses `ruv://` to name agent resources, memories, and skills without making
+the name itself a credential. A canonical URI identifies context. A separate
+RVM capability decides whether a caller may resolve, inspect, search, mutate,
+prove, or execute it.
+
+This chapter explains the version 1 namespace defined by
+[ADR-157](../docs/adr/ADR-157-ruv-context-namespace.md). For the underlying
+capability model, read [Capabilities and Proofs](05-capabilities-proofs.md).
+For the hot audit trail, read [Witness and Audit](06-witness-audit.md).
+
+---
+
+## 1. Mental Model
+
+A context object has two useful names:
+
+| Name | Example | Meaning |
+|---|---|---|
+| Versionless alias | `ruv://context.example/acme/agent/researcher/skills/web-search` | A mutable pointer intended for discovery and human workflows |
+| Pinned URI | The same path with `?rev=sha256:<64 lowercase hex>` | An immutable citation to the SHA-256 identity of the complete RVF byte stream |
+
+Aliases provide friendly names. Pinned URIs provide reproducibility. An alias
+can advance only through compare-and-swap (CAS), while bytes registered under a
+pinned revision are never overwritten.
+
+The namespace is not a filesystem mount, a network transport, or an ambient
+authority system. In particular:
+
+- parsing a URI grants no rights;
+- resolving a skill does not execute it;
+- a signed artifact is not automatically safe content;
+- `ruv://` does not define how bytes move between hosts; and
+- the reference `MemoryResolver` is bounded in-memory state, not a durable or
+  distributed database.
+
+---
+
+## 2. Canonical URI Contract
+
+The only accepted version 1 form is:
+
+```text
+ruv://authority/tenant/subject-kind/subject-id/collection[/path...][?query]
+```
+
+The structural choices are fixed:
+
+| Component | Accepted values |
+|---|---|
+| `subject-kind` | `agent`, `user`, `service`, `team` |
+| `collection` | `memory`, `resources`, `skills` |
+| `view` | `abstract`, `overview`, `content` |
+| `rev` | `sha256:` followed by exactly 64 lowercase hexadecimal characters |
+| Query | absent, `rev` only, `view` only, or canonical `rev&view` |
+
+Examples:
+
+```text
+# Collection root
+ruv://context.example/acme/team/platform/resources
+
+# Versionless alias with a progressive view
+ruv://context.example/acme/agent/researcher/memory/project-orion?view=abstract
+
+# Immutable content citation
+ruv://context.example/acme/agent/researcher/skills/web-search?rev=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&view=content
+```
+
+The parser is intentionally strict. It does not normalize alternative URL
+spellings:
+
+| Limit | Contract |
+|---|---|
+| Complete URI | At most 2,048 ASCII bytes |
+| Authority | Lowercase DNS form, at most 253 bytes; labels at most 63 bytes |
+| Tenant and subject ID | Lowercase slugs, 1 through 63 bytes |
+| Optional path | At most 32 segments and 1,024 joined bytes |
+| Path segment | 1 through 128 ASCII unreserved characters `[A-Za-z0-9._~-]` |
+
+Any non-ASCII byte, percent sign, fragment, authority credential or port,
+empty segment, trailing slash, `.` or `..` segment, duplicate or unknown query
+key, empty query value, noncanonical case, or `view` before `rev` is rejected.
+Path case is preserved; structural tokens, authorities, slugs, and revision hex
+must use the case specified above.
+
+Use the typed parser instead of a general-purpose URL normalizer:
+
+```rust
+use rvm_context::{PinnedRuvUri, RuvUri, UriError};
+
+fn parse_names() -> Result<(), UriError> {
+    let alias = RuvUri::parse(
+        "ruv://context.example/acme/agent/researcher/skills/web-search?view=overview",
+    )?;
+    assert!(!alias.is_pinned());
+
+    let pinned: PinnedRuvUri = concat!(
+        "ruv://context.example/acme/agent/researcher/skills/web-search",
+        "?rev=sha256:",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "&view=content",
+    )
+    .parse()?;
+    assert_eq!(pinned.to_string(), pinned.as_uri().to_string());
+    Ok(())
+}
+```
+
+In a `no_std` caller, formatting to an owned string requires `alloc`; parsing
+and typed inspection remain part of the `rvm-context` API.
+
+---
+
+## 3. Progressive Views
+
+A context profile can expose three semantic representations:
+
+| View | Typical use | Disclosure |
+|---|---|---|
+| `abstract` | Routing summary or relevance decision | Smallest |
+| `overview` | Structure, relationships, and fuller summary | Intermediate |
+| `content` | Source or full representation selected by the profile | Largest |
+
+These are capability-scoped representations, not interchangeable filenames.
+A grant may permit an abstract while denying the content. When a view is
+derived, its provenance binds the source digest and generation inputs so that
+changing the source, generator, model, prompt, or policy changes the derived
+commitment.
+
+If `view` is omitted, Resolve, List, Tree, History, and Verify require manifest
+metadata; Read requires content; and Search requires overview. Mutation,
+execution, delegation, revocation, and receipt sealing accept no view selector.
+An adapter must not silently broaden a grant to a larger representation.
+
+---
+
+## 4. Capabilities Are Out of Band
+
+An untrusted `ContextRequest` carries only a capability handle, operation, and
+canonical `RuvUri`. It has no actor or timestamp field. `ContextRuntime`
+construction is the trusted kernel-dispatch boundary: an authenticated
+`PartitionId` is bound immutably to the runtime, and a runtime-owned
+`ContextClock` stamps witness observations. There is no actor setter. The safe
+default is a monotonic logical clock; trusted host code may inject a clock or
+resume it explicitly.
+
+After authorization, the runtime privately creates `AuthorizedRequest`.
+`ContextScope` binds exact namespace fields, a path-segment prefix, and the
+permitted manifest/progressive-view mask. A raw string prefix is never used for
+path authorization: `team/a` cannot accidentally authorize `team/alpha`.
+
+The rights mapping is total and default-deny:
+
+| Operation | Required rights |
+|---|---|
+| Resolve, List, Tree, Read, Search, History | `READ` |
+| Verify | `READ | PROVE` |
+| Put, CompareAndSwapAlias, Forget | `WRITE` |
+| Execute | `EXECUTE` |
+| Grant | `GRANT` |
+| Revoke | `REVOKE` |
+| SealReceipt | `PROVE` |
+
+`READ` and `EXECUTE` are independent. A reviewer can inspect a hostile skill
+without being allowed to run it. Conversely, a narrowly controlled executor
+can receive an execution permit for a pinned artifact without receiving its
+content view.
+
+Every authorization result, including a denial, is appended to the RVM
+witness log before the resolver is called. Search, List, Tree, and History
+therefore authorize the whole requested scope before candidate enumeration.
+Do not build an adapter that searches a shared index first and filters results
+afterward; that leaks existence, counts, timing, or index structure.
+
+---
+
+## 5. RVF Representation
+
+The revision is SHA-256 over the complete RVF bytes. It is not a segment hash
+or a digest of only the selected view. `rvm-rvf` verifies that full identity
+before a pinned object can enter the context resolver. The `ContextProfile`
+payload maps views to segment ordinals and digests; it does not serialize a
+second whole-file identity. `VerifiedContextProfile` pairs the decoded profile
+with the expected revision and a passing full-RVF verification report.
+
+The profile and receipt design reuses canonical RVF version 1 segment types:
+
+| RVF segment | Use by the context contract |
+|---|---|
+| `PROFILE` (`0x0B`) | Versioned `ContextProfile` payload and view bindings |
+| Existing data segments | Inert bytes selected by profile references |
+| `VEC` / `INDEX` | Rebuildable authorized retrieval material |
+| `WITNESS` (`0x0A`) | Canonical witness entry committing a signed epoch receipt |
+| `META`, `MANIFEST`, `CRYPTO` | Existing RVF metadata, inventory, and producer trust material |
+
+No private context, content, tree, or representation segment discriminant is
+introduced. The context profile has its own magic and version inside an
+existing `PROFILE` payload; it does not allocate a new RVF root `profile_id`.
+This avoids creating an RVM-only RVF format fork.
+
+Exactly one unencrypted, uncompressed profile segment is accepted. Content is
+required; abstract and overview are optional. View segment IDs must be unique,
+the referenced bytes must be uncompressed and match their payload digest, and
+a derived non-content view cannot point at executable bytes. Callers choose an
+explicit trust posture: a passing trusted signature on the profile segment, or
+a pinned whole-RVF identity authenticated out of band.
+
+A valid publisher signature proves an identity statement under the verifier's
+trust policy. It does not prove that memory content is true, that a prompt is
+safe, or that executable behavior is benign. Pinned full-file identity and RVM
+execution authority remain mandatory even when signatures are present.
+
+---
+
+## 6. Publish and Advance an Alias
+
+Publishing is deliberately two-stage:
+
+1. Build the RVF and its versioned context profile.
+2. Compute SHA-256 over the complete, final RVF bytes.
+3. Construct a pinned URI whose `rev` equals that digest.
+4. Authorize `Put` with `WRITE`; the decision is witnessed.
+5. Verify the RVF identity and profile, then register the immutable object.
+6. Resolve the versionless alias to an `AliasSnapshot`.
+7. Authorize `CompareAndSwapAlias` with `WRITE`; the decision is witnessed.
+8. CAS the alias from the complete expected snapshot to the new revision.
+
+The initial alias generation is 1. Every successful CAS uses checked
+increment. The expected snapshot includes both revision and generation, so a
+stale writer loses even if an alias moved away and later returned to the same
+revision. Generation wrap fails instead of reusing an old value.
+
+The immutable Put and the alias CAS are separate operations. If another writer
+wins the alias race, the newly registered pinned object remains a valid
+immutable object, but it is not the alias head. A storage adapter may later
+garbage-collect unreachable objects under an explicit retention policy.
+
+---
+
+## 7. Resolve, Read, Search, and Execute
+
+For every operation, the safe order is:
+
+```text
+parse canonical URI
+    -> look up capability and context grant
+    -> authorize exact scope, operation, and view
+    -> append allow or denial witness
+    -> on allow only: call ContextResolver
+```
+
+An alias resolution returns its pinned revision and generation snapshot. A
+pinned resolution verifies that the registered full RVF identity equals the
+URI revision. Search is capped at `MAX_SEARCH_RESULTS = 64` before resolver
+allocation or enumeration, and the conformance resolver caps a query at 4,096
+bytes. Context RVF input is capped at `MAX_RVF_BYTES = 16 MiB` by the reference
+contract. `MemoryResolver` defaults to 64 immutable-object slots and 64 alias
+slots; both capacities are const-generic. Its matcher is linear in candidate
+bytes, and it retains only the globally ranked top K hits, so result storage is
+bounded by the requested limit rather than the number of scanned aliases.
+
+Execute is a separate path:
+
+- it requires an `EXECUTE` grant;
+- it requires a pinned URI;
+- it returns an `ExecutionPermit`; and
+- it does not itself map, load, or invoke executable bytes.
+
+The verified RVF loader and RVM launch boundary consume that permit under the
+existing verify-before-load contract. A versionless skill alias must first be
+resolved and deliberately pinned; execution must never race a moving alias.
+
+---
+
+## 8. Forgetting and Retention
+
+`Forget` applies to a versionless alias. It creates a domain-separated
+tombstone as a new immutable revision, then CAS-advances the alias to the
+tombstone. Historic pinned bytes are not rewritten.
+
+This is namespace deletion, not complete data erasure. A production adapter
+must separately implement any required key destruction and removal from
+replicas, backups, caches, vector indexes, and derived representations. Those
+storage actions need their own policy and evidence.
+
+---
+
+## 9. Epoch Receipts and Ring Wrap
+
+The hot witness log is a const-generic ring. Its retention horizon is:
+
+```text
+seconds before wrap = ring record capacity / records emitted per second
+```
+
+`rvm_witness::DEFAULT_RING_CAPACITY` is 262,144 records, or 16 MiB at 64 bytes
+per record. At 1,000 records per second it retains about 262 seconds. The
+current integrated `rvm-kernel` log uses a smaller `WitnessLog<256>`, which at
+the same rate retains only about 0.256 seconds. Deployments must size and drain
+the actual `N`; the library constant is not a service guarantee.
+
+`ContextRuntime::seal_epoch` snapshots a complete range after its owned
+checkpoint. It fails if any requested record has already wrapped rather than
+signing a partial range. The runtime owns `ReceiptChainState`, which contains
+the exact next checkpoint, next epoch ID, and previous signed-receipt ID. The
+request cannot choose any of those coordinates. Genesis is fixed to epoch 0,
+sequence 0, zero initial chain hash, and a zero prior link. The state advances
+only after the new receipt is signed and verified; persist the state atomically
+with the durable signed receipt. `ReceiptChainState::trusted_resume` is an
+explicit administrative recovery boundary and its inputs must first be
+authenticated against durable storage.
+
+The lower-level `ContextEpochReceipt::seal_from_log` returns a checkpoint
+captured under the same witness-log lock. Runtime state uses that exact boundary
+for the following epoch so a concurrent append cannot fall between receipts.
+One receipt is limited to 262,144 records. Merkle construction reduces the
+leaf vector in place, so the largest permitted epoch reserves at most 8 MiB
+for 32-byte leaf hashes rather than allocating a second tree-sized buffer.
+The unsigned receipt binds:
+
+| Field group | Binding |
+|---|---|
+| Epoch coordinates | Epoch ID, first and last sequence, record count |
+| Time | Minimum and maximum observed timestamps |
+| RVM chain | Chain hash immediately before the first record and a Merkle root of canonical 64-byte records |
+| Receipt continuity | SHA-256 ID of the previous signed receipt |
+| State and policy | Namespace root, policy hash, optional encrypted-detail commitment |
+| Content | Full RVF identity governing the epoch |
+
+Signing adds a 32-byte signer ID and 64-byte signature over a domain-separated
+digest. The fixed signed receipt is 352 bytes. `verify_records` recomputes the
+sequence, timestamp bounds, RVM chain, and Merkle root; `verify` authenticates
+the signer and signature. Sequence and chain coordinates define order;
+timestamps are non-authoritative observations, so backwards or extreme values
+do not prevent sealing. Verified typestate can require genesis or an exact
+successor, including the receipt link, checked epoch increment, exact sequence
+adjacency, and the full chain value derived across every prior sequence.
+
+The full signed receipt must be retained as durable sidecar evidence. Its
+canonical 73-byte RVF witness entry stores a chain link, a SHAKE-256 commitment
+to the full receipt, the maximum observed timestamp, and the existing RVF
+computation witness type. Signature verification produces a typed verified
+receipt before either commitment operation is available. `emit_seal` records
+the actual P1 runtime authorization and places the receipt ID and range
+commitment in the next RVM epoch, so a receipt never claims to cover its own
+seal record.
+
+Drain and seal with margin. Once the first record of an unsealed range is
+overwritten, the reference implementation refuses to manufacture a complete
+receipt. Production services need alerting and backpressure before that point.
+
+---
+
+## 10. Security Checklist
+
+Before exposing a resolver through a CLI, MCP server, or HTTP gateway:
+
+- keep capability handles out of the URI and out of ordinary logs;
+- parse with `RuvUri`, not a forgiving URL library;
+- call the resolver only through the authorization-and-witness runtime path;
+- give each tenant a structured scope, not a text-prefix filter;
+- use uniform external errors for forbidden and hidden objects unless the
+  caller has explicit audit authority;
+- require pinned URIs for Put and Execute;
+- enforce the 4,096-byte query, 64-result, and 16 MiB ceilings before
+  allocation;
+- treat retrieved context as hostile input;
+- verify derived-view provenance before serving it;
+- implement linearizable CAS in any distributed alias store; and
+- drain receipts well before the configured witness ring can wrap.
+
+The reference implementation establishes namespace, integrity, capability,
+and evidence boundaries. It does not by itself provide network federation,
+tenant-isolated persistent indexes, semantic truth, prompt-injection defense,
+cryptographic erasure, or a production receipt drainer.
+
+---
+
+## 11. Planned Validation
+
+Acceptance evidence for the initial implementation is defined in ADR-157 and
+includes URI conformance and property tests, full-RVF tamper tests, denied
+search spy-resolver tests, exhaustive operation-to-rights checks, alias race
+and wrap tests, READ-versus-EXECUTE tests, profile provenance tampering, receipt
+range/signature/tamper tests, and resource-boundary tests.
+
+Performance baselines should cover canonical and rejected URI parsing,
+authorization plus witness emission, pinned lookup, CAS, profile verification,
+search at the 64-result ceiling, and receipt sealing across representative
+epoch sizes. Compare same-host Criterion samples; do not infer a regression
+from results collected on different machines.
+
+---
+
+## Further Reading
+
+- [ADR-157: Capability-Governed `ruv://` Context Namespace](../docs/adr/ADR-157-ruv-context-namespace.md)
+- [Capabilities and Proofs](05-capabilities-proofs.md)
+- [Witness and Audit](06-witness-audit.md)
+- [Security](10-security.md)
+- [RVForge Execution Contract](../docs/adr/ADR-155-rvf-execution-contract.md)
+- [External Receipt Anchoring](../docs/adr/ADR-156-external-receipt-anchoring.md)
+- [Cross-Reference Index](cross-reference.md)

--- a/userguide/README.md
+++ b/userguide/README.md
@@ -12,7 +12,7 @@ Choose a path based on your goals:
 |------|-----------|----------------|
 | **Quick Start** | [01 -- Quick Start](01-quickstart.md) | Clone, build, boot in QEMU, and run your first partition in 5 minutes |
 | **Deep Dive** | [02 -- Core Concepts](02-core-concepts.md) then [03 -- Architecture](03-architecture.md) | How RVM thinks, why it exists, and how the pieces fit together |
-| **Reference** | [04 -- Crate Reference](04-crate-reference.md) then [15 -- Glossary](15-glossary.md) | API surface, type catalog, and precise definitions |
+| **Reference** | [04 -- Crate Reference](04-crate-reference.md), [16 -- Governed `ruv://` Context](16-ruv-context.md), then [15 -- Glossary](15-glossary.md) | API surface, governed context names, and precise definitions |
 
 Every chapter ends with cross-reference links to related sections. If you prefer to navigate by topic rather than chapter order, use the [Cross-Reference Index](cross-reference.md).
 
@@ -38,13 +38,14 @@ Every chapter ends with cross-reference links to related sections. If you prefer
 | 13 | [Advanced and Exotic](13-advanced-exotic.md) | Seed profile (64 KB), Appliance deployment, Chip targets, RuVector integration |
 | 14 | [Troubleshooting](14-troubleshooting.md) | Common build errors, QEMU issues, debugging tips, and FAQ |
 | 15 | [Glossary](15-glossary.md) | Precise definitions for every RVM-specific term |
+| 16 | [Governed `ruv://` Context](16-ruv-context.md) | Canonical context names, immutable RVF revisions, capability scopes, CAS aliases, progressive views, and epoch receipts |
 | -- | [Cross-Reference Index](cross-reference.md) | Topic-to-chapter mapping for quick navigation |
 
 ---
 
 ## Key Concepts at a Glance
 
-> **Six ideas that make RVM different from every other hypervisor.**
+> **Seven ideas that define RVM's model.**
 
 - **Coherence Domains** -- Partitions are not VMs. They have no emulated hardware. A partition is a graph-structured container whose boundaries shift dynamically based on agent communication patterns. See [Core Concepts](02-core-concepts.md).
 
@@ -57,6 +58,8 @@ Every chapter ends with cross-reference links to related sections. If you prefer
 - **Memory Tiers** -- Memory lives in four explicit tiers (Hot, Warm, Dormant, Cold) instead of a demand-paging black box. Dormant memory is stored as a checkpoint plus delta-compressed witness trail and can be reconstructed days later. See [Memory Model](08-memory-model.md).
 
 - **Partitions** -- The unit of scheduling, isolation, migration, and fault containment. Partitions can split along graph-theoretic mincut boundaries when coupling drops, and merge when coherence rises. Every lifecycle transition is witnessed. See [Partitions and Scheduling](07-partitions-scheduling.md).
+
+- **Governed Context** -- Canonical `ruv://` names identify resources, memories, and skills, while live RVM capabilities independently authorize each operation. Pinned names bind complete RVF bytes; aliases advance through compare-and-swap. See [Governed `ruv://` Context](16-ruv-context.md).
 
 ---
 
@@ -99,5 +102,5 @@ All RVM crates are `#![no_std]` and `#![forbid(unsafe_code)]` by default. No C t
 
 - **Repository**: <https://github.com/ruvnet/rvm>
 - **License**: MIT OR Apache-2.0
-- **ADR References**: ADR-132 through ADR-142
+- **Architecture decisions**: [`docs/adr/`](../docs/adr/)
 - **Start building**: [Quick Start](01-quickstart.md)


### PR DESCRIPTION
## Summary

Adds a clean-room, RVM-native governed context layer using canonical `ruv://` names.

* Introduces the safe-Rust, `no_std` `rvm-context` crate.
* Defines strict canonical URI parsing for resources, memories, and skills.
* Keeps names separate from authority through live `CapType::Context` capabilities and exact structured scopes.
* Adds immutable whole-RVF SHA-256 revisions, generation-bearing CAS aliases, tombstones, progressive views, bounded search, and byte-free execution permits.
* Reuses canonical RVF `PROFILE` and `WITNESS` segment types instead of creating a format fork.
* Bridges contiguous RVM witness ranges into signed, chain-linked epoch receipts.
* Documents the contract and threat model in ADR-157 and user guide chapter 16.

The design adopts useful context hierarchy and progressive disclosure patterns discussed by OpenViking, but imports no OpenViking code and remains under this repository's MIT OR Apache-2.0 license.

## Security model

* Authorization and its allow or denial witness occur before any resolver or candidate enumeration.
* `READ` and `EXECUTE` remain independent; execute requires a pinned RVF and returns no bytes.
* The authenticated actor, witness clock, and receipt cursor are immutable runtime-owned state, not request fields.
* Full RVF identity and each selected view are verified before registration or disclosure.
* Search uses a globally ranked top-K buffer and a linear-time matcher.
* Receipt verification checks signatures, exact sequence adjacency, full prior-range chain derivation, Merkle commitments, epoch increments, and prior receipt links.
* Grant bindings are cleared on capability epoch rotation.
* The executable RVF path now fails closed for an unsupported signature algorithm or a missing trusted key.

## Validation

All commands used the committed lockfile.

* `cargo check --workspace --locked`
* `cargo test --workspace --locked`
* `cargo clippy --workspace --locked -- -D warnings`
* `cargo test --workspace --all-targets --locked` with a 64 MiB test stack
* `cargo clippy -p rvm-context --all-targets --locked -- -D warnings`
* AArch64 `no_std` checks for `rvm-hal` and `rvm-context`
* Rust 1.77.2 checks and 61 `rvm-context` tests
* Warning-free `rvm-context` rustdoc
* 61 stable `rvm-context` tests and 1,246 workspace all-target unit tests
* Changed-file secret scan
* `cargo audit`: zero vulnerabilities

The audit retains two upstream warnings: RUSTSEC-2026-0190 through `cuda-rust-wasm -> anyhow`, and yanked `spin 0.9.8`. Repository-wide `cargo fmt --all --check` also detects pre-existing formatting drift in unchanged `rvm-anchor` sources; every changed Rust file passes rustfmt.

## Performance

The URI parser uses bounded stack-backed component ranges and fewer heap allocations. Same-host before and after Criterion samples improved:

| Path | Change |
|---|---:|
| Alias parse | 6.46% faster |
| Pinned parse | 14.14% faster |
| Pinned format | 24.19% faster |
| Heap allocations | alias 10 to 7; pinned 8 to 5 |

A final isolated run centered at 363 ns for alias parse, 446 ns for pinned parse, and 222 ns for pinned formatting.

## Residual scope

`MemoryResolver` is a bounded conformance backend. A production service still needs a tenant-isolated RuVector adapter, linearizable persistent CAS, encrypted object storage and erasure, receipt draining with backpressure, federation, quotas, and service-level timing analysis. Those are explicit later rollout phases in ADR-157.