### PR TITLE
chore(crates-io): give internal dependencies a version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,25 +41,25 @@ description = "RVM: Coherence-native microhypervisor for edge computing and mult
 
 [workspace.dependencies]
 # Internal dependencies
-rvm-types = { path = "crates/rvm-types" }
-rvm-hal = { path = "crates/rvm-hal" }
-rvm-cap = { path = "crates/rvm-cap" }
-rvm-witness = { path = "crates/rvm-witness" }
-rvm-proof = { path = "crates/rvm-proof" }
-rvm-partition = { path = "crates/rvm-partition" }
-rvm-sched = { path = "crates/rvm-sched" }
-rvm-memory = { path = "crates/rvm-memory" }
-rvm-coherence = { path = "crates/rvm-coherence" }
-rvm-boot = { path = "crates/rvm-boot" }
-rvm-wasm = { path = "crates/rvm-wasm" }
-rvm-rvf = { path = "crates/rvm-rvf" }
-rvm-host = { path = "crates/rvm-host" }
-rvm-launch = { path = "crates/rvm-launch" }
-rvm-context = { path = "crates/rvm-context" }
+rvm-types = { path = "crates/rvm-types", version = "0.1.1" }
+rvm-hal = { path = "crates/rvm-hal", version = "0.1.1" }
+rvm-cap = { path = "crates/rvm-cap", version = "0.1.1" }
+rvm-witness = { path = "crates/rvm-witness", version = "0.1.1" }
+rvm-proof = { path = "crates/rvm-proof", version = "0.1.1" }
+rvm-partition = { path = "crates/rvm-partition", version = "0.1.1" }
+rvm-sched = { path = "crates/rvm-sched", version = "0.1.1" }
+rvm-memory = { path = "crates/rvm-memory", version = "0.1.1" }
+rvm-coherence = { path = "crates/rvm-coherence", version = "0.1.1" }
+rvm-boot = { path = "crates/rvm-boot", version = "0.1.1" }
+rvm-wasm = { path = "crates/rvm-wasm", version = "0.1.1" }
+rvm-rvf = { path = "crates/rvm-rvf", version = "0.1.1" }
+rvm-host = { path = "crates/rvm-host", version = "0.1.1" }
+rvm-launch = { path = "crates/rvm-launch", version = "0.1.1" }
+rvm-context = { path = "crates/rvm-context", version = "0.1.1" }
 rvm-context-service = { path = "crates/rvm-context-service" }
-rvm-security = { path = "crates/rvm-security" }
-rvm-kernel = { path = "crates/rvm-kernel" }
-rvm-gpu = { path = "crates/rvm-gpu" }
+rvm-security = { path = "crates/rvm-security", version = "0.1.1" }
+rvm-kernel = { path = "crates/rvm-kernel", version = "0.1.1" }
+rvm-gpu = { path = "crates/rvm-gpu", version = "0.1.1" }
 
 # External dependencies
 lz4_flex = { version = "0.11", default-features = false }


### PR DESCRIPTION
Prerequisite for publishing any rvm crate. crates.io refuses a manifest whose dependencies are path-only:

```
error: all dependencies must have a version requirement specified when publishing.
  dependency `rvm-cap` does not specify a version
```

All **18** internal workspace dependency declarations were path-only, so **no crate in this workspace could be published**. Each now carries `version = "0.1.1"` (the workspace version) alongside its existing path.

Cargo uses the path for local builds and substitutes the registry version when packaging, so **nothing about how the workspace builds changes** — `cargo check --workspace --locked` is unaffected. Verified with `cargo publish --dry-run -p rvm-types`, which now packages and verifies instead of refusing the manifest.

## One crate stays unpublishable

`rvm-context-service` depends on `ruvector-context` and `ruvector-core` **by path into the submodule**, and neither is on crates.io. Publishing it requires releasing those from the RuVector repo first — a separate, cross-repo decision. The other **19** crates are publishable after this lands.