### PR TITLE
ci(pages): deploy docs/ via a workflow that does not recurse submodules

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+# Publish docs/ to GitHub Pages.
+#
+# This exists instead of the legacy branch-and-folder Pages source because that
+# builder checks out submodules recursively, and this repo cannot be recursively
+# checked out: the `cuda-wasm` submodule (ruvnet/ruv-FANN) contains a nested
+# submodule path, `cuda-wasm/archive/claude-code-flow/claude-code-flow`, that has
+# no URL entry in its own .gitmodules. Recursive checkout therefore fails with
+#
+#   fatal: No url found for submodule path '...' in .gitmodules
+#   fatal: Failed to recurse into submodule path 'cuda-wasm'
+#
+# which left every legacy Pages build erroring. Nothing under docs/ needs a
+# submodule, so this workflow checks out the superproject alone.
+name: pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel a deploy midway; queue instead.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Enabling Pages on `main` `/docs` left every build **erroring**. The cause is not the content:

```
fatal: No url found for submodule path
  'cuda-wasm/archive/claude-code-flow/claude-code-flow' in .gitmodules
fatal: Failed to recurse into submodule path 'cuda-wasm'
```

The legacy Pages builder checks out submodules **recursively**, and this repo cannot be recursively checked out — the `cuda-wasm` submodule (ruvnet/ruv-FANN) contains a nested submodule path with no URL entry in its own `.gitmodules`.

**That is an upstream defect and it breaks any recursive checkout, not just Pages.** Worth knowing independently of this change.

Nothing under `docs/` needs a submodule, so this deploys with `submodules: false`, sidestepping the defect rather than waiting on an upstream fix. The reason is recorded in the workflow header so nobody re-enables the legacy source and rediscovers it the hard way.

Path-filtered to `docs/` and the workflow file, 10-minute bound, and `concurrency` set to queue rather than cancel so a deploy is never interrupted halfway.

Requires flipping the Pages build source from `legacy` to `workflow`, which I'll do on merge.

Follows #41 and #42.