### PR TITLE
feat(context): WebAssembly/npm binding for rvm-context — naming, scopes, governed runtime, witness verification (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           targets: aarch64-unknown-none
           components: clippy, rustfmt
 
-      - run: cargo fmt -p rvm-context -p rvm-context-service -p rvm-launch -p rvm-witness -p rvm-kernel -- --check
+      - run: cargo fmt -p rvm-context -p rvm-context-service -p rvm-context-wasm -p rvm-launch -p rvm-witness -p rvm-kernel -- --check
       - run: cargo check --workspace --locked
       - run: cargo test --workspace --locked
       - run: cargo clippy --workspace --locked -- -D warnings
@@ -35,6 +35,29 @@ jobs:
           targets: aarch64-unknown-none
       - run: cargo check -p rvm-context --all-features --locked
       - run: cargo check --target aarch64-unknown-none -p rvm-context --no-default-features --locked
+
+  # The binding's tests are wasm_bindgen_test, which compile to nothing on the
+  # host, so `cargo test --workspace` above runs zero of them. They only run
+  # here, on the real wasm32 target.
+  context-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: git submodule update --init --depth 1 ruvector
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+
+      - run: cargo clippy -p rvm-context-wasm --all-targets --target wasm32-unknown-unknown --locked -- -D warnings
+      - run: wasm-pack test --node crates/rvm-context-wasm
+      - run: node crates/rvm-context-wasm/scripts/build-npm.mjs
+      - run: node crates/rvm-context-wasm/tests/smoke.mjs
 
   audit:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target/
+
+# wasm-pack npm build output for crates/rvm-context-wasm
+crates/rvm-context-wasm/pkg/
+crates/rvm-context-wasm/pkg-web/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,6 +1812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rvm-context-wasm"
+version = "0.1.1"
+dependencies = [
+ "js-sys",
+ "rvm-context",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "rvm-gpu"
 version = "0.1.1"
 dependencies = [
@@ -3663,6 +3683,45 @@ checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,9 @@ version = "0.1.1"
 dependencies = [
  "js-sys",
  "rvm-context",
+ "rvm-proof",
+ "rvm-types",
+ "rvm-witness",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/rvm-host",
     "crates/rvm-launch",
     "crates/rvm-context",
+    "crates/rvm-context-wasm",
     "crates/rvm-context-service",
     "crates/rvm-gpu",
     "crates/rvm-kernel",

--- a/crates/rvm-context-wasm/Cargo.toml
+++ b/crates/rvm-context-wasm/Cargo.toml
@@ -16,6 +16,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 rvm-context = { workspace = true, features = ["std"] }
+rvm-types = { workspace = true, features = ["std"] }
+rvm-witness = { workspace = true, features = ["std"] }
+rvm-proof = { workspace = true, features = ["std"] }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 

--- a/crates/rvm-context-wasm/Cargo.toml
+++ b/crates/rvm-context-wasm/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "rvm-context-wasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "WebAssembly bindings for the RVM ruv:// context namespace"
+keywords = ["wasm", "context", "uri", "rvm"]
+categories = ["wasm", "parser-implementations"]
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+rvm-context = { workspace = true, features = ["std"] }
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+# rustc enables these wasm proposals by default for wasm32-unknown-unknown, but
+# wasm-opt does not, so it rejects the module unless they are named explicitly.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = [
+    "-O",
+    "--enable-bulk-memory",
+    "--enable-nontrapping-float-to-int",
+    "--enable-sign-ext",
+    "--enable-mutable-globals",
+    "--enable-reference-types",
+]

--- a/crates/rvm-context-wasm/README.md
+++ b/crates/rvm-context-wasm/README.md
@@ -1,0 +1,201 @@
+# @ruvnet/rvm-context
+
+TypeScript and JavaScript bindings for the RVM `ruv://` context namespace, compiled to
+WebAssembly from the Rust [`rvm-context`](https://github.com/ruvnet/rvm/tree/main/crates/rvm-context)
+crate.
+
+This is the **naming and validation layer**. It parses, validates, constructs, and
+canonically formats `ruv://` URIs using the exact same code the RVM kernel uses, so a
+JavaScript tool and the kernel can never disagree about what a name means.
+
+Full namespace documentation: <https://ruvnet.github.io/rvm/ruv-context/>
+
+## What a `ruv://` URI looks like
+
+```
+ruv://context.example/acme/agent/researcher/memory/projects/atlas?rev=sha256:<64 hex>&view=overview
+      └─ authority ─┘ └tenant┘ └kind┘ └subject┘ └collection┘ └── path ──┘ └── optional query ──┘
+```
+
+Every name has exactly one accepted spelling. Anything else is rejected rather than
+normalized, so policy scopes, witness records, signatures, and caches cannot disagree
+about URI equivalence.
+
+## Install
+
+```sh
+npm install @ruvnet/rvm-context
+```
+
+## Usage
+
+```js
+const { RuvUri, RuvUriBuilder, ruvUriError } = require("@ruvnet/rvm-context");
+
+const uri = RuvUri.parse(
+  "ruv://context.example/acme/agent/researcher/memory/projects/atlas"
+);
+
+uri.authority;   // "context.example"
+uri.tenant;      // "acme"
+uri.subjectKind; // "agent"
+uri.subjectId;   // "researcher"
+uri.collection;  // "memory"
+uri.path;        // ["projects", "atlas"]
+uri.revision;    // undefined  (a mutable alias)
+uri.view;        // undefined
+uri.isPinned;    // false
+uri.toString();  // the canonical spelling, byte for byte
+```
+
+An ES module build for browsers and bundlers is published at the `/web` subpath:
+
+```js
+import init, { RuvUri } from "@ruvnet/rvm-context/web";
+await init();
+```
+
+### Building a URI
+
+The builder validates each component as you supply it, so you never concatenate strings:
+
+```js
+const uri = new RuvUriBuilder("context.example", "acme", "team", "core", "resources")
+  .segment("Specs")
+  .segment("API_v1")
+  .revision("sha256:" + "00".repeat(32))
+  .view("overview")
+  .build();
+```
+
+Every builder method returns a *new* builder, so a partially built value can be reused
+across branches safely.
+
+### Handling rejection
+
+Invalid input throws a real `Error` whose `code` is the exact rejection reason, so you
+can branch on the cause instead of matching message text:
+
+```js
+try {
+  RuvUri.parse("ruv://context.example/ACME/agent/researcher/memory");
+} catch (error) {
+  error.name;    // "RuvUriError"
+  error.code;    // "InvalidTenant"
+  error.message; // "invalid canonical tenant slug"
+}
+```
+
+For validation flows where throwing is inconvenient, `ruvUriError` reports the same code
+without throwing, and `isRuvUri` returns a boolean:
+
+```js
+ruvUriError("ruv://context.example/acme/agent/researcher/memory"); // undefined
+ruvUriError("ruv://context.example/acme/agent/researcher/memory/"); // "TrailingSlash"
+```
+
+Rejection codes include `InvalidScheme`, `InvalidAuthority`, `InvalidTenant`,
+`InvalidSubjectKind`, `InvalidSubjectId`, `InvalidCollection`, `MissingComponent`,
+`EmptyPathSegment`, `TrailingSlash`, `DotSegment`, `InvalidPathSegment`,
+`PercentEncodingNotAllowed`, `FragmentNotAllowed`, `CredentialsNotAllowed`,
+`PortNotAllowed`, `InvalidRevision`, `InvalidView`, `UnknownQueryKey`,
+`DuplicateQueryKey`, `QueryOrder`, `UriTooLong`, `PathTooLong`, `TooManyPathSegments`,
+and `NonAscii`.
+
+### Scopes
+
+`ContextScope` compares regions of the namespace. A scope is derived from a URI plus the
+progressive views it discloses:
+
+```js
+const { ContextScope, ViewMask } = require("@ruvnet/rvm-context");
+
+const parent = ContextScope.fromUri(RuvUri.parse(base + "/projects"), ViewMask.all());
+const child = ContextScope.fromUri(RuvUri.parse(base + "/projects/atlas"), ViewMask.all());
+
+parent.containsScope(child); // true
+child.containsScope(parent); // false
+```
+
+This is a comparison of **names**, not an authorization decision. See the boundary
+section below.
+
+### Context profiles
+
+`ContextProfile` decodes and re-encodes the deterministic progressive-view record that
+maps `abstract`, `overview`, and `content` representations to RVF segments:
+
+```js
+const profile = ContextProfile.decode(bytes);
+profile.views.map((v) => v.view);        // ["abstract", "overview", "content"]
+profile.view("content").segmentId;        // 10n
+profile.view("abstract").provenance.model; // "sha256:..."
+```
+
+## What this package does NOT do
+
+**Holding a parsed URI grants nothing.** A `ruv://` URI is a name, not a token. Parsing
+one successfully tells you the name is well formed; it tells you nothing about whether
+anyone may read, write, or execute what it names.
+
+Deliberately **not** exposed:
+
+- **The governed runtime** (`ContextRuntime`, `ExecutionPermit`) and **the resolver**
+  (`ContextResolver`, `MemoryResolver`). These require an authenticated partition
+  identity, a context clock, and live storage. A JavaScript-side actor supplying those
+  would be precisely the forgery the design prevents.
+- **Capability issuance, delegation, and revocation** (`ContextAuthority`,
+  `ContextGrantTable`, `AuthorizedRequest`). Authorization decisions belong to the
+  kernel, which alone can bind a capability to a scope and commit the decision to the
+  witness trail.
+- **Receipt sealing** (`ContextEpochReceipt` and friends), which mints signed witness
+  records.
+- **`VerifiedContextProfile.from_rvf`**, which binds a profile to a verified RVF
+  identity. It needs full RVF container bytes and a set of trusted Ed25519 publisher
+  keys — a key-management concern that belongs to the host, not to a naming library.
+
+`ContextScope.containsScope` is included because it is pure name arithmetic, and because
+a JavaScript caller who needs it would otherwise hand-roll a prefix match that drifts
+from the kernel's. Reusing the real implementation is safer than reimplementing it. It
+still is not an access check: only the kernel decides what a capability permits.
+
+## API surface
+
+| Export | Purpose |
+| --- | --- |
+| `RuvUri.parse(text)` | Parse a canonical URI, or throw `RuvUriError`. |
+| `uri.authority` / `.tenant` / `.subjectKind` / `.subjectId` / `.collection` / `.path` | Structured components. |
+| `uri.revision` / `.view` / `.isPinned` | Optional query state. |
+| `uri.toString()` | The one canonical spelling. |
+| `uri.withRevision(rev)` / `.withView(view)` | Derive a pinned or view-selected copy. |
+| `uri.equals(other)` | Structural equality. |
+| `new RuvUriBuilder(authority, tenant, subjectKind, subjectId, collection)` | Validated construction. |
+| `.segment(s)` / `.revision(r)` / `.view(v)` / `.build()` | Builder steps, each returning a new builder. |
+| `ruvUriError(text)` / `isRuvUri(text)` | Non-throwing validation. |
+| `ViewMask.all()` / `.manifest()` / `.view(name)` / `.fromBits(bits)` | Progressive-view masks. |
+| `mask.bits` / `.union(m)` / `.allows(name)` / `.contains(m)` | Mask arithmetic. |
+| `ContextScope.fromUri(uri, mask)` | Derive a namespace region. |
+| `scope.containsScope(child)` | Name containment, not authorization. |
+| `ContextProfile.decode(bytes)` / `.toBytes()` / `.views` / `.view(name)` | Profile codec. |
+| `contractVersion()` | The `ruv://` contract version this binding implements. |
+
+TypeScript declarations are generated by `wasm-bindgen` and ship with the package.
+
+## Building from source
+
+```sh
+node crates/rvm-context-wasm/scripts/build-npm.mjs
+node crates/rvm-context-wasm/tests/smoke.mjs
+```
+
+Requires the `wasm32-unknown-unknown` target and `wasm-pack`.
+
+The Rust-side binding tests run on the real wasm target under Node:
+
+```sh
+wasm-pack test --node crates/rvm-context-wasm
+```
+
+## License
+
+MIT OR Apache-2.0, matching the RVM workspace.

--- a/crates/rvm-context-wasm/README.md
+++ b/crates/rvm-context-wasm/README.md
@@ -1,14 +1,45 @@
-# @ruvnet/rvm-context
+# @ruvnet/rvm-context-wasm
 
-TypeScript and JavaScript bindings for the RVM `ruv://` context namespace, compiled to
-WebAssembly from the Rust [`rvm-context`](https://github.com/ruvnet/rvm/tree/main/crates/rvm-context)
-crate.
-
-This is the **naming and validation layer**. It parses, validates, constructs, and
-canonically formats `ruv://` URIs using the exact same code the RVM kernel uses, so a
-JavaScript tool and the kernel can never disagree about what a name means.
+The RVM `ruv://` context namespace compiled to WebAssembly from the Rust
+[`rvm-context`](https://github.com/ruvnet/rvm/tree/main/crates/rvm-context) crate, with
+TypeScript declarations.
 
 Full namespace documentation: <https://ruvnet.github.io/rvm/ruv-context/>
+
+## Read this first: the wasm module is its own authority
+
+This package hosts a **complete governed context runtime** — its own capability table,
+grant table, witness ring, and deterministic logical clock. That has consequences you
+must understand before using the runtime layer.
+
+Every capability it issues is an **index and a generation into its own live table**. A
+capability handle is not signed, not serializable, and **not portable**. A handle minted
+by a Rust-side service is just two integers that would index a different table here.
+There is no "verify a capability issued elsewhere" API, because that is not
+implementable: the module either owns its authority or it authorizes nothing.
+
+A decision this module renders **binds only to the scope table the host provisioned into
+it**. It is a faithful, deterministic policy simulator — correct for shadow-mode
+evaluation — and it is **not evidence about a separate Rust-side authority** unless that
+authority provisioned the same scopes. Anyone promoting this to enforcement must
+provision the grant table from the same authority that issues real capabilities.
+
+Two further limits, stated plainly rather than buried:
+
+- **Root provisioning runs as the hypervisor.** The core crate refuses root capability
+  creation unless the caller is `PartitionId::HYPERVISOR`. `issueRoot` performs it *as*
+  the hypervisor, which is the concrete form of "its own authority". Treat it as host
+  setup, not as something a partition may do. Everything below a root is subject to the
+  ordinary governed checks.
+- **Receipt signatures are a keyed MAC, not a public signature.** Receipts are signed
+  with HMAC-SHA256, which is symmetric, so verifying one requires the same key that
+  signed it. A caller able to check a receipt is equally able to forge one. Receipt
+  verification here is an integrity check against corruption — it is **not** third-party
+  verifiable evidence. The keyless checks (`verifyWitnessChain`, `witnessDigests`) are
+  the ones that survive a trust boundary.
+
+**The naming layer needs none of this.** `RuvUri` and `ContextScope` are pure and stand
+completely alone — see below.
 
 ## What a `ruv://` URI looks like
 
@@ -24,13 +55,13 @@ about URI equivalence.
 ## Install
 
 ```sh
-npm install @ruvnet/rvm-context
+npm install @ruvnet/rvm-context-wasm
 ```
 
 ## Usage
 
 ```js
-const { RuvUri, RuvUriBuilder, ruvUriError } = require("@ruvnet/rvm-context");
+const { RuvUri, RuvUriBuilder, ruvUriError } = require("@ruvnet/rvm-context-wasm");
 
 const uri = RuvUri.parse(
   "ruv://context.example/acme/agent/researcher/memory/projects/atlas"
@@ -51,7 +82,7 @@ uri.toString();  // the canonical spelling, byte for byte
 An ES module build for browsers and bundlers is published at the `/web` subpath:
 
 ```js
-import init, { RuvUri } from "@ruvnet/rvm-context/web";
+import init, { RuvUri } from "@ruvnet/rvm-context-wasm/web";
 await init();
 ```
 
@@ -108,7 +139,7 @@ and `NonAscii`.
 progressive views it discloses:
 
 ```js
-const { ContextScope, ViewMask } = require("@ruvnet/rvm-context");
+const { ContextScope, ViewMask } = require("@ruvnet/rvm-context-wasm");
 
 const parent = ContextScope.fromUri(RuvUri.parse(base + "/projects"), ViewMask.all());
 const child = ContextScope.fromUri(RuvUri.parse(base + "/projects/atlas"), ViewMask.all());
@@ -140,24 +171,31 @@ anyone may read, write, or execute what it names.
 
 Deliberately **not** exposed:
 
-- **The governed runtime** (`ContextRuntime`, `ExecutionPermit`) and **the resolver**
-  (`ContextResolver`, `MemoryResolver`). These require an authenticated partition
-  identity, a context clock, and live storage. A JavaScript-side actor supplying those
-  would be precisely the forgery the design prevents.
-- **Capability issuance, delegation, and revocation** (`ContextAuthority`,
-  `ContextGrantTable`, `AuthorizedRequest`). Authorization decisions belong to the
-  kernel, which alone can bind a capability to a scope and commit the decision to the
-  witness trail.
-- **Receipt sealing** (`ContextEpochReceipt` and friends), which mints signed witness
-  records.
+- **Any way to verify or import a capability issued by another process.** See above: a
+  handle is a local table index, so this cannot be built.
+- **`default_signer`, `with_default_key`, `derive_witness_key`, and `dev_measurement`.**
+  A well-known or derivable default signing key is indistinguishable from no key at all.
+  The host supplies the 32-byte key or nothing is signed.
 - **`VerifiedContextProfile.from_rvf`**, which binds a profile to a verified RVF
-  identity. It needs full RVF container bytes and a set of trusted Ed25519 publisher
-  keys — a key-management concern that belongs to the host, not to a naming library.
+  identity. It needs full RVF container bytes and trusted publisher keys — a
+  key-management concern that belongs to the host.
 
-`ContextScope.containsScope` is included because it is pure name arithmetic, and because
-a JavaScript caller who needs it would otherwise hand-roll a prefix match that drifts
-from the kernel's. Reusing the real implementation is safer than reimplementing it. It
-still is not an access check: only the kernel decides what a capability permits.
+### Fixed capacities
+
+The core types hold their tables inline, so this module compiles in fixed capacities
+rather than the core defaults. `ContextRuntime.capacities` reports them:
+
+| Table | Slots |
+| --- | --- |
+| Capabilities | 64 |
+| Scope grants | 64 |
+| Witness ring | 1024 |
+| Resolver objects | 64 |
+| Resolver aliases | 64 |
+
+The core witness default is 262,144 records, which as an inline array would reserve
+about 16 MiB inside the module. The ring is sized down here, and the capacity is part of
+this package's published contract.
 
 ## API surface
 
@@ -178,6 +216,44 @@ still is not an access check: only the kernel decides what a capability permits.
 | `scope.containsScope(child)` | Name containment, not authorization. |
 | `ContextProfile.decode(bytes)` / `.toBytes()` / `.views` / `.view(name)` | Profile codec. |
 | `contractVersion()` | The `ruv://` contract version this binding implements. |
+
+
+### Governed runtime
+
+Read the authority caveat at the top before using any of these.
+
+| Export | Purpose |
+| --- | --- |
+| `new ContextRuntime(actorId)` | A runtime bound to an actor, with a deterministic logical clock. |
+| `runtime.issueRoot(scope, rights, owner)` | Host provisioning; runs as the hypervisor. |
+| `runtime.delegate(handle, childScope, rights, owner)` | Narrower delegation; refuses escalation. |
+| `runtime.revoke(handle)` | Revoke a lineage, returning how many capabilities fell. |
+| `runtime.resolve / read / verify / put / list / tree / history / search` | Governed operations. |
+| `runtime.compareAndSwapAlias / forget` | Alias mutation with compare-and-swap. |
+| `runtime.authorizeExecute(handle, uri)` | An execution permit carrying no readable bytes. |
+| `runtime.grant / revokeGoverned` | Delegation and revocation through the witnessed path. |
+| `runtime.sealEpoch(handle, uri, key, commitments)` | Seal an epoch into a signed receipt. |
+| `runtime.witnessSequence` / `.witnessChainHash` / `.witnessRecordCount` | Witness log state. |
+| `runtime.verifyWitnessChain()` | Keyless hash-chain integrity check over its own log. |
+| `runtime.witnessDigests()` | Keyless per-record SHA-256 digests, concatenated. |
+| `ContextRuntime.capacities` | The compiled-in slot counts. |
+| `Rights.forOperation(name)` / `.forOperations(names)` / `.fromNames(names)` | Rights sets. |
+| `new EpochCommitments(namespaceRoot, rvfIdentity, policyHash, detailRoot)` | The four 32-byte epoch roots. |
+
+Each governed result carries `witnessSequence`, the sequence at which the decision was
+recorded.
+
+### Receipt verification
+
+| Export | Purpose |
+| --- | --- |
+| `SignedReceipt.decode(bytes)` / `.toBytes()` | Canonical receipt encoding. |
+| `receipt.receiptId` / `.signerId` / `.signature` | Identity fields. |
+| `receipt.epochId` / `.firstSequence` / `.lastSequence` / `.recordCount` | Epoch coverage. |
+| `receipt.witnessRoot` / `.namespaceRoot` / `.policyHash` / `.previousReceipt` | Commitments. |
+| `receipt.verifySignature(key)` | Keyed MAC check. Not third-party verifiable. |
+| `receipt.verifyGenesis(key)` | MAC check plus a well-formed genesis check. |
+| `receipt.verifySuccessor(previous, key)` | MAC check on both plus the continuity link. |
 
 TypeScript declarations are generated by `wasm-bindgen` and ship with the package.
 

--- a/crates/rvm-context-wasm/build.rs
+++ b/crates/rvm-context-wasm/build.rs
@@ -1,0 +1,23 @@
+//! Raises the wasm stack for this module.
+//!
+//! The governed runtime holds its capability table, grant table, and witness
+//! ring inline: `ContextAuthority` alone is roughly 68 KiB regardless of slot
+//! count, because its proof verifier dominates, and the witness ring adds
+//! another 64 KiB. Constructing that on wasm32 walks through several stack
+//! temporaries in an unoptimized build and exhausts the 1 MiB default stack,
+//! which surfaces as an opaque "memory access out of bounds" rather than a
+//! clean overflow.
+//!
+//! Shrinking the slot counts does not fix it (16 slots still costs ~66 KiB),
+//! so the module asks for a larger stack instead. This travels with the crate,
+//! so a plain `cargo build` and `wasm-pack` both get it without a global
+//! `.cargo/config.toml`.
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        const STACK_SIZE: &str = "-zstack-size=4194304";
+        println!("cargo::rustc-link-arg={STACK_SIZE}");
+        println!("cargo::rustc-link-arg-tests={STACK_SIZE}");
+    }
+}

--- a/crates/rvm-context-wasm/scripts/build-npm.mjs
+++ b/crates/rvm-context-wasm/scripts/build-npm.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Builds the @ruvnet/rvm-context npm package from the rvm-context-wasm crate.
+//
+// wasm-pack derives the npm package name from the crate name, so this script
+// runs both target builds and then rewrites the generated manifest into the
+// scoped package with its CommonJS (Node) and ESM (web) entry points.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const crateDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkgDir = join(crateDir, "pkg");
+const webStageDir = join(crateDir, "pkg-web");
+const webDir = join(pkgDir, "web");
+
+const PACKAGE_NAME = "@ruvnet/rvm-context";
+const ENTRY = "rvm_context_wasm";
+
+function wasmPack(target, outDir) {
+  console.log(`building ${target} -> ${outDir}`);
+  execFileSync(
+    "wasm-pack",
+    ["build", crateDir, "--release", "--target", target, "--out-dir", outDir, "--out-name", ENTRY],
+    { stdio: "inherit" }
+  );
+}
+
+rmSync(pkgDir, { recursive: true, force: true });
+rmSync(webStageDir, { recursive: true, force: true });
+
+// The nodejs build is the package root; the web build lands under ./web.
+wasmPack("nodejs", pkgDir);
+wasmPack("web", webStageDir);
+renameSync(webStageDir, webDir);
+
+// wasm-pack drops a .gitignore that would exclude the whole package from npm
+// tooling that respects it; the repo ignores pkg/ centrally instead.
+for (const stray of [join(pkgDir, ".gitignore"), join(webDir, ".gitignore")]) {
+  rmSync(stray, { force: true });
+}
+
+const manifestPath = join(pkgDir, "package.json");
+const generated = JSON.parse(readFileSync(manifestPath, "utf8"));
+const webManifest = JSON.parse(readFileSync(join(webDir, "package.json"), "utf8"));
+
+const files = [
+  ...new Set([
+    ...(generated.files ?? []),
+    ...(webManifest.files ?? []).map((file) => `web/${file}`),
+    "web/package.json",
+  ]),
+].sort();
+
+const manifest = {
+  name: PACKAGE_NAME,
+  version: generated.version,
+  description:
+    "Canonical ruv:// context URI parsing, validation, and formatting for RVM, compiled to WebAssembly",
+  license: generated.license,
+  repository: { type: "git", url: "git+https://github.com/ruvnet/rvm.git" },
+  homepage: "https://ruvnet.github.io/rvm/ruv-context/",
+  bugs: { url: "https://github.com/ruvnet/rvm/issues" },
+  keywords: ["ruv", "rvm", "uri", "context", "wasm", "webassembly", "namespace"],
+  main: `${ENTRY}.js`,
+  types: `${ENTRY}.d.ts`,
+  exports: {
+    ".": {
+      types: `./${ENTRY}.d.ts`,
+      default: `./${ENTRY}.js`,
+    },
+    "./web": {
+      types: `./web/${ENTRY}.d.ts`,
+      default: `./web/${ENTRY}.js`,
+    },
+    "./package.json": "./package.json",
+  },
+  files,
+  sideEffects: generated.sideEffects ?? false,
+};
+
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+// The nested manifest would otherwise advertise the unscoped crate name.
+writeFileSync(
+  join(webDir, "package.json"),
+  `${JSON.stringify({ type: "module", sideEffects: webManifest.sideEffects ?? false }, null, 2)}\n`
+);
+
+for (const required of [`${ENTRY}.js`, `${ENTRY}.d.ts`, `${ENTRY}_bg.wasm`]) {
+  if (!existsSync(join(pkgDir, required))) {
+    throw new Error(`expected ${required} in the built package`);
+  }
+}
+
+console.log(`\n${PACKAGE_NAME}@${manifest.version} built at ${pkgDir}`);

--- a/crates/rvm-context-wasm/scripts/build-npm.mjs
+++ b/crates/rvm-context-wasm/scripts/build-npm.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Builds the @ruvnet/rvm-context npm package from the rvm-context-wasm crate.
+// Builds the @ruvnet/rvm-context-wasm npm package from the rvm-context-wasm crate.
 //
 // wasm-pack derives the npm package name from the crate name, so this script
 // runs both target builds and then rewrites the generated manifest into the
@@ -15,7 +15,7 @@ const pkgDir = join(crateDir, "pkg");
 const webStageDir = join(crateDir, "pkg-web");
 const webDir = join(pkgDir, "web");
 
-const PACKAGE_NAME = "@ruvnet/rvm-context";
+const PACKAGE_NAME = "@ruvnet/rvm-context-wasm";
 const ENTRY = "rvm_context_wasm";
 
 function wasmPack(target, outDir) {
@@ -57,7 +57,7 @@ const manifest = {
   name: PACKAGE_NAME,
   version: generated.version,
   description:
-    "Canonical ruv:// context URI parsing, validation, and formatting for RVM, compiled to WebAssembly",
+    "The RVM ruv:// context namespace compiled to WebAssembly: canonical URI parsing, scope arithmetic, a self-contained governed runtime, and witness verification",
   license: generated.license,
   repository: { type: "git", url: "git+https://github.com/ruvnet/rvm.git" },
   homepage: "https://ruvnet.github.io/rvm/ruv-context/",

--- a/crates/rvm-context-wasm/src/error.rs
+++ b/crates/rvm-context-wasm/src/error.rs
@@ -1,0 +1,90 @@
+//! JavaScript error construction carrying the originating Rust variant name.
+
+use rvm_context::profile::ContextProfileError;
+use rvm_context::uri::UriError;
+use wasm_bindgen::prelude::*;
+
+/// Builds a JS `Error` whose `name` and `code` identify the failure precisely.
+fn js_error(name: &str, code: &str, message: &str) -> JsValue {
+    let error = js_sys::Error::new(message);
+    error.set_name(name);
+    let _ = js_sys::Reflect::set(
+        error.as_ref(),
+        &JsValue::from_str("code"),
+        &JsValue::from_str(code),
+    );
+    error.into()
+}
+
+/// Returns the stable code for a URI failure.
+///
+/// The code is the Rust variant name so that JS callers can branch on the exact
+/// rejection reason instead of matching on message text.
+#[must_use]
+pub fn uri_error_code(error: UriError) -> &'static str {
+    match error {
+        UriError::UriTooLong => "UriTooLong",
+        UriError::NonAscii => "NonAscii",
+        UriError::InvalidScheme => "InvalidScheme",
+        UriError::PercentEncodingNotAllowed => "PercentEncodingNotAllowed",
+        UriError::FragmentNotAllowed => "FragmentNotAllowed",
+        UriError::CredentialsNotAllowed => "CredentialsNotAllowed",
+        UriError::PortNotAllowed => "PortNotAllowed",
+        UriError::InvalidAuthority => "InvalidAuthority",
+        UriError::InvalidTenant => "InvalidTenant",
+        UriError::InvalidSubjectKind => "InvalidSubjectKind",
+        UriError::InvalidSubjectId => "InvalidSubjectId",
+        UriError::InvalidCollection => "InvalidCollection",
+        UriError::MissingComponent => "MissingComponent",
+        UriError::EmptyPathSegment => "EmptyPathSegment",
+        UriError::TrailingSlash => "TrailingSlash",
+        UriError::DotSegment => "DotSegment",
+        UriError::InvalidPathSegment => "InvalidPathSegment",
+        UriError::TooManyPathSegments => "TooManyPathSegments",
+        UriError::PathTooLong => "PathTooLong",
+        UriError::InvalidQuery => "InvalidQuery",
+        UriError::UnknownQueryKey => "UnknownQueryKey",
+        UriError::DuplicateQueryKey => "DuplicateQueryKey",
+        UriError::QueryOrder => "QueryOrder",
+        UriError::InvalidRevision => "InvalidRevision",
+        UriError::InvalidView => "InvalidView",
+        UriError::RevisionRequired => "RevisionRequired",
+    }
+}
+
+/// Converts a URI failure into a thrown `RuvUriError`.
+#[must_use]
+pub fn uri_error(error: UriError) -> JsValue {
+    js_error("RuvUriError", uri_error_code(error), &error.to_string())
+}
+
+/// Returns the stable code for a context profile failure.
+#[must_use]
+pub fn profile_error_code(error: ContextProfileError) -> &'static str {
+    match error {
+        ContextProfileError::Encoding(_) => "Encoding",
+        ContextProfileError::ContentViewRequired => "ContentViewRequired",
+        ContextProfileError::DuplicateView => "DuplicateView",
+        ContextProfileError::DuplicateSegment => "DuplicateSegment",
+        ContextProfileError::InvalidProvenance => "InvalidProvenance",
+        ContextProfileError::ZeroDigest => "ZeroDigest",
+        ContextProfileError::UnverifiedRvf => "UnverifiedRvf",
+        ContextProfileError::IdentityMismatch => "IdentityMismatch",
+        ContextProfileError::ProfileSegment => "ProfileSegment",
+        ContextProfileError::UntrustedProfile => "UntrustedProfile",
+        ContextProfileError::ViewSegment => "ViewSegment",
+        ContextProfileError::ViewDigestMismatch => "ViewDigestMismatch",
+        ContextProfileError::InvalidRvf => "InvalidRvf",
+        ContextProfileError::RvfTooLarge => "RvfTooLarge",
+    }
+}
+
+/// Converts a profile failure into a thrown `ContextProfileError`.
+#[must_use]
+pub fn profile_error(error: ContextProfileError) -> JsValue {
+    js_error(
+        "ContextProfileError",
+        profile_error_code(error),
+        &error.to_string(),
+    )
+}

--- a/crates/rvm-context-wasm/src/error.rs
+++ b/crates/rvm-context-wasm/src/error.rs
@@ -1,7 +1,10 @@
 //! JavaScript error construction carrying the originating Rust variant name.
 
+use rvm_context::error::ContextError;
 use rvm_context::profile::ContextProfileError;
+use rvm_context::receipt::ContextReceiptError;
 use rvm_context::uri::UriError;
+use rvm_witness::ChainIntegrityError;
 use wasm_bindgen::prelude::*;
 
 /// Builds a JS `Error` whose `name` and `code` identify the failure precisely.
@@ -87,4 +90,106 @@ pub fn profile_error(error: ContextProfileError) -> JsValue {
         profile_error_code(error),
         &error.to_string(),
     )
+}
+
+/// Returns the stable code for a governed context failure.
+#[must_use]
+pub fn context_error_code(error: ContextError) -> &'static str {
+    match error {
+        ContextError::AccessDenied => "AccessDenied",
+        ContextError::GrantTableFull => "GrantTableFull",
+        ContextError::GrantAlreadyBound => "GrantAlreadyBound",
+        ContextError::ScopeEscalation => "ScopeEscalation",
+        ContextError::Capability(_) => "Capability",
+        ContextError::PinnedUriRequired => "PinnedUriRequired",
+        ContextError::VersionlessUriRequired => "VersionlessUriRequired",
+        ContextError::ImmutableRevision => "ImmutableRevision",
+        ContextError::RevisionNotFound => "RevisionNotFound",
+        ContextError::RevisionConflict => "RevisionConflict",
+        ContextError::AliasNotFound => "AliasNotFound",
+        ContextError::AliasConflict => "AliasConflict",
+        ContextError::AliasGenerationExhausted => "AliasGenerationExhausted",
+        ContextError::ObjectTableFull => "ObjectTableFull",
+        ContextError::AliasTableFull => "AliasTableFull",
+        ContextError::ObjectTooLarge => "ObjectTooLarge",
+        ContextError::InvalidQuery => "InvalidQuery",
+        ContextError::InvalidResultLimit => "InvalidResultLimit",
+        ContextError::Tombstoned => "Tombstoned",
+        ContextError::OperationMismatch => "OperationMismatch",
+        ContextError::RevisionHashMismatch => "RevisionHashMismatch",
+        ContextError::RvfVerificationFailed => "RvfVerificationFailed",
+        ContextError::ReceiptSealFailed => "ReceiptSealFailed",
+        ContextError::InvalidTarget => "InvalidTarget",
+        ContextError::ResolverScopeViolation => "ResolverScopeViolation",
+        ContextError::BackendUnavailable => "BackendUnavailable",
+    }
+}
+
+/// Converts a governed context failure into a thrown `ContextError`.
+///
+/// Authorization failures deliberately collapse to `AccessDenied` in the core
+/// crate so that an unauthorized caller cannot probe for existence. That
+/// property is preserved here: this function adds no detail of its own.
+#[must_use]
+pub fn context_error(error: ContextError) -> JsValue {
+    js_error(
+        "ContextError",
+        context_error_code(error),
+        &error.to_string(),
+    )
+}
+
+/// Returns the stable code for a witness chain integrity failure.
+#[must_use]
+pub fn chain_error_code(error: ChainIntegrityError) -> &'static str {
+    match error {
+        ChainIntegrityError::ChainBreak { .. } => "ChainBreak",
+        ChainIntegrityError::RecordCorrupted { .. } => "RecordCorrupted",
+        ChainIntegrityError::EmptyLog => "EmptyLog",
+    }
+}
+
+/// Converts a witness chain failure into a thrown `WitnessChainError`.
+#[must_use]
+pub fn chain_error(error: ChainIntegrityError) -> JsValue {
+    js_error(
+        "WitnessChainError",
+        chain_error_code(error),
+        &error.to_string(),
+    )
+}
+
+/// Returns the stable code for a receipt failure.
+#[must_use]
+pub fn receipt_error_code(error: &ContextReceiptError) -> &'static str {
+    match error {
+        ContextReceiptError::EmptyEpoch => "EmptyEpoch",
+        ContextReceiptError::TooManyRecords => "TooManyRecords",
+        ContextReceiptError::SequenceRange => "SequenceRange",
+        ContextReceiptError::TimestampBounds => "TimestampBounds",
+        ContextReceiptError::Chain(_) => "Chain",
+        ContextReceiptError::Snapshot(_) => "Snapshot",
+        ContextReceiptError::SignerMismatch => "SignerMismatch",
+        ContextReceiptError::Signature(_) => "Signature",
+        ContextReceiptError::Encoding(_) => "Encoding",
+        ContextReceiptError::WitnessRootMismatch => "WitnessRootMismatch",
+        ContextReceiptError::ReceiptContinuity => "ReceiptContinuity",
+    }
+}
+
+/// Converts a receipt failure into a thrown `ContextReceiptError`.
+///
+/// Takes the error by value so it can be used directly as a `map_err`
+/// argument, matching the other converters in this module.
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
+pub fn receipt_error(error: ContextReceiptError) -> JsValue {
+    let code = receipt_error_code(&error);
+    js_error("ContextReceiptError", code, &error.to_string())
+}
+
+/// Builds a thrown error for a binding-level argument failure.
+#[must_use]
+pub fn argument_error(code: &str, message: &str) -> JsValue {
+    js_error("ContextArgumentError", code, message)
 }

--- a/crates/rvm-context-wasm/src/lib.rs
+++ b/crates/rvm-context-wasm/src/lib.rs
@@ -1,0 +1,34 @@
+//! WebAssembly bindings for the RVM `ruv://` context namespace.
+//!
+//! This crate exposes the naming and validation layer of `rvm-context` to
+//! JavaScript: canonical URI parsing and formatting, component construction,
+//! pure scope arithmetic, and the context profile codec.
+//!
+//! It deliberately does not expose the governed runtime, the resolver, grant
+//! issuance, or receipt sealing. Those require an authenticated partition, a
+//! clock, and live capability state; a JavaScript-side actor supplying them
+//! would be exactly the forgery the design prevents. A parsed `ruv://` URI is
+//! a name, never an authorization.
+
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+pub mod error;
+pub mod profile;
+pub mod scope;
+pub mod uri;
+
+pub use profile::{ContextProfile, DerivedView, ProfileView};
+pub use scope::{ContextScope, ViewMask};
+pub use uri::{is_ruv_uri, ruv_uri_error, RuvUri, RuvUriBuilder};
+
+use wasm_bindgen::prelude::*;
+
+/// Version of the RVM `ruv://` namespace contract this binding implements.
+#[wasm_bindgen(js_name = contractVersion)]
+#[must_use]
+pub fn contract_version() -> u32 {
+    rvm_context::RUV_CONTEXT_CONTRACT_VERSION
+}

--- a/crates/rvm-context-wasm/src/lib.rs
+++ b/crates/rvm-context-wasm/src/lib.rs
@@ -1,14 +1,38 @@
 //! WebAssembly bindings for the RVM `ruv://` context namespace.
 //!
-//! This crate exposes the naming and validation layer of `rvm-context` to
-//! JavaScript: canonical URI parsing and formatting, component construction,
-//! pure scope arithmetic, and the context profile codec.
+//! # The wasm module is its own authority
 //!
-//! It deliberately does not expose the governed runtime, the resolver, grant
-//! issuance, or receipt sealing. Those require an authenticated partition, a
-//! clock, and live capability state; a JavaScript-side actor supplying them
-//! would be exactly the forgery the design prevents. A parsed `ruv://` URI is
-//! a name, never an authorization.
+//! Read this before using anything below. This module hosts a complete
+//! governed context runtime: its own capability table, grant table, witness
+//! ring, and deterministic logical clock. Every capability it issues is an
+//! index and a generation into *its own* live table. Handles are not signed,
+//! not serializable, and **not portable** across a process boundary; a handle
+//! minted by a Rust-side service is just two integers that would index a
+//! different table here.
+//!
+//! A decision this module renders binds only to the scope table the host
+//! provisioned into it. It is a faithful, deterministic policy simulator,
+//! correct for shadow-mode evaluation, and it is **not** evidence about a
+//! separate Rust-side authority unless that authority provisioned the same
+//! scopes. Anyone promoting it to enforcement must provision the grant table
+//! from the same authority that issues real capabilities.
+//!
+//! Two consequences worth stating plainly:
+//!
+//! - "Verify a capability issued elsewhere" is not implementable and is not
+//!   offered. The module either owns its authority or authorizes nothing.
+//! - Receipt signatures are HMAC-SHA256, which is symmetric. Verifying one
+//!   requires the key that signed it, so a caller able to check a receipt is
+//!   equally able to forge one. See [`receipt`] for what that does and does
+//!   not establish. The keyless witness-chain and record-digest checks are the
+//!   ones that survive a trust boundary.
+//!
+//! # Layers
+//!
+//! The naming layer stands alone and needs none of the above: [`RuvUri`]
+//! parses and canonically formats names, and [`ContextScope`] compares regions
+//! of the namespace. Scope containment answers "would `ruv://` have allowed
+//! this reach?" with no capability and no runtime involved.
 
 #![deny(missing_docs)]
 #![deny(clippy::all)]
@@ -17,10 +41,19 @@
 
 pub mod error;
 pub mod profile;
+pub mod receipt;
+pub mod rights;
+pub mod runtime;
 pub mod scope;
 pub mod uri;
 
 pub use profile::{ContextProfile, DerivedView, ProfileView};
+pub use receipt::SignedReceipt;
+pub use rights::Rights;
+pub use runtime::{
+    AliasSnapshot, CapabilityHandle, ContextHit, ContextRuntime, EpochCommitments, ExecutionPermit,
+    ReadResult, ResolvedContext,
+};
 pub use scope::{ContextScope, ViewMask};
 pub use uri::{is_ruv_uri, ruv_uri_error, RuvUri, RuvUriBuilder};
 

--- a/crates/rvm-context-wasm/src/profile.rs
+++ b/crates/rvm-context-wasm/src/profile.rs
@@ -1,0 +1,146 @@
+//! Decoding and re-encoding of the deterministic context profile payload.
+//!
+//! This is the fixed-record codec only. Binding a profile to a verified RVF
+//! identity is a separate, key-dependent operation that stays in the kernel.
+
+use crate::error::profile_error;
+use crate::error::uri_error;
+use rvm_context::profile as core_profile;
+use rvm_context::uri::ProgressiveView;
+use wasm_bindgen::prelude::*;
+
+/// The provenance binding a derived representation to its content.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct DerivedView {
+    inner: core_profile::DerivedView,
+}
+
+#[wasm_bindgen]
+impl DerivedView {
+    /// Digest of the full content bytes this view summarizes.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn source(&self) -> String {
+        self.inner.source().to_string()
+    }
+
+    /// Identity of the deterministic generator implementation.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn generator(&self) -> String {
+        self.inner.generator().to_string()
+    }
+
+    /// Identity of the model or algorithm weights.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn model(&self) -> String {
+        self.inner.model().to_string()
+    }
+
+    /// Digest of the exact prompt or transformation configuration.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn prompt(&self) -> String {
+        self.inner.prompt().to_string()
+    }
+
+    /// Digest of the policy governing generation and disclosure.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn policy(&self) -> String {
+        self.inner.policy().to_string()
+    }
+}
+
+/// One progressive representation mapped to an RVF segment.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct ProfileView {
+    inner: core_profile::ProfileView,
+}
+
+#[wasm_bindgen]
+impl ProfileView {
+    /// The representation: `abstract`, `overview`, or `content`.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn view(&self) -> String {
+        self.inner.view().as_str().into()
+    }
+
+    /// The RVF segment holding this representation.
+    #[wasm_bindgen(getter, js_name = segmentId)]
+    #[must_use]
+    pub fn segment_id(&self) -> u64 {
+        self.inner.segment_id()
+    }
+
+    /// The SHA-256 digest of the segment payload.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn payload(&self) -> String {
+        self.inner.payload().to_string()
+    }
+
+    /// The provenance of a derived view, or undefined for the content view.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn provenance(&self) -> Option<DerivedView> {
+        self.inner.provenance().map(|inner| DerivedView { inner })
+    }
+}
+
+/// A decoded, validated set of progressive view mappings.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct ContextProfile {
+    inner: core_profile::ContextProfile,
+}
+
+#[wasm_bindgen]
+impl ContextProfile {
+    /// Decodes and validates a profile payload.
+    ///
+    /// # Errors
+    ///
+    /// Throws a `ContextProfileError` whose `code` names the rejection reason,
+    /// such as `Encoding`, `DuplicateView`, or `ContentViewRequired`.
+    pub fn decode(bytes: &[u8]) -> Result<ContextProfile, JsValue> {
+        core_profile::ContextProfile::from_bytes(bytes)
+            .map(|inner| Self { inner })
+            .map_err(profile_error)
+    }
+
+    /// Re-encodes the canonical payload.
+    #[wasm_bindgen(js_name = toBytes)]
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.inner.to_bytes()
+    }
+
+    /// The view mappings in canonical abstract, overview, content order.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn views(&self) -> Vec<ProfileView> {
+        self.inner
+            .views()
+            .iter()
+            .map(|view| ProfileView { inner: *view })
+            .collect()
+    }
+
+    /// One view mapping by name, or undefined when the profile omits it.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `name` is not a registered progressive view.
+    pub fn view(&self, name: &str) -> Result<Option<ProfileView>, JsValue> {
+        let requested: ProgressiveView = name.parse().map_err(uri_error)?;
+        Ok(self
+            .inner
+            .view(requested)
+            .map(|view| ProfileView { inner: *view }))
+    }
+}

--- a/crates/rvm-context-wasm/src/receipt.rs
+++ b/crates/rvm-context-wasm/src/receipt.rs
@@ -1,0 +1,245 @@
+//! Epoch receipt encoding, decoding, and verification.
+//!
+//! # Receipt signatures are a keyed MAC, not a public signature
+//!
+//! Witness receipts are signed with HMAC-SHA256, which is symmetric.
+//! Verifying a receipt requires the **same 32-byte key that signed it**. A caller holding that key can forge a receipt exactly as easily as it
+//! can check one, so verification here is an integrity check against
+//! corruption, truncation, and accidental mismatch — it is not third-party
+//! verifiable evidence, and a receipt checked in JavaScript proves nothing to
+//! anyone who did not already trust the key holder.
+//!
+//! The keyless checks are the ones that carry weight across a trust boundary:
+//! [`crate::ContextRuntime::verify_witness_chain`] and the record digests,
+//! which are pure functions of the record bytes.
+//!
+//! Receipts are signed through `rvm_proof::WitnessSigner` (a distinct trait
+//! from the same-named one in `rvm-witness`). Its implementations include
+//! `HmacSha256WitnessSigner`, used here, and a feature-gated
+//! `Ed25519WitnessSigner` that this build does not enable — `ed25519` is not a
+//! default feature of `rvm-proof`, and its constructor takes a signing seed
+//! rather than a bare public key, so it would not offer verify-only checking
+//! either.
+//!
+//! The host supplies the key. This module deliberately does not expose
+//! `default_signer`, `with_default_key`, `derive_witness_key`, or
+//! `dev_measurement`: a well-known or derivable default key is
+//! indistinguishable from no key at all.
+
+use crate::error::{argument_error, receipt_error};
+use rvm_context::receipt::{
+    ContextEpochReceipt, SignedContextEpochReceipt, CONTEXT_RECEIPT_ENCODED_SIZE,
+    CONTEXT_RECEIPT_VERSION,
+};
+use rvm_proof::HmacSha256WitnessSigner;
+use wasm_bindgen::prelude::*;
+
+/// The encoded size of a signed receipt in bytes.
+#[wasm_bindgen(js_name = receiptEncodedSize)]
+#[must_use]
+pub fn receipt_encoded_size() -> usize {
+    CONTEXT_RECEIPT_ENCODED_SIZE
+}
+
+/// The receipt format version this binding implements.
+#[wasm_bindgen(js_name = receiptVersion)]
+#[must_use]
+pub fn receipt_version() -> u16 {
+    CONTEXT_RECEIPT_VERSION
+}
+
+pub(crate) fn signer_from_key(key: &[u8]) -> Result<HmacSha256WitnessSigner, JsValue> {
+    let key: [u8; 32] = key.try_into().map_err(|_| {
+        argument_error(
+            "InvalidKeyLength",
+            "the witness HMAC key must be exactly 32 bytes",
+        )
+    })?;
+    Ok(HmacSha256WitnessSigner::new(key))
+}
+
+/// A signed epoch receipt.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct SignedReceipt {
+    inner: SignedContextEpochReceipt,
+}
+
+impl SignedReceipt {
+    pub(crate) fn from_inner(inner: SignedContextEpochReceipt) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl SignedReceipt {
+    /// Decodes a receipt from its canonical byte encoding.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextReceiptError` when the bytes are the wrong length,
+    /// version, or shape.
+    pub fn decode(bytes: &[u8]) -> Result<SignedReceipt, JsValue> {
+        SignedContextEpochReceipt::from_bytes(bytes)
+            .map(|inner| Self { inner })
+            .map_err(receipt_error)
+    }
+
+    /// Encodes the receipt canonically.
+    #[wasm_bindgen(js_name = toBytes)]
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.inner.to_bytes().to_vec()
+    }
+
+    /// The receipt's own identity digest.
+    #[wasm_bindgen(getter, js_name = receiptId)]
+    #[must_use]
+    pub fn receipt_id(&self) -> Vec<u8> {
+        self.inner.receipt_id().to_vec()
+    }
+
+    /// The identity of the key that signed this receipt.
+    #[wasm_bindgen(getter, js_name = signerId)]
+    #[must_use]
+    pub fn signer_id(&self) -> Vec<u8> {
+        self.inner.signer_id().to_vec()
+    }
+
+    /// The raw signature bytes.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn signature(&self) -> Vec<u8> {
+        self.inner.signature().to_vec()
+    }
+
+    /// The epoch this receipt seals.
+    #[wasm_bindgen(getter, js_name = epochId)]
+    #[must_use]
+    pub fn epoch_id(&self) -> u64 {
+        self.receipt().epoch_id()
+    }
+
+    /// The first witness sequence covered.
+    #[wasm_bindgen(getter, js_name = firstSequence)]
+    #[must_use]
+    pub fn first_sequence(&self) -> u64 {
+        self.receipt().first_sequence()
+    }
+
+    /// The last witness sequence covered.
+    #[wasm_bindgen(getter, js_name = lastSequence)]
+    #[must_use]
+    pub fn last_sequence(&self) -> u64 {
+        self.receipt().last_sequence()
+    }
+
+    /// How many witness records the epoch covers.
+    #[wasm_bindgen(getter, js_name = recordCount)]
+    #[must_use]
+    pub fn record_count(&self) -> u32 {
+        self.receipt().record_count()
+    }
+
+    /// The logical timestamp the epoch started at.
+    #[wasm_bindgen(getter, js_name = startedNs)]
+    #[must_use]
+    pub fn started_ns(&self) -> u64 {
+        self.receipt().started_ns()
+    }
+
+    /// The logical timestamp the epoch ended at.
+    #[wasm_bindgen(getter, js_name = endedNs)]
+    #[must_use]
+    pub fn ended_ns(&self) -> u64 {
+        self.receipt().ended_ns()
+    }
+
+    /// The digest of the previous receipt in the chain.
+    #[wasm_bindgen(getter, js_name = previousReceipt)]
+    #[must_use]
+    pub fn previous_receipt(&self) -> Vec<u8> {
+        self.receipt().previous_receipt().to_vec()
+    }
+
+    /// The witness root committed by this receipt.
+    #[wasm_bindgen(getter, js_name = witnessRoot)]
+    #[must_use]
+    pub fn witness_root(&self) -> Vec<u8> {
+        self.receipt().witness_root().to_vec()
+    }
+
+    /// The namespace root committed by this receipt.
+    #[wasm_bindgen(getter, js_name = namespaceRoot)]
+    #[must_use]
+    pub fn namespace_root(&self) -> Vec<u8> {
+        self.receipt().namespace_root().to_vec()
+    }
+
+    /// The policy hash committed by this receipt.
+    #[wasm_bindgen(getter, js_name = policyHash)]
+    #[must_use]
+    pub fn policy_hash(&self) -> Vec<u8> {
+        self.receipt().policy_hash().to_vec()
+    }
+
+    /// Checks the receipt's HMAC against `key`, and that it is a valid genesis
+    /// receipt.
+    ///
+    /// `key` must be the same 32 bytes that signed the receipt. See the module
+    /// documentation: possession of this key is possession of signing power.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextReceiptError` when the signature does not match or the
+    /// receipt is not a well-formed genesis.
+    /// Throws `ContextArgumentError` when `key` is not 32 bytes.
+    #[wasm_bindgen(js_name = verifyGenesis)]
+    pub fn verify_genesis(&self, key: &[u8]) -> Result<(), JsValue> {
+        let signer = signer_from_key(key)?;
+        let verified = self.inner.verify(&signer).map_err(receipt_error)?;
+        verified.verify_genesis().map_err(receipt_error)
+    }
+
+    /// Checks the receipt's HMAC against `key`, and that it validly succeeds
+    /// `previous`.
+    ///
+    /// Both receipts are checked against the same key, since a continuity link
+    /// between receipts signed by different keys establishes nothing.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextReceiptError` when either signature does not match or
+    /// the continuity link to `previous` is broken.
+    /// Throws `ContextArgumentError` when `key` is not 32 bytes.
+    #[wasm_bindgen(js_name = verifySuccessor)]
+    pub fn verify_successor(&self, previous: &SignedReceipt, key: &[u8]) -> Result<(), JsValue> {
+        let signer = signer_from_key(key)?;
+        let previous_verified = previous.inner.verify(&signer).map_err(receipt_error)?;
+        let verified = self.inner.verify(&signer).map_err(receipt_error)?;
+        verified
+            .verify_successor(&previous_verified)
+            .map_err(receipt_error)
+    }
+
+    /// Checks only the receipt's HMAC against `key`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextReceiptError` when the signature does not match.
+    /// Throws `ContextArgumentError` when `key` is not 32 bytes.
+    #[wasm_bindgen(js_name = verifySignature)]
+    pub fn verify_signature(&self, key: &[u8]) -> Result<(), JsValue> {
+        let signer = signer_from_key(key)?;
+        self.inner
+            .verify(&signer)
+            .map(|_| ())
+            .map_err(receipt_error)
+    }
+}
+
+impl SignedReceipt {
+    fn receipt(&self) -> &ContextEpochReceipt {
+        self.inner.receipt()
+    }
+}

--- a/crates/rvm-context-wasm/src/rights.rs
+++ b/crates/rvm-context-wasm/src/rights.rs
@@ -1,0 +1,177 @@
+//! Capability rights, named the way the `ruv://` operations name them.
+
+use crate::error::argument_error;
+use rvm_context::capability::ContextOperation;
+use rvm_types::CapRights;
+use wasm_bindgen::prelude::*;
+
+/// Parses the registered lowercase spelling of a governed operation.
+pub(crate) fn parse_operation(name: &str) -> Result<ContextOperation, JsValue> {
+    Ok(match name {
+        "resolve" => ContextOperation::Resolve,
+        "list" => ContextOperation::List,
+        "tree" => ContextOperation::Tree,
+        "read" => ContextOperation::Read,
+        "search" => ContextOperation::Search,
+        "history" => ContextOperation::History,
+        "verify" => ContextOperation::Verify,
+        "put" => ContextOperation::Put,
+        "compareAndSwapAlias" => ContextOperation::CompareAndSwapAlias,
+        "forget" => ContextOperation::Forget,
+        "execute" => ContextOperation::Execute,
+        "grant" => ContextOperation::Grant,
+        "revoke" => ContextOperation::Revoke,
+        "sealReceipt" => ContextOperation::SealReceipt,
+        other => return Err(argument_error("UnknownOperation", &alloc_format(other))),
+    })
+}
+
+fn alloc_format(name: &str) -> String {
+    format!("unknown context operation: {name}")
+}
+
+const RIGHT_NAMES: [(&str, CapRights); 7] = [
+    ("read", CapRights::READ),
+    ("write", CapRights::WRITE),
+    ("grant", CapRights::GRANT),
+    ("revoke", CapRights::REVOKE),
+    ("execute", CapRights::EXECUTE),
+    ("prove", CapRights::PROVE),
+    ("grantOnce", CapRights::GRANT_ONCE),
+];
+
+/// A set of capability rights.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct Rights {
+    inner: CapRights,
+}
+
+impl Rights {
+    pub(crate) fn inner(self) -> CapRights {
+        self.inner
+    }
+}
+
+#[wasm_bindgen]
+impl Rights {
+    /// The empty rights set.
+    #[must_use]
+    pub fn none() -> Rights {
+        Self {
+            inner: CapRights::empty(),
+        }
+    }
+
+    /// Builds a rights set from names.
+    ///
+    /// Valid names are `read`, `write`, `grant`, `revoke`, `execute`, `prove`,
+    /// and `grantOnce`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextArgumentError` with code `UnknownRight` for any
+    /// unrecognized name.
+    #[wasm_bindgen(js_name = fromNames)]
+    pub fn from_names(names: Vec<String>) -> Result<Rights, JsValue> {
+        let mut inner = CapRights::empty();
+        for name in names {
+            let found = RIGHT_NAMES
+                .iter()
+                .find(|(candidate, _)| *candidate == name.as_str())
+                .ok_or_else(|| {
+                    argument_error("UnknownRight", &format!("unknown capability right: {name}"))
+                })?;
+            inner = inner.union(found.1);
+        }
+        Ok(Self { inner })
+    }
+
+    /// The exact rights a governed operation requires.
+    ///
+    /// This is the authoritative mapping from the core crate, so a caller
+    /// never has to guess which rights an operation needs.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextArgumentError` with code `UnknownOperation` when
+    /// `operation` is not a registered operation name.
+    #[wasm_bindgen(js_name = forOperation)]
+    pub fn for_operation(operation: &str) -> Result<Rights, JsValue> {
+        Ok(Self {
+            inner: parse_operation(operation)?.required_rights(),
+        })
+    }
+
+    /// The union of the rights every named operation requires.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextArgumentError` when any name is not a registered
+    /// operation.
+    #[wasm_bindgen(js_name = forOperations)]
+    pub fn for_operations(operations: Vec<String>) -> Result<Rights, JsValue> {
+        let mut inner = CapRights::empty();
+        for operation in operations {
+            inner = inner.union(parse_operation(&operation)?.required_rights());
+        }
+        Ok(Self { inner })
+    }
+
+    /// The stable bit representation.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn bits(&self) -> u8 {
+        self.inner.bits()
+    }
+
+    /// The names of the rights in this set.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn names(&self) -> Vec<String> {
+        RIGHT_NAMES
+            .iter()
+            .filter(|(_, right)| self.inner.contains(*right))
+            .map(|(name, _)| (*name).into())
+            .collect()
+    }
+
+    /// Combines two rights sets.
+    #[must_use]
+    pub fn union(&self, other: &Rights) -> Rights {
+        Self {
+            inner: self.inner.union(other.inner),
+        }
+    }
+
+    /// Whether `other` is equal to or narrower than this set.
+    #[must_use]
+    pub fn contains(&self, other: &Rights) -> bool {
+        self.inner.contains(other.inner)
+    }
+}
+
+/// The registered governed operation names.
+#[wasm_bindgen(js_name = operationNames)]
+#[must_use]
+pub fn operation_names() -> Vec<String> {
+    [
+        "resolve",
+        "list",
+        "tree",
+        "read",
+        "search",
+        "history",
+        "verify",
+        "put",
+        "compareAndSwapAlias",
+        "forget",
+        "execute",
+        "grant",
+        "revoke",
+        "sealReceipt",
+    ]
+    .iter()
+    .map(|name| (*name).into())
+    .collect()
+}

--- a/crates/rvm-context-wasm/src/runtime.rs
+++ b/crates/rvm-context-wasm/src/runtime.rs
@@ -1,0 +1,838 @@
+//! A self-contained governed context runtime hosted inside the wasm module.
+//!
+//! # The wasm module is its own authority
+//!
+//! This runtime owns its capability table, its grant table, its witness ring,
+//! and its logical clock. Every capability it issues is an index and a
+//! generation into *its own* live table. A [`CapabilityHandle`] is therefore
+//! not a bearer token: it is not signed, not serializable, and not meaningful
+//! to any other process. A handle minted by a Rust-side service is just two
+//! integers that would index a different table here.
+//!
+//! A decision this runtime renders binds only to the scope table the host
+//! provisioned into it. It is a faithful, deterministic policy simulator,
+//! correct for shadow-mode evaluation, and it is **not** evidence about a
+//! separate Rust-side authority unless that authority provisioned the same
+//! scopes. Anyone promoting this to enforcement must provision the grant table
+//! from the same authority that issues real capabilities.
+
+use crate::error::{argument_error, chain_error, context_error};
+use crate::receipt::{signer_from_key, SignedReceipt};
+use crate::rights::Rights;
+use crate::scope::ContextScope;
+use crate::uri::RuvUri;
+use rvm_context::capability::{
+    CapabilityHandle as CoreHandle, ContextAuthority, ContextOperation, ContextRequest,
+};
+use rvm_context::resolver::{
+    AliasSnapshot as CoreAlias, ContextHit as CoreHit, MemoryResolver,
+    ResolvedContext as CoreResolved,
+};
+use rvm_context::runtime::{ContextRuntime as CoreRuntime, ExecutionPermit as CorePermit};
+use rvm_context::uri::Revision;
+use rvm_types::{PartitionId, WitnessRecord};
+use wasm_bindgen::prelude::*;
+
+/// Capability table slots this module provisions.
+pub const CAPABILITY_SLOTS: usize = 64;
+/// Scope grant bindings this module provisions.
+pub const GRANT_SLOTS: usize = 64;
+/// Witness ring records this module retains.
+///
+/// The core default is `rvm_witness::DEFAULT_RING_CAPACITY` (262,144), which
+/// as an inline `[WitnessRecord; N]` would reserve roughly 16 MiB inside the
+/// module. A wasm module cannot spend that, so the ring is sized down here and
+/// the capacity is part of this binding's published contract.
+pub const WITNESS_SLOTS: usize = 1024;
+/// Immutable objects the in-module resolver retains.
+pub const OBJECT_SLOTS: usize = 64;
+/// Aliases the in-module resolver retains.
+pub const ALIAS_SLOTS: usize = 64;
+
+type Resolver = MemoryResolver<OBJECT_SLOTS, ALIAS_SLOTS>;
+type Inner = CoreRuntime<Resolver, CAPABILITY_SLOTS, GRANT_SLOTS, WITNESS_SLOTS>;
+
+/// An index and generation into this module's live capability table.
+///
+/// Not a bearer token. Not portable across a process boundary.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct CapabilityHandle {
+    inner: CoreHandle,
+}
+
+#[wasm_bindgen]
+impl CapabilityHandle {
+    /// The table slot index.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn index(&self) -> u32 {
+        self.inner.index()
+    }
+
+    /// The slot generation, which invalidates stale handles after revocation.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn generation(&self) -> u32 {
+        self.inner.generation()
+    }
+}
+
+/// A revision resolved through the governed runtime.
+#[wasm_bindgen]
+pub struct ResolvedContext {
+    inner: CoreResolved,
+    witness_sequence: u64,
+}
+
+#[wasm_bindgen]
+impl ResolvedContext {
+    /// The pinned URI naming the immutable revision.
+    #[wasm_bindgen(getter, js_name = pinnedUri)]
+    #[must_use]
+    pub fn pinned_uri(&self) -> String {
+        self.inner.pinned_uri().to_string()
+    }
+
+    /// The immutable revision.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn revision(&self) -> String {
+        self.inner.revision().to_string()
+    }
+
+    /// The stored RVF length in bytes.
+    #[wasm_bindgen(getter, js_name = rvfLength)]
+    #[must_use]
+    pub fn rvf_length(&self) -> usize {
+        self.inner.rvf_len()
+    }
+
+    /// The alias snapshot this resolution passed through, when it had one.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn alias(&self) -> Option<AliasSnapshot> {
+        self.inner.alias().map(|alias| AliasSnapshot {
+            inner: alias.clone(),
+        })
+    }
+
+    /// The witness sequence at the moment this decision was recorded.
+    #[wasm_bindgen(getter, js_name = witnessSequence)]
+    #[must_use]
+    pub fn witness_sequence(&self) -> u64 {
+        self.witness_sequence
+    }
+}
+
+/// A mutable alias observed at one generation.
+#[wasm_bindgen]
+pub struct AliasSnapshot {
+    inner: CoreAlias,
+}
+
+#[wasm_bindgen]
+impl AliasSnapshot {
+    /// The versionless alias URI.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn alias(&self) -> String {
+        self.inner.alias().to_string()
+    }
+
+    /// The revision the alias points at.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn revision(&self) -> String {
+        self.inner.revision().to_string()
+    }
+
+    /// The alias generation counter, used for compare-and-swap.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.inner.generation().get()
+    }
+
+    /// Whether the alias has been tombstoned.
+    #[wasm_bindgen(getter, js_name = isTombstone)]
+    #[must_use]
+    pub fn is_tombstone(&self) -> bool {
+        self.inner.is_tombstone()
+    }
+}
+
+/// One search candidate.
+#[wasm_bindgen]
+pub struct ContextHit {
+    inner: CoreHit,
+}
+
+#[wasm_bindgen]
+impl ContextHit {
+    /// The pinned URI of the candidate.
+    #[wasm_bindgen(getter, js_name = pinnedUri)]
+    #[must_use]
+    pub fn pinned_uri(&self) -> String {
+        self.inner.pinned_uri().to_string()
+    }
+
+    /// The candidate revision.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn revision(&self) -> String {
+        self.inner.revision().to_string()
+    }
+
+    /// The relevance score.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn score(&self) -> u32 {
+        self.inner.score()
+    }
+
+    /// The alias generation, when the hit came through an alias.
+    #[wasm_bindgen(getter, js_name = aliasGeneration)]
+    #[must_use]
+    pub fn alias_generation(&self) -> Option<u64> {
+        self.inner
+            .alias_generation()
+            .map(rvm_context::resolver::AliasGeneration::get)
+    }
+}
+
+/// Permission to execute a skill, carrying no readable bytes.
+#[wasm_bindgen]
+pub struct ExecutionPermit {
+    inner: CorePermit,
+}
+
+#[wasm_bindgen]
+impl ExecutionPermit {
+    /// The authenticated actor the permit was issued to.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn actor(&self) -> u32 {
+        self.inner.actor().as_u32()
+    }
+
+    /// The pinned URI the permit authorizes.
+    #[wasm_bindgen(getter, js_name = pinnedUri)]
+    #[must_use]
+    pub fn pinned_uri(&self) -> String {
+        self.inner.pinned_uri().to_string()
+    }
+
+    /// The immutable revision the permit authorizes.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn revision(&self) -> String {
+        self.inner.revision().to_string()
+    }
+
+    /// The hash of the capability that produced the permit.
+    #[wasm_bindgen(getter, js_name = capabilityHash)]
+    #[must_use]
+    pub fn capability_hash(&self) -> u32 {
+        self.inner.capability_hash()
+    }
+
+    /// The witness sequence of the allow record.
+    #[wasm_bindgen(getter, js_name = witnessSequence)]
+    #[must_use]
+    pub fn witness_sequence(&self) -> u64 {
+        self.inner.witness_sequence()
+    }
+}
+
+/// A resolved revision together with its content bytes.
+#[wasm_bindgen]
+pub struct ReadResult {
+    context: ResolvedContext,
+    bytes: Vec<u8>,
+}
+
+#[wasm_bindgen]
+impl ReadResult {
+    /// The resolved revision.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn context(self) -> ResolvedContext {
+        self.context
+    }
+
+    /// The content bytes.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn bytes(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
+}
+
+fn parse_revision(text: &str) -> Result<Revision, JsValue> {
+    text.parse::<Revision>().map_err(crate::error::uri_error)
+}
+
+/// The four 32-byte roots a host binds into a sealed epoch.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct EpochCommitments {
+    namespace_root: [u8; 32],
+    rvf_identity: [u8; 32],
+    policy_hash: [u8; 32],
+    detail_root: [u8; 32],
+}
+
+#[wasm_bindgen]
+impl EpochCommitments {
+    /// Collects the four commitments, each exactly 32 bytes.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextArgumentError` with code `InvalidDigestLength` naming
+    /// the field that was not 32 bytes.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        namespace_root: &[u8],
+        rvf_identity: &[u8],
+        policy_hash: &[u8],
+        detail_root: &[u8],
+    ) -> Result<EpochCommitments, JsValue> {
+        Ok(Self {
+            namespace_root: digest32(namespace_root, "namespaceRoot")?,
+            rvf_identity: digest32(rvf_identity, "rvfIdentity")?,
+            policy_hash: digest32(policy_hash, "policyHash")?,
+            detail_root: digest32(detail_root, "detailRoot")?,
+        })
+    }
+}
+
+/// A governed `ruv://` context runtime, entirely contained in this module.
+///
+/// See the module documentation: this runtime is its own authority, and the
+/// handles it issues are not portable.
+#[wasm_bindgen]
+pub struct ContextRuntime {
+    inner: Inner,
+}
+
+#[wasm_bindgen]
+impl ContextRuntime {
+    /// Creates a runtime bound to `actor`, with an empty authority and store.
+    ///
+    /// The clock is the deterministic `LogicalContextClock`, which counts from
+    /// zero. No host time source is consulted, so identical call sequences
+    /// produce identical witness timestamps.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextArgumentError` when `actor` exceeds the logical
+    /// partition maximum.
+    #[wasm_bindgen(constructor)]
+    pub fn new(actor: u32) -> Result<ContextRuntime, JsValue> {
+        let actor = partition(actor)?;
+        Ok(Self {
+            inner: CoreRuntime::new(
+                actor,
+                ContextAuthority::with_defaults(),
+                MemoryResolver::new(),
+            ),
+        })
+    }
+
+    /// The authenticated actor bound at construction.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn actor(&self) -> u32 {
+        self.inner.actor().as_u32()
+    }
+
+    /// The sequence the next witness record will take.
+    #[wasm_bindgen(getter, js_name = witnessSequence)]
+    #[must_use]
+    pub fn witness_sequence(&self) -> u64 {
+        self.inner.witness_log().checkpoint().next_sequence()
+    }
+
+    /// The witness chain hash immediately before the next record.
+    #[wasm_bindgen(getter, js_name = witnessChainHash)]
+    #[must_use]
+    pub fn witness_chain_hash(&self) -> u64 {
+        self.inner.witness_log().checkpoint().chain_hash()
+    }
+
+    /// The capacities this module was compiled with.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn capacities() -> Vec<u32> {
+        [
+            CAPABILITY_SLOTS,
+            GRANT_SLOTS,
+            WITNESS_SLOTS,
+            OBJECT_SLOTS,
+            ALIAS_SLOTS,
+        ]
+        .iter()
+        .map(|slots| u32::try_from(*slots).unwrap_or(u32::MAX))
+        .collect()
+    }
+
+    /// Provisions a root capability over `scope` with `rights`.
+    ///
+    /// # This is a privileged host step, not a partition-facing request
+    ///
+    /// The core crate refuses root creation unless the caller is
+    /// `PartitionId::HYPERVISOR`; in a real RVM only the kernel may mint a
+    /// root. This module performs it *as* the hypervisor, which is the
+    /// concrete form of "the wasm module is its own authority". The runtime's
+    /// own `actor` is deliberately not used as the caller here, because a
+    /// partition promoting itself to hypervisor is exactly the escalation the
+    /// core check exists to stop.
+    ///
+    /// Treat this as the provisioning API the host calls during setup. Every
+    /// capability below it is then subject to the ordinary governed checks.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` when the capability or grant table is full.
+    #[wasm_bindgen(js_name = issueRoot)]
+    pub fn issue_root(
+        &mut self,
+        scope: &ContextScope,
+        rights: &Rights,
+        owner: u32,
+    ) -> Result<CapabilityHandle, JsValue> {
+        let owner = partition(owner)?;
+        self.inner
+            .authority_mut()
+            .issue_root(
+                scope.inner().clone(),
+                rights.inner(),
+                owner,
+                PartitionId::HYPERVISOR,
+            )
+            .map(|inner| CapabilityHandle { inner })
+            .map_err(context_error)
+    }
+
+    /// Delegates a narrower capability from `source`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` with code `ScopeEscalation` when the child scope
+    /// or rights would widen the parent.
+    pub fn delegate(
+        &mut self,
+        source: &CapabilityHandle,
+        child_scope: &ContextScope,
+        rights: &Rights,
+        target_owner: u32,
+    ) -> Result<CapabilityHandle, JsValue> {
+        let target_owner = partition(target_owner)?;
+        let caller = self.inner.actor();
+        self.inner
+            .authority_mut()
+            .delegate(
+                source.inner,
+                child_scope.inner().clone(),
+                rights.inner(),
+                target_owner,
+                caller,
+            )
+            .map(|inner| CapabilityHandle { inner })
+            .map_err(context_error)
+    }
+
+    /// Revokes a capability lineage, returning how many capabilities fell.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` when the handle is stale or not a context
+    /// capability.
+    pub fn revoke(&mut self, handle: &CapabilityHandle) -> Result<usize, JsValue> {
+        self.inner
+            .authority_mut()
+            .revoke(handle.inner)
+            .map_err(context_error)
+    }
+
+    /// Advances the capability epoch.
+    #[wasm_bindgen(js_name = incrementEpoch)]
+    pub fn increment_epoch(&mut self) {
+        self.inner.authority_mut().increment_epoch();
+    }
+
+    /// Resolves a name to an immutable revision.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError`; authorization failures collapse to
+    /// `AccessDenied` by design.
+    pub fn resolve(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+    ) -> Result<ResolvedContext, JsValue> {
+        let request = request(handle, ContextOperation::Resolve, target);
+        let resolved = self.inner.resolve(&request).map_err(context_error)?;
+        Ok(self.wrap(resolved))
+    }
+
+    /// Verifies a revision and produces proof material.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal.
+    pub fn verify(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+    ) -> Result<ResolvedContext, JsValue> {
+        let request = request(handle, ContextOperation::Verify, target);
+        let resolved = self.inner.verify(&request).map_err(context_error)?;
+        Ok(self.wrap(resolved))
+    }
+
+    /// Reads context bytes.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal.
+    pub fn read(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+    ) -> Result<ReadResult, JsValue> {
+        let request = request(handle, ContextOperation::Read, target);
+        let (resolved, bytes) = self.inner.read(&request).map_err(context_error)?;
+        Ok(ReadResult {
+            context: self.wrap(resolved),
+            bytes,
+        })
+    }
+
+    /// Registers a new immutable whole-RVF revision.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` when the bytes do not hash to the pinned
+    /// revision, or on refusal.
+    pub fn put(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        rvf: &[u8],
+    ) -> Result<ResolvedContext, JsValue> {
+        let request = request(handle, ContextOperation::Put, target);
+        let resolved = self.inner.put(&request, rvf).map_err(context_error)?;
+        Ok(self.wrap(resolved))
+    }
+
+    /// Lists direct children below a path.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal or an invalid limit.
+    pub fn list(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        limit: usize,
+    ) -> Result<Vec<ResolvedContext>, JsValue> {
+        let request = request(handle, ContextOperation::List, target);
+        let found = self.inner.list(&request, limit).map_err(context_error)?;
+        Ok(self.wrap_all(found))
+    }
+
+    /// Traverses containment below a path.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal or an invalid limit.
+    pub fn tree(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        limit: usize,
+    ) -> Result<Vec<ResolvedContext>, JsValue> {
+        let request = request(handle, ContextOperation::Tree, target);
+        let found = self.inner.tree(&request, limit).map_err(context_error)?;
+        Ok(self.wrap_all(found))
+    }
+
+    /// Inspects prior revisions of an alias.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal or an invalid limit.
+    pub fn history(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        limit: usize,
+    ) -> Result<Vec<ResolvedContext>, JsValue> {
+        let request = request(handle, ContextOperation::History, target);
+        let found = self.inner.history(&request, limit).map_err(context_error)?;
+        Ok(self.wrap_all(found))
+    }
+
+    /// Enumerates semantically relevant candidates.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal, an empty query, or an invalid limit.
+    pub fn search(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        query: &[u8],
+        limit: usize,
+    ) -> Result<Vec<ContextHit>, JsValue> {
+        let request = request(handle, ContextOperation::Search, target);
+        let hits = self
+            .inner
+            .search(&request, query, limit)
+            .map_err(context_error)?;
+        Ok(hits.into_iter().map(|inner| ContextHit { inner }).collect())
+    }
+
+    /// Advances an alias with compare-and-swap.
+    ///
+    /// Pass `expected` as undefined to require that the alias does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` with code `AliasConflict` when the observed
+    /// snapshot differs.
+    #[wasm_bindgen(js_name = compareAndSwapAlias)]
+    pub fn compare_and_swap_alias(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        expected: Option<AliasSnapshot>,
+        next_revision: &str,
+    ) -> Result<AliasSnapshot, JsValue> {
+        let revision = parse_revision(next_revision)?;
+        let request = request(handle, ContextOperation::CompareAndSwapAlias, target);
+        let expected = expected.map(|snapshot| snapshot.inner);
+        self.inner
+            .compare_and_swap_alias(&request, expected.as_ref(), revision)
+            .map(|inner| AliasSnapshot { inner })
+            .map_err(context_error)
+    }
+
+    /// Advances an alias to a tombstone.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal or a snapshot conflict.
+    pub fn forget(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        expected: &AliasSnapshot,
+    ) -> Result<AliasSnapshot, JsValue> {
+        let request = request(handle, ContextOperation::Forget, target);
+        self.inner
+            .forget(&request, &expected.inner)
+            .map(|inner| AliasSnapshot { inner })
+            .map_err(context_error)
+    }
+
+    /// Authorizes execution of a skill without disclosing its bytes.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal.
+    #[wasm_bindgen(js_name = authorizeExecute)]
+    pub fn authorize_execute(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+    ) -> Result<ExecutionPermit, JsValue> {
+        let request = request(handle, ContextOperation::Execute, target);
+        self.inner
+            .authorize_execute(&request)
+            .map(|inner| ExecutionPermit { inner })
+            .map_err(context_error)
+    }
+
+    /// Delegates through the governed path, emitting a witness record.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal or scope escalation.
+    pub fn grant(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        child_scope: &ContextScope,
+        rights: &Rights,
+        target_owner: u32,
+    ) -> Result<CapabilityHandle, JsValue> {
+        let target_owner = partition(target_owner)?;
+        let request = request(handle, ContextOperation::Grant, target);
+        self.inner
+            .grant(
+                &request,
+                child_scope.inner().clone(),
+                rights.inner(),
+                target_owner,
+            )
+            .map(|inner| CapabilityHandle { inner })
+            .map_err(context_error)
+    }
+
+    /// Revokes through the governed path, emitting a witness record.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` on refusal.
+    #[wasm_bindgen(js_name = revokeGoverned)]
+    pub fn revoke_governed(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+    ) -> Result<usize, JsValue> {
+        let request = request(handle, ContextOperation::Revoke, target);
+        self.inner.revoke(&request).map_err(context_error)
+    }
+
+    /// Seals the witnessed decisions since the last epoch into a receipt.
+    ///
+    /// `key` is the 32-byte HMAC key the host provisions; this module has no
+    /// default key and will not invent one. The four roots are the commitments
+    /// the host binds into the epoch, each 32 bytes.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ContextError` when the request is refused or the epoch cannot
+    /// be sealed, and `ContextArgumentError` when `key` or a root is not 32
+    /// bytes.
+    #[wasm_bindgen(js_name = sealEpoch)]
+    pub fn seal_epoch(
+        &mut self,
+        handle: &CapabilityHandle,
+        target: &RuvUri,
+        key: &[u8],
+        commitments: &EpochCommitments,
+    ) -> Result<SignedReceipt, JsValue> {
+        let signer = signer_from_key(key)?;
+        let EpochCommitments {
+            namespace_root,
+            rvf_identity,
+            policy_hash,
+            detail_root,
+        } = *commitments;
+        let request = request(handle, ContextOperation::SealReceipt, target);
+        let mut scratch = vec![WitnessRecord::zeroed(); WITNESS_SLOTS];
+        let (sealed, _checkpoint) = self
+            .inner
+            .seal_epoch(
+                &request,
+                &mut scratch,
+                namespace_root,
+                rvf_identity,
+                policy_hash,
+                detail_root,
+                &signer,
+            )
+            .map_err(context_error)?;
+        Ok(SignedReceipt::from_inner(sealed))
+    }
+
+    /// Verifies the integrity of this module's own witness chain.
+    ///
+    /// This check is keyless: it recomputes the hash chain over the retained
+    /// records. It proves the log has not been reordered or truncated in
+    /// memory. It says nothing about any other process's log.
+    ///
+    /// # Errors
+    ///
+    /// Throws `WitnessChainError` on a chain break, a corrupted record, or an
+    /// empty log.
+    #[wasm_bindgen(js_name = verifyWitnessChain)]
+    pub fn verify_witness_chain(&self) -> Result<usize, JsValue> {
+        let records = self.snapshot_records();
+        rvm_witness::verify_chain(&records).map_err(chain_error)
+    }
+
+    /// The SHA-256 digest of every retained witness record, in order.
+    ///
+    /// `record_to_digest` is a pure, keyless function of the record bytes, so
+    /// these digests are the anchor for cross-implementation determinism.
+    #[wasm_bindgen(js_name = witnessDigests)]
+    #[must_use]
+    pub fn witness_digests(&self) -> Vec<u8> {
+        let records = self.snapshot_records();
+        let mut out = Vec::with_capacity(records.len() * 32);
+        for record in &records {
+            out.extend_from_slice(&rvm_witness::record_to_digest(record));
+        }
+        out
+    }
+
+    /// How many witness records are currently retained.
+    #[wasm_bindgen(getter, js_name = witnessRecordCount)]
+    #[must_use]
+    pub fn witness_record_count(&self) -> usize {
+        self.snapshot_records().len()
+    }
+}
+
+fn request(
+    handle: &CapabilityHandle,
+    operation: ContextOperation,
+    target: &RuvUri,
+) -> ContextRequest {
+    ContextRequest::new(handle.inner, operation, target.inner().clone())
+}
+
+impl ContextRuntime {
+    fn wrap(&self, inner: CoreResolved) -> ResolvedContext {
+        ResolvedContext {
+            inner,
+            witness_sequence: self.witness_sequence(),
+        }
+    }
+
+    fn wrap_all(&self, found: Vec<CoreResolved>) -> Vec<ResolvedContext> {
+        let sequence = self.witness_sequence();
+        found
+            .into_iter()
+            .map(|inner| ResolvedContext {
+                inner,
+                witness_sequence: sequence,
+            })
+            .collect()
+    }
+
+    fn snapshot_records(&self) -> Vec<WitnessRecord> {
+        let mut buffer = vec![WitnessRecord::zeroed(); WITNESS_SLOTS];
+        let count = self.inner.witness_log().snapshot(&mut buffer);
+        buffer.truncate(count);
+        buffer
+    }
+}
+
+fn digest32(bytes: &[u8], field: &str) -> Result<[u8; 32], JsValue> {
+    bytes.try_into().map_err(|_| {
+        argument_error(
+            "InvalidDigestLength",
+            &format!("{field} must be exactly 32 bytes"),
+        )
+    })
+}
+
+fn partition(id: u32) -> Result<PartitionId, JsValue> {
+    if id >= PartitionId::MAX_LOGICAL {
+        return Err(argument_error(
+            "InvalidPartitionId",
+            &format!(
+                "partition id {id} is at or beyond the logical maximum {}",
+                PartitionId::MAX_LOGICAL
+            ),
+        ));
+    }
+    Ok(PartitionId::new(id))
+}

--- a/crates/rvm-context-wasm/src/runtime.rs
+++ b/crates/rvm-context-wasm/src/runtime.rs
@@ -473,7 +473,7 @@ impl ContextRuntime {
         handle: &CapabilityHandle,
         target: &RuvUri,
     ) -> Result<ResolvedContext, JsValue> {
-        let request = request(handle, ContextOperation::Resolve, target);
+        let request = request(*handle, ContextOperation::Resolve, target);
         let resolved = self.inner.resolve(&request).map_err(context_error)?;
         Ok(self.wrap(resolved))
     }
@@ -488,7 +488,7 @@ impl ContextRuntime {
         handle: &CapabilityHandle,
         target: &RuvUri,
     ) -> Result<ResolvedContext, JsValue> {
-        let request = request(handle, ContextOperation::Verify, target);
+        let request = request(*handle, ContextOperation::Verify, target);
         let resolved = self.inner.verify(&request).map_err(context_error)?;
         Ok(self.wrap(resolved))
     }
@@ -503,7 +503,7 @@ impl ContextRuntime {
         handle: &CapabilityHandle,
         target: &RuvUri,
     ) -> Result<ReadResult, JsValue> {
-        let request = request(handle, ContextOperation::Read, target);
+        let request = request(*handle, ContextOperation::Read, target);
         let (resolved, bytes) = self.inner.read(&request).map_err(context_error)?;
         Ok(ReadResult {
             context: self.wrap(resolved),
@@ -523,7 +523,7 @@ impl ContextRuntime {
         target: &RuvUri,
         rvf: &[u8],
     ) -> Result<ResolvedContext, JsValue> {
-        let request = request(handle, ContextOperation::Put, target);
+        let request = request(*handle, ContextOperation::Put, target);
         let resolved = self.inner.put(&request, rvf).map_err(context_error)?;
         Ok(self.wrap(resolved))
     }
@@ -539,7 +539,7 @@ impl ContextRuntime {
         target: &RuvUri,
         limit: usize,
     ) -> Result<Vec<ResolvedContext>, JsValue> {
-        let request = request(handle, ContextOperation::List, target);
+        let request = request(*handle, ContextOperation::List, target);
         let found = self.inner.list(&request, limit).map_err(context_error)?;
         Ok(self.wrap_all(found))
     }
@@ -555,7 +555,7 @@ impl ContextRuntime {
         target: &RuvUri,
         limit: usize,
     ) -> Result<Vec<ResolvedContext>, JsValue> {
-        let request = request(handle, ContextOperation::Tree, target);
+        let request = request(*handle, ContextOperation::Tree, target);
         let found = self.inner.tree(&request, limit).map_err(context_error)?;
         Ok(self.wrap_all(found))
     }
@@ -571,7 +571,7 @@ impl ContextRuntime {
         target: &RuvUri,
         limit: usize,
     ) -> Result<Vec<ResolvedContext>, JsValue> {
-        let request = request(handle, ContextOperation::History, target);
+        let request = request(*handle, ContextOperation::History, target);
         let found = self.inner.history(&request, limit).map_err(context_error)?;
         Ok(self.wrap_all(found))
     }
@@ -588,7 +588,7 @@ impl ContextRuntime {
         query: &[u8],
         limit: usize,
     ) -> Result<Vec<ContextHit>, JsValue> {
-        let request = request(handle, ContextOperation::Search, target);
+        let request = request(*handle, ContextOperation::Search, target);
         let hits = self
             .inner
             .search(&request, query, limit)
@@ -613,7 +613,7 @@ impl ContextRuntime {
         next_revision: &str,
     ) -> Result<AliasSnapshot, JsValue> {
         let revision = parse_revision(next_revision)?;
-        let request = request(handle, ContextOperation::CompareAndSwapAlias, target);
+        let request = request(*handle, ContextOperation::CompareAndSwapAlias, target);
         let expected = expected.map(|snapshot| snapshot.inner);
         self.inner
             .compare_and_swap_alias(&request, expected.as_ref(), revision)
@@ -632,7 +632,7 @@ impl ContextRuntime {
         target: &RuvUri,
         expected: &AliasSnapshot,
     ) -> Result<AliasSnapshot, JsValue> {
-        let request = request(handle, ContextOperation::Forget, target);
+        let request = request(*handle, ContextOperation::Forget, target);
         self.inner
             .forget(&request, &expected.inner)
             .map(|inner| AliasSnapshot { inner })
@@ -650,7 +650,7 @@ impl ContextRuntime {
         handle: &CapabilityHandle,
         target: &RuvUri,
     ) -> Result<ExecutionPermit, JsValue> {
-        let request = request(handle, ContextOperation::Execute, target);
+        let request = request(*handle, ContextOperation::Execute, target);
         self.inner
             .authorize_execute(&request)
             .map(|inner| ExecutionPermit { inner })
@@ -671,7 +671,7 @@ impl ContextRuntime {
         target_owner: u32,
     ) -> Result<CapabilityHandle, JsValue> {
         let target_owner = partition(target_owner)?;
-        let request = request(handle, ContextOperation::Grant, target);
+        let request = request(*handle, ContextOperation::Grant, target);
         self.inner
             .grant(
                 &request,
@@ -694,7 +694,7 @@ impl ContextRuntime {
         handle: &CapabilityHandle,
         target: &RuvUri,
     ) -> Result<usize, JsValue> {
-        let request = request(handle, ContextOperation::Revoke, target);
+        let request = request(*handle, ContextOperation::Revoke, target);
         self.inner.revoke(&request).map_err(context_error)
     }
 
@@ -724,7 +724,7 @@ impl ContextRuntime {
             policy_hash,
             detail_root,
         } = *commitments;
-        let request = request(handle, ContextOperation::SealReceipt, target);
+        let request = request(*handle, ContextOperation::SealReceipt, target);
         let mut scratch = vec![WitnessRecord::zeroed(); WITNESS_SLOTS];
         let (sealed, _checkpoint) = self
             .inner
@@ -781,7 +781,7 @@ impl ContextRuntime {
 }
 
 fn request(
-    handle: &CapabilityHandle,
+    handle: CapabilityHandle,
     operation: ContextOperation,
     target: &RuvUri,
 ) -> ContextRequest {

--- a/crates/rvm-context-wasm/src/scope.rs
+++ b/crates/rvm-context-wasm/src/scope.rs
@@ -106,6 +106,12 @@ impl ViewMask {
     }
 }
 
+impl ContextScope {
+    pub(crate) fn inner(&self) -> &CoreScope {
+        &self.inner
+    }
+}
+
 impl ViewMask {
     pub(crate) fn from_inner(inner: ContextViewMask) -> Self {
         Self { inner }
@@ -199,5 +205,22 @@ impl ContextScope {
     #[must_use]
     pub fn contains_scope(&self, child: &ContextScope) -> bool {
         self.inner.contains_scope(&child.inner)
+    }
+
+    /// Whether `uri` names something inside this region.
+    ///
+    /// This is the shadow-mode question — "would `ruv://` have allowed this
+    /// reach?" — answered with no capability, no runtime, and no witness
+    /// record. It compares the authority, tenant, subject, collection, and
+    /// path prefix.
+    ///
+    /// It is name containment only. It is **not** an access check: it does not
+    /// consult rights, and it cannot tell you whether any caller holds a
+    /// capability over this region. Only the kernel decides that.
+    #[wasm_bindgen(js_name = containsUri)]
+    #[must_use]
+    pub fn contains_uri(&self, uri: &RuvUri) -> bool {
+        let target = CoreScope::from_uri(uri.inner(), self.inner.views());
+        self.inner.contains_scope(&target)
     }
 }

--- a/crates/rvm-context-wasm/src/scope.rs
+++ b/crates/rvm-context-wasm/src/scope.rs
@@ -1,0 +1,203 @@
+//! Pure scope arithmetic: view masks and name containment.
+//!
+//! Nothing here decides access. These are predicates over names, exposed so
+//! that JavaScript callers reuse the kernel's own comparison instead of
+//! hand-rolling a prefix match that drifts from it.
+
+use crate::error::uri_error;
+use crate::uri::RuvUri;
+use rvm_context::capability::ContextScope as CoreScope;
+use rvm_context::capability::ContextViewMask;
+use rvm_context::uri::ProgressiveView;
+use wasm_bindgen::prelude::*;
+
+/// A bit mask over the progressive representations a scope may disclose.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct ViewMask {
+    inner: ContextViewMask,
+}
+
+#[wasm_bindgen]
+impl ViewMask {
+    /// The mask permitting every v1 representation.
+    #[must_use]
+    pub fn all() -> ViewMask {
+        Self {
+            inner: ContextViewMask::ALL,
+        }
+    }
+
+    /// The mask permitting manifest metadata only.
+    #[must_use]
+    pub fn manifest() -> ViewMask {
+        Self {
+            inner: ContextViewMask::MANIFEST,
+        }
+    }
+
+    /// The mask permitting exactly one progressive view.
+    ///
+    /// `name` is `abstract`, `overview`, or `content`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `name` is not a registered progressive view.
+    pub fn view(name: &str) -> Result<ViewMask, JsValue> {
+        let view: ProgressiveView = name.parse().map_err(uri_error)?;
+        let inner = match view {
+            ProgressiveView::Abstract => ContextViewMask::ABSTRACT,
+            ProgressiveView::Overview => ContextViewMask::OVERVIEW,
+            ProgressiveView::Content => ContextViewMask::CONTENT,
+        };
+        Ok(Self { inner })
+    }
+
+    /// Rebuilds a mask from its stable bit representation.
+    ///
+    /// # Errors
+    ///
+    /// Throws `ViewMaskError` when `bits` is zero or sets a reserved bit.
+    #[wasm_bindgen(js_name = fromBits)]
+    pub fn from_bits(bits: u8) -> Result<ViewMask, JsValue> {
+        ContextViewMask::from_bits(bits)
+            .map(|inner| Self { inner })
+            .ok_or_else(|| {
+                let error = js_sys::Error::new("view mask bits are zero or reserved");
+                error.set_name("ViewMaskError");
+                let _ = js_sys::Reflect::set(
+                    error.as_ref(),
+                    &JsValue::from_str("code"),
+                    &JsValue::from_str("InvalidViewMask"),
+                );
+                error.into()
+            })
+    }
+
+    /// The stable bit representation.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn bits(&self) -> u8 {
+        self.inner.bits()
+    }
+
+    /// Combines two masks.
+    #[must_use]
+    pub fn union(&self, other: &ViewMask) -> ViewMask {
+        Self {
+            inner: self.inner.union(other.inner),
+        }
+    }
+
+    /// Whether this mask permits a named progressive view.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `name` is not a registered progressive view.
+    pub fn allows(&self, name: &str) -> Result<bool, JsValue> {
+        let view: ProgressiveView = name.parse().map_err(uri_error)?;
+        Ok(self.inner.allows(view))
+    }
+
+    /// Whether `other` is equal to or narrower than this mask.
+    #[must_use]
+    pub fn contains(&self, other: &ViewMask) -> bool {
+        self.inner.contains(other.inner)
+    }
+}
+
+impl ViewMask {
+    pub(crate) fn from_inner(inner: ContextViewMask) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) fn inner(self) -> ContextViewMask {
+        self.inner
+    }
+}
+
+/// A namespace and path-prefix region, derived from a URI.
+///
+/// A scope is a description of a region of the namespace. Comparing scopes
+/// tells you how two names relate; it does not tell you what a caller may do.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct ContextScope {
+    inner: CoreScope,
+}
+
+#[wasm_bindgen]
+impl ContextScope {
+    /// Derives the scope rooted at `uri` disclosing `views`.
+    ///
+    /// A revision or view on `uri` is not part of the region.
+    #[wasm_bindgen(js_name = fromUri)]
+    #[must_use]
+    pub fn from_uri(uri: &RuvUri, views: &ViewMask) -> ContextScope {
+        Self {
+            inner: CoreScope::from_uri(uri.inner(), views.inner()),
+        }
+    }
+
+    /// The bound authority.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn authority(&self) -> String {
+        self.inner.authority().as_str().into()
+    }
+
+    /// The bound tenant.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn tenant(&self) -> String {
+        self.inner.tenant().as_str().into()
+    }
+
+    /// The bound subject category.
+    #[wasm_bindgen(getter, js_name = subjectKind)]
+    #[must_use]
+    pub fn subject_kind(&self) -> String {
+        self.inner.subject().kind().as_str().into()
+    }
+
+    /// The bound subject identifier.
+    #[wasm_bindgen(getter, js_name = subjectId)]
+    #[must_use]
+    pub fn subject_id(&self) -> String {
+        self.inner.subject().id().as_str().into()
+    }
+
+    /// The bound collection.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn collection(&self) -> String {
+        self.inner.collection().as_str().into()
+    }
+
+    /// The path segments every name in this region starts with.
+    #[wasm_bindgen(getter, js_name = pathPrefix)]
+    #[must_use]
+    pub fn path_prefix(&self) -> Vec<String> {
+        self.inner
+            .path_prefix()
+            .iter()
+            .map(|segment| segment.as_str().into())
+            .collect()
+    }
+
+    /// The representations this region discloses.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn views(&self) -> ViewMask {
+        ViewMask::from_inner(self.inner.views())
+    }
+
+    /// Whether `child` is equal to or narrower than this region.
+    ///
+    /// This is a comparison of names, not an authorization decision.
+    #[wasm_bindgen(js_name = containsScope)]
+    #[must_use]
+    pub fn contains_scope(&self, child: &ContextScope) -> bool {
+        self.inner.contains_scope(&child.inner)
+    }
+}

--- a/crates/rvm-context-wasm/src/uri.rs
+++ b/crates/rvm-context-wasm/src/uri.rs
@@ -1,0 +1,278 @@
+//! Canonical `ruv://` URI parsing, construction, and formatting for JavaScript.
+
+use crate::error::{uri_error, uri_error_code};
+use rvm_context::uri as core_uri;
+use wasm_bindgen::prelude::*;
+
+/// A validated canonical `ruv://` URI.
+///
+/// Holding one grants nothing. It is a name that has been proven well formed,
+/// not a token that authorizes access to what it names.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct RuvUri {
+    inner: core_uri::RuvUri,
+}
+
+impl RuvUri {
+    pub(crate) fn from_inner(inner: core_uri::RuvUri) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) fn inner(&self) -> &core_uri::RuvUri {
+        &self.inner
+    }
+}
+
+#[wasm_bindgen]
+impl RuvUri {
+    /// Parses a URI, rejecting every noncanonical spelling.
+    ///
+    /// # Errors
+    ///
+    /// Throws a `RuvUriError` whose `code` names the exact rejection reason,
+    /// such as `InvalidTenant`, `TrailingSlash`, or `DotSegment`.
+    pub fn parse(text: &str) -> Result<RuvUri, JsValue> {
+        core_uri::RuvUri::parse(text)
+            .map(Self::from_inner)
+            .map_err(uri_error)
+    }
+
+    /// The canonical lowercase DNS authority.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn authority(&self) -> String {
+        self.inner.authority().as_str().into()
+    }
+
+    /// The canonical tenant slug.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn tenant(&self) -> String {
+        self.inner.tenant().as_str().into()
+    }
+
+    /// The subject category: `agent`, `user`, `service`, or `team`.
+    #[wasm_bindgen(getter, js_name = subjectKind)]
+    #[must_use]
+    pub fn subject_kind(&self) -> String {
+        self.inner.subject().kind().as_str().into()
+    }
+
+    /// The canonical subject slug.
+    #[wasm_bindgen(getter, js_name = subjectId)]
+    #[must_use]
+    pub fn subject_id(&self) -> String {
+        self.inner.subject().id().as_str().into()
+    }
+
+    /// The top-level collection: `memory`, `resources`, or `skills`.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn collection(&self) -> String {
+        self.inner.collection().as_str().into()
+    }
+
+    /// The case-sensitive path segments below the collection.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn path(&self) -> Vec<String> {
+        self.inner
+            .path()
+            .iter()
+            .map(|segment| segment.as_str().into())
+            .collect()
+    }
+
+    /// The pinned revision as `sha256:<64 hex digits>`, or undefined when the
+    /// URI is a mutable alias.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn revision(&self) -> Option<String> {
+        self.inner.revision().map(|rev| rev.to_string())
+    }
+
+    /// The requested progressive view, or undefined when none was requested.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn view(&self) -> Option<String> {
+        self.inner.view().map(|view| view.as_str().into())
+    }
+
+    /// Whether this URI names an immutable revision rather than an alias.
+    #[wasm_bindgen(getter, js_name = isPinned)]
+    #[must_use]
+    pub fn is_pinned(&self) -> bool {
+        self.inner.is_pinned()
+    }
+
+    /// Renders the one canonical spelling of this URI.
+    #[wasm_bindgen(js_name = toString)]
+    #[must_use]
+    pub fn render(&self) -> String {
+        self.inner.to_string()
+    }
+
+    /// Returns a copy pinned to `revision`, given as `sha256:<64 hex digits>`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `revision` is malformed or the result would
+    /// exceed the URI byte limit.
+    #[wasm_bindgen(js_name = withRevision)]
+    pub fn with_revision(&self, revision: &str) -> Result<RuvUri, JsValue> {
+        let parsed: core_uri::Revision = revision.parse().map_err(uri_error)?;
+        self.inner
+            .clone()
+            .with_revision(parsed)
+            .map(|pinned| Self::from_inner(pinned.into_uri()))
+            .map_err(uri_error)
+    }
+
+    /// Returns a copy requesting `view`: `abstract`, `overview`, or `content`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `view` is unregistered or the result would
+    /// exceed the URI byte limit.
+    #[wasm_bindgen(js_name = withView)]
+    pub fn with_view(&self, view: &str) -> Result<RuvUri, JsValue> {
+        let parsed: core_uri::ProgressiveView = view.parse().map_err(uri_error)?;
+        self.inner
+            .clone()
+            .with_view(parsed)
+            .map(Self::from_inner)
+            .map_err(uri_error)
+    }
+
+    /// Whether two URIs name exactly the same thing.
+    #[must_use]
+    pub fn equals(&self, other: &RuvUri) -> bool {
+        self.inner == other.inner
+    }
+}
+
+/// Reports why `text` is not a canonical `ruv://` URI without throwing.
+///
+/// Returns the error code, or undefined when `text` parses.
+#[wasm_bindgen(js_name = ruvUriError)]
+#[must_use]
+pub fn ruv_uri_error(text: &str) -> Option<String> {
+    core_uri::RuvUri::parse(text)
+        .err()
+        .map(|error| uri_error_code(error).into())
+}
+
+/// Whether `text` is a canonical `ruv://` URI.
+#[wasm_bindgen(js_name = isRuvUri)]
+#[must_use]
+pub fn is_ruv_uri(text: &str) -> bool {
+    core_uri::RuvUri::parse(text).is_ok()
+}
+
+/// Builds a canonical `ruv://` URI from validated components.
+///
+/// Every method returns a new builder, so a builder value can be reused safely.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct RuvUriBuilder {
+    authority: core_uri::Authority,
+    tenant: core_uri::TenantId,
+    subject: core_uri::Subject,
+    collection: core_uri::Collection,
+    path: Vec<core_uri::PathSegment>,
+    revision: Option<core_uri::Revision>,
+    view: Option<core_uri::ProgressiveView>,
+}
+
+#[wasm_bindgen]
+impl RuvUriBuilder {
+    /// Validates the five required components of every `ruv://` name.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` naming the component that failed validation.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        authority: &str,
+        tenant: &str,
+        subject_kind: &str,
+        subject_id: &str,
+        collection: &str,
+    ) -> Result<RuvUriBuilder, JsValue> {
+        let authority = core_uri::Authority::new(authority).map_err(uri_error)?;
+        let tenant = core_uri::TenantId::new(tenant).map_err(uri_error)?;
+        let kind: core_uri::SubjectKind = subject_kind.parse().map_err(uri_error)?;
+        let id = core_uri::SubjectId::new(subject_id).map_err(uri_error)?;
+        let collection: core_uri::Collection = collection.parse().map_err(uri_error)?;
+        Ok(Self {
+            authority,
+            tenant,
+            subject: core_uri::Subject::new(kind, id),
+            collection,
+            path: Vec::new(),
+            revision: None,
+            view: None,
+        })
+    }
+
+    /// Appends one validated path segment below the collection.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `segment` is empty, a dot segment, too long,
+    /// or contains a character outside the unreserved set.
+    pub fn segment(&self, segment: &str) -> Result<RuvUriBuilder, JsValue> {
+        let segment = core_uri::PathSegment::new(segment).map_err(uri_error)?;
+        let mut next = self.clone();
+        next.path.push(segment);
+        Ok(next)
+    }
+
+    /// Pins the name to `revision`, given as `sha256:<64 hex digits>`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `revision` is not `sha256:` followed by 64
+    /// lowercase hexadecimal digits.
+    pub fn revision(&self, revision: &str) -> Result<RuvUriBuilder, JsValue> {
+        let revision = revision.parse().map_err(uri_error)?;
+        let mut next = self.clone();
+        next.revision = Some(revision);
+        Ok(next)
+    }
+
+    /// Requests `view`: `abstract`, `overview`, or `content`.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when `view` is not a registered progressive view.
+    pub fn view(&self, view: &str) -> Result<RuvUriBuilder, JsValue> {
+        let view = view.parse().map_err(uri_error)?;
+        let mut next = self.clone();
+        next.view = Some(view);
+        Ok(next)
+    }
+
+    /// Validates aggregate limits and produces the URI.
+    ///
+    /// # Errors
+    ///
+    /// Throws `RuvUriError` when the path or complete URI exceeds its limit.
+    pub fn build(&self) -> Result<RuvUri, JsValue> {
+        let mut builder = core_uri::RuvUri::builder(
+            self.authority.clone(),
+            self.tenant.clone(),
+            self.subject.clone(),
+            self.collection,
+        )
+        .path(self.path.clone());
+        if let Some(revision) = self.revision {
+            builder = builder.revision(revision);
+        }
+        if let Some(view) = self.view {
+            builder = builder.view(view);
+        }
+        builder.build().map(RuvUri::from_inner).map_err(uri_error)
+    }
+}

--- a/crates/rvm-context-wasm/tests/binding.rs
+++ b/crates/rvm-context-wasm/tests/binding.rs
@@ -421,3 +421,286 @@ fn distinct_revisions_produce_distinct_uris() {
     assert!(!a.equals(&b));
     assert_ne!(a.render(), b.render());
 }
+
+// ---------------------------------------------------------------------------
+// Governed runtime
+//
+// These are wasm-only because every rejection path constructs a JsValue.
+// ---------------------------------------------------------------------------
+
+use rvm_context_wasm::{ContextRuntime, EpochCommitments, Rights};
+
+const BASE: &str = "ruv://context.example/acme/agent/researcher/memory";
+
+fn runtime_with_root(
+    scope_uri: &str,
+    operations: &[&str],
+) -> (ContextRuntime, rvm_context_wasm::CapabilityHandle) {
+    let mut runtime = ContextRuntime::new(7).expect("actor in range");
+    let root = RuvUri::parse(scope_uri).expect("scope root parses");
+    let scope = ContextScope::from_uri(&root, &ViewMask::all());
+    let rights = Rights::for_operations(operations.iter().map(|op| (*op).into()).collect())
+        .expect("registered operations");
+    let handle = runtime
+        .issue_root(&scope, &rights, 7)
+        .expect("root capability issues");
+    (runtime, handle)
+}
+
+#[wasm_bindgen_test]
+fn runtime_issues_and_revokes_a_root_capability() {
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve", "read"]);
+    assert_eq!(runtime.actor(), 7);
+    // The generation is an opaque staleness counter; only its role matters,
+    // which `a_stale_handle_is_refused_after_revocation` covers.
+    let felled = runtime.revoke(&handle).expect("revocation succeeds");
+    assert!(felled >= 1, "revoking a root should fell at least itself");
+}
+
+#[wasm_bindgen_test]
+fn a_stale_handle_is_refused_after_revocation() {
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve"]);
+    runtime.revoke(&handle).expect("revocation succeeds");
+    let target = RuvUri::parse(BASE).expect("parses");
+    let error = runtime
+        .resolve(&handle, &target)
+        .err()
+        .expect("a revoked handle must not resolve");
+    assert_eq!(thrown_code(&error), "AccessDenied");
+}
+
+#[wasm_bindgen_test]
+fn a_cross_tenant_reach_is_refused() {
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve", "read"]);
+    // Same shape, different tenant.
+    let other_tenant =
+        RuvUri::parse("ruv://context.example/other/agent/researcher/memory").expect("parses");
+    let error = runtime
+        .resolve(&handle, &other_tenant)
+        .err()
+        .expect("a cross-tenant reach must be refused");
+    assert_eq!(thrown_code(&error), "AccessDenied");
+
+    // Same tenant, different subject.
+    let other_subject =
+        RuvUri::parse("ruv://context.example/acme/agent/other/memory").expect("parses");
+    assert_eq!(
+        thrown_code(
+            &runtime
+                .resolve(&handle, &other_subject)
+                .err()
+                .expect("refused")
+        ),
+        "AccessDenied"
+    );
+
+    // Same subject, different collection.
+    let other_collection =
+        RuvUri::parse("ruv://context.example/acme/agent/researcher/skills").expect("parses");
+    assert_eq!(
+        thrown_code(
+            &runtime
+                .resolve(&handle, &other_collection)
+                .err()
+                .expect("refused")
+        ),
+        "AccessDenied"
+    );
+}
+
+#[wasm_bindgen_test]
+fn a_reach_outside_the_path_prefix_is_refused_at_the_last_segment() {
+    // The scope is pinned three segments deep. The violating segment is at the
+    // LAST prefix position: a containment check inside a short-circuiting loop
+    // would pass position 1 and still be wrong here.
+    let (mut runtime, handle) = runtime_with_root(&format!("{BASE}/a/b/c"), &["resolve"]);
+
+    let diverges_last = RuvUri::parse(&format!("{BASE}/a/b/X")).expect("parses");
+    assert_eq!(
+        thrown_code(
+            &runtime
+                .resolve(&handle, &diverges_last)
+                .err()
+                .expect("divergence at the last prefix segment must be refused")
+        ),
+        "AccessDenied"
+    );
+
+    let diverges_middle = RuvUri::parse(&format!("{BASE}/a/X/c")).expect("parses");
+    assert_eq!(
+        thrown_code(
+            &runtime
+                .resolve(&handle, &diverges_middle)
+                .err()
+                .expect("divergence in the middle must be refused")
+        ),
+        "AccessDenied"
+    );
+
+    // A strict ancestor of the scope is also outside it.
+    let ancestor = RuvUri::parse(&format!("{BASE}/a/b")).expect("parses");
+    assert_eq!(
+        thrown_code(&runtime.resolve(&handle, &ancestor).err().expect("refused")),
+        "AccessDenied"
+    );
+}
+
+#[wasm_bindgen_test]
+fn rights_are_enforced_per_operation() {
+    // Read-only rights must not authorize a write.
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve"]);
+    let pinned = RuvUri::parse(&format!("{BASE}?rev={ZERO_REV}")).expect("parses");
+    let error = runtime
+        .put(&handle, &pinned, &[0_u8; 8])
+        .err()
+        .expect("a read-only capability must not put");
+    assert_eq!(thrown_code(&error), "AccessDenied");
+}
+
+#[wasm_bindgen_test]
+fn delegation_cannot_widen_the_parent_scope() {
+    let (mut runtime, handle) = runtime_with_root(&format!("{BASE}/a/b"), &["resolve", "grant"]);
+
+    // Widening the path prefix upward must be refused.
+    let wider = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{BASE}/a")).expect("parses"),
+        &ViewMask::all(),
+    );
+    let rights = Rights::for_operation("resolve").expect("registered");
+    let error = runtime
+        .delegate(&handle, &wider, &rights, 7)
+        .err()
+        .expect("widening the scope must be refused");
+    assert_eq!(thrown_code(&error), "ScopeEscalation");
+
+    // Narrowing is allowed.
+    let narrower = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{BASE}/a/b/c")).expect("parses"),
+        &ViewMask::all(),
+    );
+    let child = runtime
+        .delegate(&handle, &narrower, &rights, 7)
+        .expect("narrowing delegation succeeds");
+    assert!(child.index() != handle.index() || child.generation() != handle.generation());
+}
+
+#[wasm_bindgen_test]
+fn delegation_cannot_widen_the_view_mask() {
+    let narrow_views = ViewMask::view("abstract").expect("view");
+    let mut runtime = ContextRuntime::new(7).expect("actor in range");
+    let root = RuvUri::parse(BASE).expect("parses");
+    let scope = ContextScope::from_uri(&root, &narrow_views);
+    let rights = Rights::for_operations(vec!["resolve".into(), "grant".into()]).expect("rights");
+    let handle = runtime.issue_root(&scope, &rights, 7).expect("root issues");
+
+    let wider = ContextScope::from_uri(&root, &ViewMask::all());
+    let error = runtime
+        .delegate(&handle, &wider, &rights, 7)
+        .err()
+        .expect("widening the view mask must be refused");
+    assert_eq!(thrown_code(&error), "ScopeEscalation");
+}
+
+#[wasm_bindgen_test]
+fn the_witness_log_records_decisions_and_verifies() {
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve", "read"]);
+    let before = runtime.witness_sequence();
+
+    let outside =
+        RuvUri::parse("ruv://context.example/other/agent/researcher/memory").expect("parses");
+    let _ = runtime.resolve(&handle, &outside);
+    let target = RuvUri::parse(BASE).expect("parses");
+    let _ = runtime.resolve(&handle, &target);
+
+    let after = runtime.witness_sequence();
+    assert!(
+        after > before,
+        "governed decisions must advance the witness sequence: {before} -> {after}"
+    );
+    assert_eq!(
+        runtime.witness_record_count() as u64,
+        after,
+        "retained record count should match the sequence for a short session"
+    );
+
+    // The keyless chain check must pass over the module's own log.
+    let verified = runtime
+        .verify_witness_chain()
+        .expect("the module's own chain verifies");
+    assert_eq!(verified as u64, after);
+
+    // Digests are 32 bytes each and cover every retained record.
+    let digests = runtime.witness_digests();
+    assert_eq!(digests.len(), runtime.witness_record_count() * 32);
+}
+
+#[wasm_bindgen_test]
+fn the_logical_clock_makes_sessions_reproducible() {
+    let first = scripted_witness_digests();
+    let second = scripted_witness_digests();
+    assert_eq!(
+        first, second,
+        "two identical sessions must produce identical witness digests"
+    );
+    assert!(!first.is_empty(), "the session recorded nothing");
+}
+
+fn scripted_witness_digests() -> Vec<u8> {
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve", "read"]);
+    let outside =
+        RuvUri::parse("ruv://context.example/other/agent/researcher/memory").expect("parses");
+    let _ = runtime.resolve(&handle, &outside);
+    runtime.witness_digests()
+}
+
+#[wasm_bindgen_test]
+fn rights_names_round_trip() {
+    let rights = Rights::from_names(vec!["read".into(), "write".into(), "prove".into()])
+        .expect("known rights");
+    assert_eq!(rights.names(), vec!["read", "write", "prove"]);
+    assert_eq!(
+        thrown_code(
+            &Rights::from_names(vec!["admin".into()])
+                .err()
+                .expect("rejected")
+        ),
+        "UnknownRight"
+    );
+    assert_eq!(
+        thrown_code(&Rights::for_operation("teleport").err().expect("rejected")),
+        "UnknownOperation"
+    );
+}
+
+#[wasm_bindgen_test]
+fn an_out_of_range_partition_is_refused() {
+    let error = ContextRuntime::new(4096).err().expect("rejected");
+    assert_eq!(thrown_code(&error), "InvalidPartitionId");
+    assert!(ContextRuntime::new(4095).is_ok());
+}
+
+#[wasm_bindgen_test]
+fn receipt_verification_requires_a_thirty_two_byte_key() {
+    let (mut runtime, handle) = runtime_with_root(BASE, &["resolve", "sealReceipt"]);
+    let target = RuvUri::parse(BASE).expect("parses");
+    let _ = runtime.resolve(&handle, &target);
+    let commitments = EpochCommitments::new(&[0; 32], &[0; 32], &[0; 32], &[0; 32])
+        .expect("32-byte roots are accepted");
+    let error = runtime
+        .seal_epoch(&handle, &target, &[0_u8; 8], &commitments)
+        .err()
+        .expect("a short key must be refused");
+    assert_eq!(thrown_code(&error), "InvalidKeyLength");
+
+    // A commitment of the wrong length names the field that was wrong.
+    let error = EpochCommitments::new(&[0; 32], &[0; 31], &[0; 32], &[0; 32])
+        .err()
+        .expect("a short root must be refused");
+    assert_eq!(thrown_code(&error), "InvalidDigestLength");
+}
+
+#[wasm_bindgen_test]
+fn capacities_are_published() {
+    let capacities = ContextRuntime::capacities();
+    assert_eq!(capacities, vec![64_u32, 64, 1024, 64, 64]);
+}

--- a/crates/rvm-context-wasm/tests/binding.rs
+++ b/crates/rvm-context-wasm/tests/binding.rs
@@ -1,0 +1,423 @@
+//! Binding tests exercised on the real wasm32 target under Node.
+
+use rvm_context::profile::{DerivedView as CoreDerived, ProfileView as CoreView};
+use rvm_context::uri::{ProgressiveView, Revision};
+use rvm_context_wasm::{ContextProfile, ContextScope, RuvUri, RuvUriBuilder, ViewMask};
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+const CANONICAL: &str = "ruv://context.example/acme/agent/researcher/memory";
+const ZERO_REV: &str = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+const ONE_REV: &str = "sha256:0000000000000000000000000000000000000000000000000000000000000001";
+
+/// Reads the `code` property off a thrown JS error.
+fn thrown_code(error: &JsValue) -> String {
+    js_sys::Reflect::get(error, &JsValue::from_str("code"))
+        .expect("error has a code property")
+        .as_string()
+        .expect("code is a string")
+}
+
+fn expect_rejection(text: &str, expected_code: &str) {
+    let error = RuvUri::parse(text).err().unwrap_or_else(|| {
+        panic!("expected {text} to be rejected as {expected_code}, but it parsed")
+    });
+    assert_eq!(thrown_code(&error), expected_code, "for input {text}");
+    assert_eq!(
+        rvm_context_wasm::ruv_uri_error(text).as_deref(),
+        Some(expected_code),
+        "non-throwing probe disagrees for {text}"
+    );
+    assert!(!rvm_context_wasm::is_ruv_uri(text));
+}
+
+#[wasm_bindgen_test]
+fn canonical_uri_parses_into_components() {
+    let uri = RuvUri::parse(CANONICAL).expect("canonical URI parses");
+    assert_eq!(uri.authority(), "context.example");
+    assert_eq!(uri.tenant(), "acme");
+    assert_eq!(uri.subject_kind(), "agent");
+    assert_eq!(uri.subject_id(), "researcher");
+    assert_eq!(uri.collection(), "memory");
+    assert!(uri.path().is_empty());
+    assert_eq!(uri.revision(), None);
+    assert_eq!(uri.view(), None);
+    assert!(!uri.is_pinned());
+}
+
+#[wasm_bindgen_test]
+fn full_uri_exposes_path_revision_and_view() {
+    let text = format!(
+        "ruv://context.example/acme/team/core/resources/Specs/API_v1?rev={ZERO_REV}&view=overview"
+    );
+    let uri = RuvUri::parse(&text).expect("full URI parses");
+    assert_eq!(uri.path(), vec!["Specs".to_string(), "API_v1".to_string()]);
+    assert_eq!(uri.revision().as_deref(), Some(ZERO_REV));
+    assert_eq!(uri.view().as_deref(), Some("overview"));
+    assert!(uri.is_pinned());
+    assert_eq!(uri.subject_kind(), "team");
+    assert_eq!(uri.collection(), "resources");
+}
+
+#[wasm_bindgen_test]
+fn parse_format_round_trips_exactly() {
+    let cases = [
+        CANONICAL.to_string(),
+        "ruv://context.example/acme/user/alice/skills/deploy".to_string(),
+        format!("{CANONICAL}?rev={ZERO_REV}"),
+        format!("{CANONICAL}?view=content"),
+        format!("{CANONICAL}?rev={ZERO_REV}&view=abstract"),
+        "ruv://a.b.c/t/service/api/resources/A/b-c/d.e/f_g/h~i".to_string(),
+    ];
+    for text in cases {
+        let uri = RuvUri::parse(&text).expect("case parses");
+        assert_eq!(uri.render(), text, "round trip changed the spelling");
+        let again = RuvUri::parse(&uri.render()).expect("reparse succeeds");
+        assert!(again.equals(&uri));
+    }
+}
+
+#[wasm_bindgen_test]
+fn each_rejection_class_reports_its_own_code() {
+    expect_rejection(
+        "ruv://context.example/ACME/agent/researcher/memory",
+        "InvalidTenant",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher/memory/",
+        "TrailingSlash",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher/memory/../secrets",
+        "DotSegment",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher//memory",
+        "EmptyPathSegment",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher/memory/a%2Fb",
+        "PercentEncodingNotAllowed",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher/memory#section",
+        "FragmentNotAllowed",
+    );
+    expect_rejection(
+        "ruv://user:pw@context.example/acme/agent/researcher/memory",
+        "CredentialsNotAllowed",
+    );
+    expect_rejection(
+        "ruv://context.example:8443/acme/agent/researcher/memory",
+        "PortNotAllowed",
+    );
+}
+
+#[wasm_bindgen_test]
+fn other_noncanonical_spellings_are_rejected() {
+    expect_rejection("https://context.example/a/agent/b/memory", "InvalidScheme");
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher",
+        "MissingComponent",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/Agent/researcher/memory",
+        "InvalidSubjectKind",
+    );
+    expect_rejection(
+        "ruv://context.example/acme/agent/researcher/Memory",
+        "InvalidCollection",
+    );
+    expect_rejection(&format!("{CANONICAL}?rev=sha256:beef"), "InvalidRevision");
+    expect_rejection(&format!("{CANONICAL}?view=Overview"), "InvalidView");
+    expect_rejection(&format!("{CANONICAL}?depth=2"), "UnknownQueryKey");
+    expect_rejection(
+        &format!("{CANONICAL}?view=content&rev={ZERO_REV}"),
+        "QueryOrder",
+    );
+}
+
+#[wasm_bindgen_test]
+fn thrown_errors_are_real_js_errors() {
+    let error = RuvUri::parse("ruv://context.example/ACME/agent/researcher/memory")
+        .err()
+        .expect("rejected");
+    assert!(error.is_instance_of::<js_sys::Error>());
+    let error: js_sys::Error = error.unchecked_into();
+    assert_eq!(error.name(), "RuvUriError");
+    assert_eq!(
+        String::from(error.message()),
+        "invalid canonical tenant slug"
+    );
+}
+
+#[wasm_bindgen_test]
+fn builder_constructs_the_canonical_spelling() {
+    let uri = RuvUriBuilder::new("context.example", "acme", "team", "core", "resources")
+        .expect("components validate")
+        .segment("Specs")
+        .expect("segment validates")
+        .segment("API_v1")
+        .expect("segment validates")
+        .revision(ZERO_REV)
+        .expect("revision validates")
+        .view("overview")
+        .expect("view validates")
+        .build()
+        .expect("aggregate limits hold");
+    assert_eq!(
+        uri.render(),
+        format!("ruv://context.example/acme/team/core/resources/Specs/API_v1?rev={ZERO_REV}&view=overview")
+    );
+}
+
+#[wasm_bindgen_test]
+fn builder_reports_the_component_that_failed() {
+    let cases = [
+        (
+            ("Context.Example", "acme", "agent", "a", "memory"),
+            "InvalidAuthority",
+        ),
+        (
+            ("context.example", "ACME", "agent", "a", "memory"),
+            "InvalidTenant",
+        ),
+        (
+            ("context.example", "acme", "robot", "a", "memory"),
+            "InvalidSubjectKind",
+        ),
+        (
+            ("context.example", "acme", "agent", "-bad", "memory"),
+            "InvalidSubjectId",
+        ),
+        (
+            ("context.example", "acme", "agent", "a", "notes"),
+            "InvalidCollection",
+        ),
+    ];
+    for ((authority, tenant, kind, id, collection), code) in cases {
+        let error = RuvUriBuilder::new(authority, tenant, kind, id, collection)
+            .err()
+            .unwrap_or_else(|| panic!("expected {code}"));
+        assert_eq!(thrown_code(&error), code);
+    }
+}
+
+#[wasm_bindgen_test]
+fn builder_values_are_reusable_across_branches() {
+    let base = RuvUriBuilder::new("context.example", "acme", "agent", "researcher", "memory")
+        .expect("components validate");
+    let first = base
+        .segment("alpha")
+        .expect("segment")
+        .build()
+        .expect("build");
+    let second = base
+        .segment("beta")
+        .expect("segment")
+        .build()
+        .expect("build");
+    assert_eq!(first.render(), format!("{CANONICAL}/alpha"));
+    assert_eq!(second.render(), format!("{CANONICAL}/beta"));
+}
+
+#[wasm_bindgen_test]
+fn with_revision_and_with_view_extend_a_parsed_uri() {
+    let uri = RuvUri::parse(CANONICAL).expect("parses");
+    let pinned = uri.with_revision(ZERO_REV).expect("revision validates");
+    assert!(pinned.is_pinned());
+    assert_eq!(pinned.render(), format!("{CANONICAL}?rev={ZERO_REV}"));
+
+    let viewed = pinned.with_view("content").expect("view validates");
+    assert_eq!(
+        viewed.render(),
+        format!("{CANONICAL}?rev={ZERO_REV}&view=content")
+    );
+
+    assert_eq!(
+        thrown_code(&uri.with_revision("sha256:zz").err().expect("rejected")),
+        "InvalidRevision"
+    );
+    assert_eq!(
+        thrown_code(&uri.with_view("full").err().expect("rejected")),
+        "InvalidView"
+    );
+}
+
+#[wasm_bindgen_test]
+fn view_masks_compose_and_reject_reserved_bits() {
+    let all = ViewMask::all();
+    let content = ViewMask::view("content").expect("view name");
+    let abstract_only = ViewMask::view("abstract").expect("view name");
+
+    assert!(all.contains(&content));
+    assert!(!content.contains(&all));
+    assert!(all.allows("overview").expect("view name"));
+    assert!(!abstract_only.allows("content").expect("view name"));
+
+    let combined = content.union(&abstract_only);
+    assert!(combined.contains(&content));
+    assert!(combined.contains(&abstract_only));
+    assert_eq!(
+        ViewMask::from_bits(combined.bits())
+            .expect("round trips")
+            .bits(),
+        combined.bits()
+    );
+
+    assert_eq!(
+        thrown_code(&ViewMask::from_bits(0).err().expect("rejected")),
+        "InvalidViewMask"
+    );
+    assert_eq!(
+        thrown_code(&ViewMask::from_bits(0x10).err().expect("rejected")),
+        "InvalidViewMask"
+    );
+    assert_eq!(
+        thrown_code(&ViewMask::view("raw").err().expect("rejected")),
+        "InvalidView"
+    );
+}
+
+#[wasm_bindgen_test]
+fn scope_containment_follows_the_path_prefix() {
+    let parent_uri = RuvUri::parse(&format!("{CANONICAL}/projects")).expect("parses");
+    let child_uri = RuvUri::parse(&format!("{CANONICAL}/projects/atlas")).expect("parses");
+    let other_uri = RuvUri::parse(&format!("{CANONICAL}/archive")).expect("parses");
+
+    let parent = ContextScope::from_uri(&parent_uri, &ViewMask::all());
+    let child = ContextScope::from_uri(&child_uri, &ViewMask::all());
+    let other = ContextScope::from_uri(&other_uri, &ViewMask::all());
+
+    assert!(parent.contains_scope(&child));
+    assert!(!child.contains_scope(&parent));
+    assert!(!parent.contains_scope(&other));
+
+    assert_eq!(parent.authority(), "context.example");
+    assert_eq!(parent.tenant(), "acme");
+    assert_eq!(parent.subject_kind(), "agent");
+    assert_eq!(parent.subject_id(), "researcher");
+    assert_eq!(parent.collection(), "memory");
+    assert_eq!(parent.path_prefix(), vec!["projects".to_string()]);
+
+    // A narrower view mask is contained; a wider one is not.
+    let narrow = ContextScope::from_uri(&child_uri, &ViewMask::view("abstract").expect("view"));
+    assert!(parent.contains_scope(&narrow));
+    let wide = ContextScope::from_uri(&parent_uri, &ViewMask::view("abstract").expect("view"));
+    assert!(!wide.contains_scope(&child));
+}
+
+#[wasm_bindgen_test]
+fn scope_ignores_the_revision_and_view_of_its_root() {
+    let plain = RuvUri::parse(&format!("{CANONICAL}/notes")).expect("parses");
+    let decorated =
+        RuvUri::parse(&format!("{CANONICAL}/notes?rev={ZERO_REV}&view=content")).expect("parses");
+    let a = ContextScope::from_uri(&plain, &ViewMask::all());
+    let b = ContextScope::from_uri(&decorated, &ViewMask::all());
+    assert!(a.contains_scope(&b));
+    assert!(b.contains_scope(&a));
+}
+
+fn sample_profile_bytes() -> Vec<u8> {
+    let content_digest = Revision::sha256([1_u8; 32]);
+    let provenance = CoreDerived::new(
+        content_digest,
+        Revision::sha256([2_u8; 32]),
+        Revision::sha256([3_u8; 32]),
+        Revision::sha256([4_u8; 32]),
+        Revision::sha256([5_u8; 32]),
+    )
+    .expect("provenance digests are nonzero");
+    let views = vec![
+        CoreView::content(10, content_digest).expect("content view"),
+        CoreView::derived(
+            ProgressiveView::Abstract,
+            11,
+            Revision::sha256([6_u8; 32]),
+            provenance,
+        )
+        .expect("abstract view"),
+    ];
+    rvm_context::profile::ContextProfile::new(views)
+        .expect("profile validates")
+        .to_bytes()
+}
+
+#[wasm_bindgen_test]
+fn profile_decodes_and_round_trips() {
+    let bytes = sample_profile_bytes();
+    let profile = ContextProfile::decode(&bytes).expect("payload decodes");
+    assert_eq!(profile.to_bytes(), bytes, "re-encode is not byte identical");
+
+    let views = profile.views();
+    assert_eq!(views.len(), 2);
+    assert_eq!(views[0].view(), "abstract");
+    assert_eq!(views[1].view(), "content");
+
+    let content = profile
+        .view("content")
+        .expect("view name")
+        .expect("content view is present");
+    assert_eq!(content.segment_id(), 10);
+    assert_eq!(
+        content.payload(),
+        "sha256:0101010101010101010101010101010101010101010101010101010101010101"
+    );
+    assert!(content.provenance().is_none());
+
+    let derived = profile
+        .view("abstract")
+        .expect("view name")
+        .expect("abstract view is present");
+    let provenance = derived
+        .provenance()
+        .expect("derived views carry provenance");
+    assert_eq!(provenance.source(), content.payload());
+    assert_eq!(
+        provenance.generator(),
+        "sha256:0202020202020202020202020202020202020202020202020202020202020202"
+    );
+
+    assert!(profile.view("overview").expect("view name").is_none());
+}
+
+#[wasm_bindgen_test]
+fn profile_rejects_corrupt_payloads() {
+    let bytes = sample_profile_bytes();
+
+    let mut wrong_magic = bytes.clone();
+    wrong_magic[0] = b'X';
+    assert_eq!(
+        thrown_code(
+            &ContextProfile::decode(&wrong_magic)
+                .err()
+                .expect("rejected")
+        ),
+        "Encoding"
+    );
+
+    let truncated = &bytes[..bytes.len() - 1];
+    assert_eq!(
+        thrown_code(&ContextProfile::decode(truncated).err().expect("rejected")),
+        "Encoding"
+    );
+
+    assert_eq!(
+        thrown_code(&ContextProfile::decode(&[]).err().expect("rejected")),
+        "Encoding"
+    );
+}
+
+#[wasm_bindgen_test]
+fn contract_version_is_exposed() {
+    assert_eq!(rvm_context_wasm::contract_version(), 1);
+}
+
+#[wasm_bindgen_test]
+fn distinct_revisions_produce_distinct_uris() {
+    let base = RuvUri::parse(CANONICAL).expect("parses");
+    let a = base.with_revision(ZERO_REV).expect("revision");
+    let b = base.with_revision(ONE_REV).expect("revision");
+    assert!(!a.equals(&b));
+    assert_ne!(a.render(), b.render());
+}

--- a/crates/rvm-context-wasm/tests/determinism.rs
+++ b/crates/rvm-context-wasm/tests/determinism.rs
@@ -1,0 +1,231 @@
+//! Cross-implementation determinism.
+//!
+//! Every assertion here runs twice: natively via `cargo test`, and on
+//! `wasm32-unknown-unknown` under Node via `wasm-pack test --node`. The
+//! expected values are hardcoded, so if the two targets ever disagree about
+//! canonical bytes, one of the two runs fails rather than drifting silently.
+//!
+//! This is the property that keeps policy scopes, witness records, signatures,
+//! and caches from disagreeing about identity across targets.
+//!
+//! Only success paths appear here: constructing a `JsValue` error outside wasm
+//! panics, so rejection behaviour lives in `binding.rs`, which is wasm-only.
+
+use rvm_context_wasm::{ContextScope, Rights, RuvUri, RuvUriBuilder, ViewMask};
+use rvm_types::WitnessRecord;
+
+const AUTHORITY: &str = "context.example";
+const TENANT: &str = "acme";
+const ZERO_REV: &str = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Canonical URI formatting must be byte-identical on both targets.
+fn canonical_uri_bytes_are_stable() {
+    let cases: [&str; 5] = [
+        "ruv://context.example/acme/agent/researcher/memory",
+        "ruv://context.example/acme/team/core/resources/Specs/API_v1",
+        "ruv://a.b.c/t/service/api/skills/deploy?view=content",
+        "ruv://context.example/acme/user/alice/memory?rev=sha256:0000000000000000000000000000000000000000000000000000000000000000&view=abstract",
+        "ruv://context.example/acme/agent/r/resources/A/b-c/d.e/f_g/h~i",
+    ];
+    for input in cases {
+        let uri = RuvUri::parse(input).expect("case parses");
+        assert_eq!(uri.render(), input, "canonical spelling drifted");
+        assert_eq!(
+            hex(uri.render().as_bytes()),
+            hex(input.as_bytes()),
+            "canonical bytes drifted"
+        );
+        // Reparsing the rendered form is a fixed point.
+        let again = RuvUri::parse(&uri.render()).expect("reparses");
+        assert!(again.equals(&uri));
+    }
+}
+
+/// The builder must produce exactly the bytes the parser accepts.
+fn builder_and_parser_agree() {
+    let built = RuvUriBuilder::new(AUTHORITY, TENANT, "agent", "researcher", "memory")
+        .expect("components validate")
+        .segment("projects")
+        .expect("segment validates")
+        .segment("atlas")
+        .expect("segment validates")
+        .revision(ZERO_REV)
+        .expect("revision validates")
+        .build()
+        .expect("limits hold");
+    let expected =
+        format!("ruv://context.example/acme/agent/researcher/memory/projects/atlas?rev={ZERO_REV}");
+    assert_eq!(built.render(), expected);
+    assert!(
+        RuvUri::parse(&expected).expect("parses").equals(&built),
+        "builder and parser disagree"
+    );
+}
+
+/// Rights bits are a stable wire value and must not drift.
+fn rights_bits_are_stable() {
+    let expectations: [(&str, u8); 7] = [
+        ("resolve", 0x01),
+        ("read", 0x01),
+        ("put", 0x02),
+        ("grant", 0x04),
+        ("revoke", 0x08),
+        ("execute", 0x10),
+        ("sealReceipt", 0x20),
+    ];
+    for (operation, bits) in expectations {
+        let rights = Rights::for_operation(operation).expect("registered operation");
+        assert_eq!(rights.bits(), bits, "rights bits drifted for {operation}");
+    }
+    // Verify requires READ and PROVE together.
+    assert_eq!(
+        Rights::for_operation("verify").expect("registered").bits(),
+        0x21
+    );
+}
+
+/// View mask bits are a stable wire value.
+fn view_mask_bits_are_stable() {
+    assert_eq!(ViewMask::all().bits(), 0x0f);
+    assert_eq!(ViewMask::manifest().bits(), 0x01);
+    assert_eq!(ViewMask::view("abstract").expect("view").bits(), 0x02);
+    assert_eq!(ViewMask::view("overview").expect("view").bits(), 0x04);
+    assert_eq!(ViewMask::view("content").expect("view").bits(), 0x08);
+}
+
+/// Scope containment is a pure predicate and must agree on both targets.
+///
+/// The violating segment sits at the LAST position of the path. A containment
+/// check written as a short-circuiting loop is green for position 1 while
+/// broken for positions 2..n, so probing only the first position proves
+/// nothing.
+fn scope_containment_agrees() {
+    let base = "ruv://context.example/acme/agent/researcher/memory";
+    let parent = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{base}/a/b/c")).expect("parses"),
+        &ViewMask::all(),
+    );
+
+    // Diverges only at the final prefix segment.
+    let last_position = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{base}/a/b/X")).expect("parses"),
+        &ViewMask::all(),
+    );
+    assert!(
+        !parent.contains_scope(&last_position),
+        "divergence at the last prefix segment was not caught"
+    );
+
+    // Diverges at the first segment, the easy case.
+    let first_position = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{base}/X/b/c")).expect("parses"),
+        &ViewMask::all(),
+    );
+    assert!(!parent.contains_scope(&first_position));
+
+    // A genuine descendant is contained, at depth beyond the prefix.
+    let descendant = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{base}/a/b/c/d/e")).expect("parses"),
+        &ViewMask::all(),
+    );
+    assert!(parent.contains_scope(&descendant));
+
+    // A strict ancestor is not contained by its child.
+    let ancestor = ContextScope::from_uri(
+        &RuvUri::parse(&format!("{base}/a/b")).expect("parses"),
+        &ViewMask::all(),
+    );
+    assert!(!parent.contains_scope(&ancestor));
+    assert!(ancestor.contains_scope(&parent));
+}
+
+/// `record_to_digest` is keyless and pure, so its output must be identical on
+/// both targets for the same record. This is the anchor that stops witness
+/// identity from diverging between the Rust service and the wasm module.
+fn witness_record_digests_are_stable() {
+    let digests: Vec<String> = scripted_records()
+        .iter()
+        .map(|record| hex(&rvm_witness::record_to_digest(record)))
+        .collect();
+
+    assert_eq!(
+        digests, EXPECTED_RECORD_DIGESTS,
+        "witness record digests drifted between targets or from the recorded vector"
+    );
+
+    // The raw 64-byte record encoding must also be stable, since the digest is
+    // taken over it.
+    let encodings: Vec<String> = scripted_records()
+        .iter()
+        .map(|record| hex(&rvm_witness::record_to_bytes(record)))
+        .collect();
+    assert_eq!(
+        encodings, EXPECTED_RECORD_BYTES,
+        "witness record encoding drifted"
+    );
+}
+
+/// A fixed set of witness records with every field pinned, so nothing depends
+/// on a clock, on entropy, or on allocation order.
+fn scripted_records() -> Vec<WitnessRecord> {
+    let mut records = Vec::new();
+    for (index, action_kind) in [1_u8, 2, 7].into_iter().enumerate() {
+        let mut record = WitnessRecord::zeroed();
+        record.sequence = index as u64;
+        record.timestamp_ns = (index as u64) * 1_000;
+        record.action_kind = action_kind;
+        record.proof_tier = 1;
+        record.flags = 0;
+        record.actor_partition_id = 7;
+        record.target_object_id = 0x0102_0304_0506_0708;
+        record.capability_hash = 0xdead_beef;
+        record.payload = [1, 2, 3, 4, 5, 6, 7, 8];
+        record.prev_hash = index as u32;
+        record.record_hash = 0xfeed_face;
+        record.aux = [9, 10, 11, 12, 13, 14, 15, 16];
+        records.push(record);
+    }
+    records
+}
+
+/// Receipt wire constants are part of the published contract.
+fn receipt_constants_are_stable() {
+    assert_eq!(rvm_context_wasm::receipt::receipt_encoded_size(), 352);
+    assert_eq!(rvm_context_wasm::receipt::receipt_version(), 1);
+    assert_eq!(rvm_context_wasm::contract_version(), 1);
+}
+
+const EXPECTED_RECORD_DIGESTS: [&str; 3] = [
+    "d4353ecac0d4e0e6607dc518d04d4d7cabf3b4f06ba4b073b61086bf1a7f1271",
+    "c58f5cc50515b847ec51a18df8d9f01925dc17486419472f66fab69a5bebaa71",
+    "829d920fb412442b513816ac2d74a585a27a8a2a3498fa75c6d02869c5205ffe",
+];
+const EXPECTED_RECORD_BYTES: [&str; 3] = [
+    "0000000000000000000000000000000001010000070000000807060504030201efbeadde010203040506070800000000cefaedfe090a0b0c0d0e0f1000000000",
+    "0100000000000000e80300000000000002010000070000000807060504030201efbeadde010203040506070801000000cefaedfe090a0b0c0d0e0f1000000000",
+    "0200000000000000d00700000000000007010000070000000807060504030201efbeadde010203040506070802000000cefaedfe090a0b0c0d0e0f1000000000",
+];
+
+fn all_checks() {
+    canonical_uri_bytes_are_stable();
+    builder_and_parser_agree();
+    rights_bits_are_stable();
+    view_mask_bits_are_stable();
+    scope_containment_agrees();
+    witness_record_digests_are_stable();
+    receipt_constants_are_stable();
+}
+
+#[test]
+fn determinism_native() {
+    all_checks();
+}
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn determinism_wasm() {
+    all_checks();
+}

--- a/crates/rvm-context-wasm/tests/smoke.mjs
+++ b/crates/rvm-context-wasm/tests/smoke.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Node smoke test for the built @ruvnet/rvm-context package.
+// Node smoke test for the built @ruvnet/rvm-context-wasm package.
 //
 // Packs and installs the package into a temporary directory, then imports it by
 // its published name so the exports map and files list are exercised the same
@@ -46,9 +46,19 @@ execFileSync(
 );
 
 const require = createRequire(join(stage, "index.js"));
-const rvm = require("@ruvnet/rvm-context");
-const { RuvUri, RuvUriBuilder, ViewMask, ContextScope, ruvUriError, isRuvUri, contractVersion } =
-  rvm;
+const rvm = require("@ruvnet/rvm-context-wasm");
+const {
+  RuvUri,
+  RuvUriBuilder,
+  ViewMask,
+  ContextScope,
+  ContextRuntime,
+  EpochCommitments,
+  Rights,
+  ruvUriError,
+  isRuvUri,
+  contractVersion,
+} = rvm;
 
 let passed = 0;
 const failures = [];
@@ -227,10 +237,10 @@ test("the contract version is exposed", () => {
 test("TypeScript declarations and the web build ship with the package", () => {
   // The exports map deliberately does not expose arbitrary subpaths, so locate
   // the install through its package.json rather than resolving files directly.
-  const installed = dirname(require.resolve("@ruvnet/rvm-context/package.json"));
-  const manifest = require("@ruvnet/rvm-context/package.json");
+  const installed = dirname(require.resolve("@ruvnet/rvm-context-wasm/package.json"));
+  const manifest = require("@ruvnet/rvm-context-wasm/package.json");
 
-  assert.equal(manifest.name, "@ruvnet/rvm-context");
+  assert.equal(manifest.name, "@ruvnet/rvm-context-wasm");
   assert.equal(manifest.license, "MIT OR Apache-2.0");
   assert.ok(existsSync(join(installed, manifest.types)), "the .d.ts is installed");
   assert.ok(existsSync(join(installed, manifest.main)), "the entry point is installed");
@@ -243,6 +253,153 @@ test("TypeScript declarations and the web build ship with the package", () => {
     "the web build is installed"
   );
   assert.ok(existsSync(join(installed, "README.md")), "the README is installed");
+});
+
+// ---------------------------------------------------------------------------
+// Governed runtime, as a consumer would drive it.
+// ---------------------------------------------------------------------------
+
+function rootedRuntime(scopeUri, operations) {
+  const runtime = new ContextRuntime(7);
+  const scope = ContextScope.fromUri(RuvUri.parse(scopeUri), ViewMask.all());
+  const handle = runtime.issueRoot(scope, Rights.forOperations(operations), 7);
+  return { runtime, handle };
+}
+
+test("the runtime provisions a root capability and reports its actor", () => {
+  const { runtime, handle } = rootedRuntime(BASE, ["resolve", "read"]);
+  assert.equal(runtime.actor, 7);
+  assert.ok(Number.isInteger(handle.index));
+  // Published as a static readonly Uint32Array of the compiled-in slot counts.
+  assert.deepEqual(Array.from(ContextRuntime.capacities), [64, 64, 1024, 64, 64]);
+});
+
+test("a cross-tenant reach is refused", () => {
+  const { runtime, handle } = rootedRuntime(BASE, ["resolve", "read"]);
+  const other = RuvUri.parse("ruv://context.example/other/agent/researcher/memory");
+  assert.throws(
+    () => runtime.resolve(handle, other),
+    (error) => {
+      assert.equal(error.name, "ContextError");
+      assert.equal(error.code, "AccessDenied");
+      return true;
+    }
+  );
+});
+
+test("a reach diverging at the LAST prefix segment is refused", () => {
+  // The violating segment is deliberately last: a containment check inside a
+  // short-circuiting loop would pass position 1 and still be wrong here.
+  const { runtime, handle } = rootedRuntime(`${BASE}/a/b/c`, ["resolve"]);
+  for (const bad of [`${BASE}/a/b/X`, `${BASE}/a/X/c`, `${BASE}/X/b/c`, `${BASE}/a/b`]) {
+    assert.throws(
+      () => runtime.resolve(handle, RuvUri.parse(bad)),
+      (error) => error.code === "AccessDenied",
+      `${bad} should have been refused`
+    );
+  }
+});
+
+test("scope containment answers the shadow-mode question with no capability", () => {
+  const scope = ContextScope.fromUri(RuvUri.parse(`${BASE}/a/b/c`), ViewMask.all());
+  assert.equal(scope.containsUri(RuvUri.parse(`${BASE}/a/b/c/d`)), true);
+  assert.equal(scope.containsUri(RuvUri.parse(`${BASE}/a/b/X`)), false);
+  assert.equal(
+    scope.containsUri(RuvUri.parse("ruv://context.example/other/agent/researcher/memory/a/b/c")),
+    false
+  );
+});
+
+test("rights are enforced per operation", () => {
+  const { runtime, handle } = rootedRuntime(BASE, ["resolve"]);
+  const pinned = RuvUri.parse(`${BASE}?rev=${ZERO_REV}`);
+  assert.throws(
+    () => runtime.put(handle, pinned, new Uint8Array(8)),
+    (error) => error.code === "AccessDenied"
+  );
+});
+
+test("delegation cannot widen the parent scope", () => {
+  const { runtime, handle } = rootedRuntime(`${BASE}/a/b`, ["resolve", "grant"]);
+  const wider = ContextScope.fromUri(RuvUri.parse(`${BASE}/a`), ViewMask.all());
+  assert.throws(
+    () => runtime.delegate(handle, wider, Rights.forOperation("resolve"), 7),
+    (error) => error.code === "ScopeEscalation"
+  );
+  const narrower = ContextScope.fromUri(RuvUri.parse(`${BASE}/a/b/c`), ViewMask.all());
+  const child = runtime.delegate(handle, narrower, Rights.forOperation("resolve"), 7);
+  assert.ok(Number.isInteger(child.index));
+});
+
+test("a revoked handle stops working", () => {
+  const { runtime, handle } = rootedRuntime(BASE, ["resolve"]);
+  assert.ok(runtime.revoke(handle) >= 1);
+  assert.throws(
+    () => runtime.resolve(handle, RuvUri.parse(BASE)),
+    (error) => error.code === "AccessDenied"
+  );
+});
+
+test("decisions advance the witness log and the chain verifies", () => {
+  const { runtime, handle } = rootedRuntime(BASE, ["resolve", "read"]);
+  const before = runtime.witnessSequence;
+  try {
+    runtime.resolve(handle, RuvUri.parse("ruv://context.example/other/agent/researcher/memory"));
+  } catch {
+    // refused on purpose; the witness record is the point
+  }
+  const after = runtime.witnessSequence;
+  assert.ok(after > before, `witness sequence did not advance: ${before} -> ${after}`);
+  assert.equal(runtime.verifyWitnessChain(), Number(after));
+  assert.equal(runtime.witnessDigests().length, runtime.witnessRecordCount * 32);
+});
+
+test("the logical clock makes sessions byte-reproducible", () => {
+  const run = () => {
+    const { runtime, handle } = rootedRuntime(BASE, ["resolve"]);
+    try {
+      runtime.resolve(handle, RuvUri.parse("ruv://context.example/other/agent/researcher/memory"));
+    } catch {
+      // refused on purpose
+    }
+    return Buffer.from(runtime.witnessDigests()).toString("hex");
+  };
+  const first = run();
+  assert.equal(first, run(), "identical sessions produced different witness digests");
+  assert.ok(first.length > 0, "the session recorded nothing");
+});
+
+test("receipt sealing requires a host-supplied 32-byte key", () => {
+  const { runtime, handle } = rootedRuntime(BASE, ["resolve", "sealReceipt"]);
+  const target = RuvUri.parse(BASE);
+  const roots = new Uint8Array(32);
+  const commitments = new EpochCommitments(roots, roots, roots, roots);
+  assert.throws(
+    () => runtime.sealEpoch(handle, target, new Uint8Array(8), commitments),
+    (error) => error.code === "InvalidKeyLength"
+  );
+  assert.throws(
+    () => new EpochCommitments(roots, new Uint8Array(31), roots, roots),
+    (error) => error.code === "InvalidDigestLength"
+  );
+});
+
+test("rights map to the operations that need them", () => {
+  assert.equal(Rights.forOperation("read").bits, 0x01);
+  assert.equal(Rights.forOperation("put").bits, 0x02);
+  assert.equal(Rights.forOperation("execute").bits, 0x10);
+  assert.deepEqual(Rights.fromNames(["read", "prove"]).names, ["read", "prove"]);
+  assert.throws(
+    () => Rights.fromNames(["admin"]),
+    (error) => error.code === "UnknownRight"
+  );
+});
+
+test("an out-of-range partition id is refused", () => {
+  assert.throws(
+    () => new ContextRuntime(4096),
+    (error) => error.code === "InvalidPartitionId"
+  );
 });
 
 console.log(`\n${passed} passed, ${failures.length} failed`);

--- a/crates/rvm-context-wasm/tests/smoke.mjs
+++ b/crates/rvm-context-wasm/tests/smoke.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// Node smoke test for the built @ruvnet/rvm-context package.
+//
+// Packs and installs the package into a temporary directory, then imports it by
+// its published name so the exports map and files list are exercised the same
+// way a consumer would exercise them.
+//
+// Usage: node crates/rvm-context-wasm/tests/smoke.mjs
+//        (run scripts/build-npm.mjs first)
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const crateDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkgDir = join(crateDir, "pkg");
+
+if (!existsSync(join(pkgDir, "package.json"))) {
+  console.error("pkg/ not found — run scripts/build-npm.mjs first");
+  process.exit(1);
+}
+
+const stage = mkdtempSync(join(tmpdir(), "rvm-context-smoke-"));
+process.on("exit", () => rmSync(stage, { recursive: true, force: true }));
+
+console.log("packing and installing the built package...");
+execFileSync("npm", ["pack", "--pack-destination", stage, "--silent"], {
+  cwd: pkgDir,
+  stdio: "inherit",
+});
+const tarball = readdirSync(stage).find((file) => file.endsWith(".tgz"));
+assert.ok(tarball, "npm pack produced a tarball");
+
+writeFileSync(
+  join(stage, "package.json"),
+  JSON.stringify({ name: "smoke-host", version: "1.0.0", private: true }) + "\n"
+);
+execFileSync(
+  "npm",
+  ["install", join(stage, tarball), "--no-audit", "--no-fund", "--silent"],
+  { cwd: stage, stdio: "inherit" }
+);
+
+const require = createRequire(join(stage, "index.js"));
+const rvm = require("@ruvnet/rvm-context");
+const { RuvUri, RuvUriBuilder, ViewMask, ContextScope, ruvUriError, isRuvUri, contractVersion } =
+  rvm;
+
+let passed = 0;
+const failures = [];
+
+function test(name, body) {
+  try {
+    body();
+    passed += 1;
+    console.log(`  ok  ${name}`);
+  } catch (error) {
+    failures.push({ name, error });
+    console.log(`  FAIL ${name}\n       ${error.message}`);
+  }
+}
+
+const BASE = "ruv://context.example/acme/agent/researcher/memory";
+const ZERO_REV = `sha256:${"0".repeat(64)}`;
+
+console.log("\nrunning smoke tests against the installed package");
+
+test("a canonical URI parses into the right components", () => {
+  const uri = RuvUri.parse(`${BASE}/projects/atlas`);
+  assert.equal(uri.authority, "context.example");
+  assert.equal(uri.tenant, "acme");
+  assert.equal(uri.subjectKind, "agent");
+  assert.equal(uri.subjectId, "researcher");
+  assert.equal(uri.collection, "memory");
+  assert.deepEqual(uri.path, ["projects", "atlas"]);
+  assert.equal(uri.revision, undefined);
+  assert.equal(uri.view, undefined);
+  assert.equal(uri.isPinned, false);
+});
+
+test("a pinned URI exposes its revision and view", () => {
+  const uri = RuvUri.parse(`${BASE}?rev=${ZERO_REV}&view=overview`);
+  assert.equal(uri.revision, ZERO_REV);
+  assert.equal(uri.view, "overview");
+  assert.equal(uri.isPinned, true);
+});
+
+test("path segments keep their case", () => {
+  const uri = RuvUri.parse("ruv://context.example/acme/team/core/resources/Specs/API_v1");
+  assert.deepEqual(uri.path, ["Specs", "API_v1"]);
+});
+
+// Each rejection class, using the real cases.
+const rejections = [
+  ["uppercase tenant", "ruv://context.example/ACME/agent/researcher/memory", "InvalidTenant"],
+  ["trailing slash", `${BASE}/`, "TrailingSlash"],
+  ["dot-dot segment", `${BASE}/../secrets`, "DotSegment"],
+  ["empty segment", "ruv://context.example/acme/agent/researcher//memory", "EmptyPathSegment"],
+  ["percent encoding", `${BASE}/a%2Fb`, "PercentEncodingNotAllowed"],
+  ["fragment", `${BASE}#section`, "FragmentNotAllowed"],
+  [
+    "credentials in authority",
+    "ruv://user:pw@context.example/acme/agent/researcher/memory",
+    "CredentialsNotAllowed",
+  ],
+  ["port in authority", "ruv://context.example:8443/acme/agent/researcher/memory", "PortNotAllowed"],
+];
+
+for (const [label, input, expectedCode] of rejections) {
+  test(`rejects ${label} with code ${expectedCode}`, () => {
+    assert.throws(
+      () => RuvUri.parse(input),
+      (error) => {
+        assert.ok(error instanceof Error, "throws a real Error");
+        assert.equal(error.name, "RuvUriError");
+        assert.equal(error.code, expectedCode);
+        assert.ok(error.message.length > 0, "carries a message");
+        return true;
+      },
+      `${input} should have been rejected`
+    );
+    assert.equal(ruvUriError(input), expectedCode, "non-throwing probe agrees");
+    assert.equal(isRuvUri(input), false);
+  });
+}
+
+test("round trip: parse then format is byte identical", () => {
+  const cases = [
+    BASE,
+    `${BASE}/projects/atlas`,
+    "ruv://context.example/acme/user/alice/skills/deploy",
+    "ruv://a.b.c/t/service/api/resources/A/b-c/d.e/f_g/h~i",
+    `${BASE}?rev=${ZERO_REV}`,
+    `${BASE}?view=content`,
+    `${BASE}?rev=${ZERO_REV}&view=abstract`,
+  ];
+  for (const text of cases) {
+    const once = RuvUri.parse(text).toString();
+    assert.equal(once, text, `round trip changed ${text}`);
+    assert.equal(RuvUri.parse(once).toString(), once, "second round trip is stable");
+  }
+});
+
+test("valid URIs report no error", () => {
+  assert.equal(ruvUriError(BASE), undefined);
+  assert.equal(isRuvUri(BASE), true);
+});
+
+test("the builder produces the canonical spelling", () => {
+  const uri = new RuvUriBuilder("context.example", "acme", "team", "core", "resources")
+    .segment("Specs")
+    .segment("API_v1")
+    .revision(ZERO_REV)
+    .view("overview")
+    .build();
+  assert.equal(
+    uri.toString(),
+    `ruv://context.example/acme/team/core/resources/Specs/API_v1?rev=${ZERO_REV}&view=overview`
+  );
+});
+
+test("the builder names the component that failed", () => {
+  assert.throws(
+    () => new RuvUriBuilder("context.example", "ACME", "agent", "a", "memory"),
+    (error) => error.code === "InvalidTenant"
+  );
+  assert.throws(
+    () => new RuvUriBuilder("context.example", "acme", "robot", "a", "memory"),
+    (error) => error.code === "InvalidSubjectKind"
+  );
+  assert.throws(
+    () => new RuvUriBuilder("context.example", "acme", "agent", "a", "memory").segment(".."),
+    (error) => error.code === "DotSegment"
+  );
+});
+
+test("a builder value is reusable across branches", () => {
+  const base = new RuvUriBuilder("context.example", "acme", "agent", "researcher", "memory");
+  assert.equal(base.segment("alpha").build().toString(), `${BASE}/alpha`);
+  assert.equal(base.segment("beta").build().toString(), `${BASE}/beta`);
+});
+
+test("withRevision and withView extend a parsed URI", () => {
+  const uri = RuvUri.parse(BASE);
+  const pinned = uri.withRevision(ZERO_REV);
+  assert.equal(pinned.toString(), `${BASE}?rev=${ZERO_REV}`);
+  assert.equal(pinned.withView("content").toString(), `${BASE}?rev=${ZERO_REV}&view=content`);
+  assert.equal(uri.isPinned, false, "the original is unchanged");
+});
+
+test("equals compares structurally", () => {
+  assert.equal(RuvUri.parse(BASE).equals(RuvUri.parse(BASE)), true);
+  assert.equal(RuvUri.parse(BASE).equals(RuvUri.parse(`${BASE}/x`)), false);
+});
+
+test("view masks compose", () => {
+  const all = ViewMask.all();
+  const content = ViewMask.view("content");
+  assert.equal(all.contains(content), true);
+  assert.equal(content.contains(all), false);
+  assert.equal(all.allows("abstract"), true);
+  assert.equal(content.allows("abstract"), false);
+  assert.equal(ViewMask.fromBits(all.bits).bits, all.bits);
+  assert.throws(() => ViewMask.fromBits(0), (error) => error.code === "InvalidViewMask");
+  assert.throws(() => ViewMask.fromBits(0x10), (error) => error.code === "InvalidViewMask");
+});
+
+test("scope containment follows the path prefix", () => {
+  const parent = ContextScope.fromUri(RuvUri.parse(`${BASE}/projects`), ViewMask.all());
+  const child = ContextScope.fromUri(RuvUri.parse(`${BASE}/projects/atlas`), ViewMask.all());
+  const other = ContextScope.fromUri(RuvUri.parse(`${BASE}/archive`), ViewMask.all());
+  assert.equal(parent.containsScope(child), true);
+  assert.equal(child.containsScope(parent), false);
+  assert.equal(parent.containsScope(other), false);
+  assert.deepEqual(parent.pathPrefix, ["projects"]);
+  assert.equal(parent.subjectKind, "agent");
+});
+
+test("the contract version is exposed", () => {
+  assert.equal(contractVersion(), 1);
+});
+
+test("TypeScript declarations and the web build ship with the package", () => {
+  // The exports map deliberately does not expose arbitrary subpaths, so locate
+  // the install through its package.json rather than resolving files directly.
+  const installed = dirname(require.resolve("@ruvnet/rvm-context/package.json"));
+  const manifest = require("@ruvnet/rvm-context/package.json");
+
+  assert.equal(manifest.name, "@ruvnet/rvm-context");
+  assert.equal(manifest.license, "MIT OR Apache-2.0");
+  assert.ok(existsSync(join(installed, manifest.types)), "the .d.ts is installed");
+  assert.ok(existsSync(join(installed, manifest.main)), "the entry point is installed");
+  assert.ok(
+    existsSync(join(installed, "rvm_context_wasm_bg.wasm")),
+    "the wasm binary is installed"
+  );
+  assert.ok(
+    existsSync(join(installed, "web", "rvm_context_wasm.js")),
+    "the web build is installed"
+  );
+  assert.ok(existsSync(join(installed, "README.md")), "the README is installed");
+});
+
+console.log(`\n${passed} passed, ${failures.length} failed`);
+if (failures.length > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Closes #45.

## Why

`crates/rvm-context` is `crate-type = ["rlib"]`, so it links Rust-to-Rust only — there is no way to reach it from JavaScript today. (`crates/rvm-wasm` is unrelated: it is a WebAssembly *guest runtime* for RVM partitions, not a JS binding. It is untouched here.)

This adds `crates/rvm-context-wasm`, a `cdylib` compiled to `wasm32-unknown-unknown` and packaged for npm as `@ruvnet/rvm-context-wasm`, with generated TypeScript declarations.

## Read this first: the wasm module is its own authority

This is the load-bearing caveat, and it is the opening section of both the crate docs and the package README rather than a footnote.

The module hosts a **complete governed runtime** — its own capability table, grant table, witness ring, and deterministic logical clock. Every capability it issues is an **index and a generation into its own live table**: not signed, not serializable, **not portable**. A handle minted by a Rust-side service is two integers that would index a different table here. There is consequently **no "verify a capability issued elsewhere" API**, because that is not implementable — the module either owns its authority or it authorizes nothing.

A decision it renders **binds only to the scope table the host provisioned into it**. It is a faithful, deterministic policy simulator, correct for shadow-mode evaluation, and **not evidence about a separate Rust-side authority** unless that authority provisioned the same scopes. Promoting it to enforcement requires provisioning the grant table from the same authority that issues real capabilities.

Two further limits:

- **`issueRoot` runs as the hypervisor.** The core crate refuses root creation unless the caller `is_hypervisor()`. This module performs it *as* `PartitionId::HYPERVISOR` — the concrete form of "its own authority" — documented as host provisioning, not a partition-facing call. Everything below a root gets the ordinary governed checks.
- **Receipt signatures are a keyed MAC.** HMAC-SHA256 is symmetric: verifying needs the key that signed, so a caller who can check a receipt can forge one. That is an integrity check, **not** third-party verifiable evidence. The keyless checks (`verifyWitnessChain`, `witnessDigests`) are the ones that cross a trust boundary.

**The naming layer needs none of this.** `RuvUri` and `ContextScope` are pure and stand alone.

## What is exposed

**Naming** — `RuvUri.parse` with canonical formatting and structured accessors; `RuvUriBuilder` (each step returns a new builder); `ruvUriError` / `isRuvUri` for non-throwing validation. Rejections throw a real `Error` whose **`code` is the Rust `UriError` variant name**, never collapsed into one generic error.

**Scopes** — `ContextScope.fromUri`, `.containsScope`, and `.containsUri`. `containsUri` answers the shadow-mode question ("would `ruv://` have allowed this reach?") with no capability and no runtime, which is the standalone use meta-llm needs.

**Governed runtime** — `issueRoot` / `delegate` / `revoke`; `resolve`, `read`, `verify`, `put`, `list`, `tree`, `history`, `search`, `compareAndSwapAlias`, `forget`, `authorizeExecute`, `grant`, `revokeGoverned`; `sealEpoch`. Every governed result carries the `witnessSequence` at which the decision was recorded. `Rights.forOperation` sources the mapping from the core crate's own `required_rights`, so callers never guess.

**Verification** — keyless `verifyWitnessChain()` and `witnessDigests()`; `SignedReceipt` encode/decode with `verifySignature` / `verifyGenesis` / `verifySuccessor`.

**Profiles** — the `ContextProfile` fixed-record codec.

## Where the source contradicted the brief

Reported in full in [this comment](https://github.com/ruvnet/rvm/pull/46#issuecomment-5387548956). The load-bearing ones:

- Receipts are bound on **`rvm_proof::WitnessSigner`**, a *different trait* that shares its name with `rvm_witness::WitnessSigner`. An Ed25519 receipt path therefore exists, though it is not usable here (non-default feature; its constructor takes a signing seed, not a public key).
- ed25519 is a non-optional runtime dep of `rvm-rvf` and `rvm-anchor`, so it *is* in `rvm-context`'s tree — harmless, since verification needs no entropy and no `getrandom` was added.
- `create_root_capability_checked` refuses any non-hypervisor caller, which is what forced the provisioning design above.
- Const generics (`ContextRuntime<R,C,G,W>`, `ContextAuthority<C,G>`, `MemoryResolver<O,A>`, `WitnessLog<W>`) and the borrowed `VerifiedContextEpochReceipt<'a>` cannot be expressed through wasm-bindgen, so the module monomorphizes to fixed capacities and folds the borrowed verification steps into single calls.

## Fixed capacities

`ContextRuntime.capacities` publishes them: 64 capabilities, 64 grants, **1024 witness records**, 64 objects, 64 aliases. The core witness default is 262,144 records held inline at 64 bytes each — about 16 MiB — which a wasm module cannot spend.

## Blocker hit: wasm stack exhaustion

Constructing the runtime failed as an opaque `RuntimeError: memory access out of bounds`. `ContextAuthority` is ~68 KiB **regardless of slot count** (16 slots still costs ~66 KiB), and the witness ring adds 64 KiB; an unoptimized wasm build walks that through enough stack temporaries to exhaust the 1 MiB default stack. Shrinking slot counts does not help. `build.rs` raises the wasm stack to 4 MiB and travels with the crate, so `cargo` and `wasm-pack` both get it without a global `.cargo/config.toml`.

Separately, `wasm-opt` rejected the module until the wasm proposals rustc enables by default (`bulk-memory` and friends) were named explicitly in `[package.metadata.wasm-pack.profile.release]`.

## Tests

- **30 wasm binding tests** on the real `wasm32-unknown-unknown` target under Node.
- **1 determinism test whose assertions run on BOTH targets** — natively via `cargo test` and on wasm via `wasm-pack test --node` — against hardcoded vectors covering canonical URI bytes, rights bits, view-mask bits, scope containment, and witness record encodings plus `record_to_digest` output. If the two builds ever diverge, one run fails instead of drifting silently (issue AC#5).
- **34 Node tests** against the **packed and installed tarball** (`npm pack` → `npm install` → import by published name), so the `exports` map and `files` list are exercised as a consumer would.

Round-trip (`parse` → `toString` → byte-identical) is verified across the accepted corpus; every rejection class is asserted against its specific code — uppercase tenant, trailing slash, `..`, empty segment, percent-encoding, fragment, credentials, port, and more.

Negative containment tests place the violating segment at the **last** prefix position (`/a/b/X` against a scope of `/a/b/c`), so a short-circuiting check that is green at position 1 still fails. Cross-tenant, cross-subject, cross-collection, ancestor, view-mask widening, and path widening are each refused; `delegate` refuses escalation with `ScopeEscalation`; a revoked handle stops resolving.

All green. `cargo test --workspace` remains green.

## Artifact

Release wasm is **282,019 bytes** (102,399 gzipped). CommonJS entry at the package root, ESM web build under `/web`; both loaded and exercised.

## Notes for review

- The crate is **`publish = false`** — npm, not crates.io.
- `wasm_bindgen_test` compiles to nothing on the host, so `cargo test --workspace` runs **zero** of these tests. A `context-wasm` CI job runs them on wasm32 plus the packaged smoke test, otherwise the suite is dead weight.
- **Not published to npm**, per instructions.

### Pre-existing issue, not fixed here

`cargo clippy --workspace -- -D warnings` fails on `crates/rvm-hal/src/aarch64/boot.rs:455` (`uninlined_format_args`) under Rust 1.97.1. That file is untouched by this branch and `cargo clippy -p rvm-hal` fails standalone, so it is toolchain drift on `main`. Left alone rather than mixing an unrelated fix into this PR.

Also worth settling before publishing: the repo declares `MIT OR Apache-2.0` but contains **no LICENSE files**, so the npm tarball ships without license text. The manifest's `license` field is correct; only the files are missing.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5