### PR TITLE
fix(launch): bind runtime bytes to the verified RVF executable

### DIFF
--- a/crates/rvm-host/src/package.rs
+++ b/crates/rvm-host/src/package.rs
@@ -10,22 +10,24 @@
 //! because there is no unverified value to pass.
 
 use alloc::vec::Vec;
-use rvm_rvf::{CapabilityClass, CapabilityMapping, VerificationReport};
+use rvm_rvf::{
+    format::SEG_TYPE_WASM, CapabilityClass, CapabilityMapping, VerificationReport,
+    VerifiedExecutable,
+};
 
 use crate::error::{HostError, HostResult};
 
 /// An RVF that passed every verification check, with the capability mapping it
 /// resolved to.
 ///
-/// Holds no container bytes: verification is complete by the time this exists,
-/// and the payload a runtime will later execute is passed separately and
-/// explicitly, so that "I hold a verified package" never silently means "I
-/// hold runnable code".
+/// Holds no container bytes, but retains each executable payload's identity so
+/// separately supplied runtime bytes can be bound back to what was verified.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedPackage {
     identity: [u8; 32],
     byte_length: u64,
     segment_count: usize,
+    executables: Vec<VerifiedExecutable>,
     capabilities: CapabilityMapping,
 }
 
@@ -45,6 +47,7 @@ impl VerifiedPackage {
             identity: report.rvf_identity,
             byte_length: report.byte_length,
             segment_count: report.segment_count,
+            executables: report.executables.clone(),
             capabilities: report.capabilities.clone(),
         })
     }
@@ -74,6 +77,14 @@ impl VerifiedPackage {
     #[must_use]
     pub const fn capabilities(&self) -> &CapabilityMapping {
         &self.capabilities
+    }
+
+    /// Whether `module` exactly matches a WASM payload in this package.
+    #[must_use]
+    pub fn accepts_wasm(&self, module: &[u8]) -> bool {
+        self.executables
+            .iter()
+            .any(|entry| entry.segment_type == SEG_TYPE_WASM && entry.matches(module))
     }
 
     /// The classes this package declared and RVM will issue.
@@ -150,6 +161,19 @@ mod tests {
     }
 
     #[test]
+    fn executable_bytes_are_bound_to_the_verified_segment_identity() {
+        let data = testkit::container_with_wasm("memory");
+        let report = verify(&data, &testkit::lenient_options()).unwrap();
+        let pkg = VerifiedPackage::from_report(&report).unwrap();
+        let substitute = [
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        assert!(pkg.accepts_wasm(&testkit::MINIMAL_WASM));
+        assert!(!pkg.accepts_wasm(&substitute));
+    }
+
+    #[test]
     fn granted_classes_come_back_in_declaration_order() {
         let data = testkit::container_declaring("clock,memory,model");
         let report = verify(&data, &testkit::lenient_options()).unwrap();
@@ -169,7 +193,7 @@ mod tests {
         let data = testkit::container_declaring("memory");
         let report = verify(&data, &testkit::lenient_options()).unwrap();
         let pkg = VerifiedPackage::from_report(&report).unwrap();
-        // The identity is retained; the payload is not, so holding a package
+        // Identities are retained; payload bytes are not, so holding a package
         // is never the same as holding runnable code.
         assert_eq!(pkg.byte_length(), data.len() as u64);
         assert_eq!(core::mem::size_of_val(pkg.identity()), 32);

--- a/crates/rvm-host/src/testkit.rs
+++ b/crates/rvm-host/src/testkit.rs
@@ -69,13 +69,19 @@ pub fn container_declaring(classes: &str) -> Vec<u8> {
 /// as long as `classes` keeps the metadata payload under 48 bytes.
 #[must_use]
 pub fn container_with_wasm(classes: &str) -> Vec<u8> {
+    container_with_module(classes, &MINIMAL_WASM)
+}
+
+/// A container declaring `classes` with the supplied unsigned WASM payload.
+#[must_use]
+pub fn container_with_module(classes: &str, module: &[u8]) -> Vec<u8> {
     let meta = meta_payload(classes);
     assert!(
         SEGMENT_HEADER_SIZE + meta.len() <= 128,
         "fixture assumes the META segment occupies two 64-byte blocks"
     );
     let mut data = segment(SEG_TYPE_META, &meta, 1);
-    data.extend(segment(SEG_TYPE_WASM, &MINIMAL_WASM, 2));
+    data.extend(segment(SEG_TYPE_WASM, module, 2));
     data.extend(segment(SEG_TYPE_MANIFEST, b"root", 3));
     data
 }

--- a/crates/rvm-launch/src/error.rs
+++ b/crates/rvm-launch/src/error.rs
@@ -26,6 +26,8 @@ pub enum LaunchError {
     LineageMismatch,
     /// A context execution permit names another RVF or partition.
     ContextPermitMismatch,
+    /// Runtime bytes do not match any executable segment that was verified.
+    ExecutableMismatch,
     /// The host adapter refused.
     Host(HostError),
     /// The execution backend refused.
@@ -45,6 +47,9 @@ impl fmt::Display for LaunchError {
             }
             Self::ContextPermitMismatch => {
                 f.write_str("context execution permit does not match package and placement")
+            }
+            Self::ExecutableMismatch => {
+                f.write_str("module does not match a verified executable segment")
             }
             Self::Host(e) => write!(f, "{e}"),
             Self::Backend(e) => write!(f, "{e}"),
@@ -69,7 +74,9 @@ impl From<LaunchError> for RvmError {
     fn from(e: LaunchError) -> Self {
         match e {
             LaunchError::IllegalTransition { .. } => RvmError::InvalidPartitionState,
-            LaunchError::LineageMismatch | LaunchError::ContextPermitMismatch => {
+            LaunchError::LineageMismatch
+            | LaunchError::ContextPermitMismatch
+            | LaunchError::ExecutableMismatch => {
                 RvmError::ProofInvalid
             }
             LaunchError::Host(inner) => inner.into(),
@@ -97,6 +104,7 @@ mod tests {
             },
             LaunchError::LineageMismatch,
             LaunchError::ContextPermitMismatch,
+            LaunchError::ExecutableMismatch,
             LaunchError::Host(HostError::Unverified),
             LaunchError::Backend(RvmError::ResourceLimitExceeded),
             LaunchError::Rvf(RvfError::BadMagic),

--- a/crates/rvm-launch/src/error.rs
+++ b/crates/rvm-launch/src/error.rs
@@ -76,9 +76,7 @@ impl From<LaunchError> for RvmError {
             LaunchError::IllegalTransition { .. } => RvmError::InvalidPartitionState,
             LaunchError::LineageMismatch
             | LaunchError::ContextPermitMismatch
-            | LaunchError::ExecutableMismatch => {
-                RvmError::ProofInvalid
-            }
+            | LaunchError::ExecutableMismatch => RvmError::ProofInvalid,
             LaunchError::Host(inner) => inner.into(),
             LaunchError::Backend(inner) => inner,
             LaunchError::Rvf(inner) => inner.into(),

--- a/crates/rvm-launch/src/instance.rs
+++ b/crates/rvm-launch/src/instance.rs
@@ -163,6 +163,7 @@ impl<A: HostAdapter> Instance<A> {
     ) -> LaunchResult<()> {
         self.guard(LifecycleOp::Start, log, timestamp_ns)?;
         let start = log.total_emitted();
+        self.guard_executable(module, log, timestamp_ns, start)?;
 
         let agent = self
             .adapter
@@ -321,6 +322,10 @@ impl<A: HostAdapter> Instance<A> {
         }
         self.guard(LifecycleOp::Restore, log, timestamp_ns)?;
 
+        if self.state == InstanceState::Created {
+            self.guard_executable(module, log, timestamp_ns, start)?;
+        }
+
         match self.state {
             InstanceState::Created => {
                 let agent =
@@ -452,6 +457,27 @@ impl<A: HostAdapter> Instance<A> {
         if end > start {
             self.ranges.push((start, end));
         }
+    }
+
+    fn guard_executable<const N: usize>(
+        &mut self,
+        module: &[u8],
+        log: &WitnessLog<N>,
+        timestamp_ns: u64,
+        start: u64,
+    ) -> LaunchResult<()> {
+        if self.package.accepts_wasm(module) {
+            return Ok(());
+        }
+        emit(
+            log,
+            LaunchEvent::ExecutableRejected,
+            &self.witness_context(timestamp_ns),
+            self.state,
+            fnv1a_32(module),
+        );
+        self.record_range(start, log.total_emitted());
+        Err(LaunchError::ExecutableMismatch)
     }
 }
 

--- a/crates/rvm-launch/src/instance_lineage_tests.rs
+++ b/crates/rvm-launch/src/instance_lineage_tests.rs
@@ -13,6 +13,9 @@ use rvm_types::PartitionId;
 const PLACEMENT: Placement = Placement::new(PartitionId::new(1), 0, 16);
 type Log = WitnessLog<512>;
 type Agents = AgentManager<8>;
+const SUBSTITUTE_WASM: [u8; 11] = [
+    0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+];
 
 // ---------------------------------------------------------------------
 // Checkpoint lineage
@@ -166,6 +169,33 @@ fn a_checkpoint_resumes_into_a_new_instance_of_the_same_lineage() {
     assert!(second.agent().is_some());
     // The two runs obtained different, honestly reported boundaries.
     assert_eq!(second.isolation().claim, IsolationClaim::OsSandboxWasm);
+}
+
+#[test]
+fn a_created_restore_refuses_module_bytes_not_bound_to_the_package() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = instance(&log);
+    let checkpoint = Checkpoint::new(
+        *inst.package().identity(),
+        InstanceId::new(99),
+        0,
+        InstanceState::Suspended,
+        16,
+        0,
+    );
+
+    assert_eq!(
+        inst.restore(&checkpoint, &SUBSTITUTE_WASM, &mut agents, &log, 2),
+        Err(LaunchError::ExecutableMismatch)
+    );
+    assert_eq!(inst.state(), InstanceState::Created);
+    assert_eq!(inst.agent(), None);
+    assert_eq!(agents.count(), 0);
+    assert_eq!(
+        events(&inst, &log).last(),
+        Some(&LaunchEvent::ExecutableRejected)
+    );
 }
 
 #[test]

--- a/crates/rvm-launch/src/instance_tests.rs
+++ b/crates/rvm-launch/src/instance_tests.rs
@@ -8,6 +8,9 @@ use rvm_rvf::CapabilityClass;
 use rvm_types::PartitionId;
 
 const PLACEMENT: Placement = Placement::new(PartitionId::new(1), 0, 16);
+const SUBSTITUTE_WASM: [u8; 11] = [
+    0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+];
 type Log = WitnessLog<512>;
 type Agents = AgentManager<8>;
 
@@ -146,20 +149,50 @@ fn the_full_lifecycle_runs_end_to_end() {
 fn a_module_that_fails_admission_leaves_the_instance_created() {
     let log = Log::new();
     let mut agents = Agents::new();
-    let mut inst = instance(&log);
+    let malformed = b"not wasm";
+    let data = rvm_host::testkit::container_with_module("memory,clock", malformed);
+    let report = rvm_rvf::verify(&data, &rvm_host::testkit::lenient_options()).unwrap();
+    let package = VerifiedPackage::from_report(&report).unwrap();
+    let mut inst = Instance::create(
+        InstanceId::new(1),
+        WasmAdapter::new(),
+        package,
+        PLACEMENT,
+        &log,
+        1,
+    )
+    .unwrap();
 
     assert!(matches!(
-        inst.start(b"not wasm", &mut agents, &log, 2),
+        inst.start(malformed, &mut agents, &log, 2),
         Err(LaunchError::Host(HostError::ModuleRejected(_)))
     ));
     assert_eq!(inst.state(), InstanceState::Created);
     assert_eq!(inst.agent(), None);
     assert_eq!(agents.count(), 0);
 
-    // And the instance is still startable with a module that does pass.
-    inst.start(&rvm_host::testkit::MINIMAL_WASM, &mut agents, &log, 3)
-        .unwrap();
-    assert_eq!(inst.state(), InstanceState::Running);
+    // Verification established byte identity, not WASM validity; runtime
+    // admission remains a distinct gate and the refusal is non-mutating.
+    assert_eq!(inst.state(), InstanceState::Created);
+}
+
+#[test]
+fn a_valid_but_unverified_module_is_refused_before_admission() {
+    let log = Log::new();
+    let mut agents = Agents::new();
+    let mut inst = instance(&log);
+
+    assert_eq!(
+        inst.start(&SUBSTITUTE_WASM, &mut agents, &log, 2),
+        Err(LaunchError::ExecutableMismatch)
+    );
+    assert_eq!(inst.state(), InstanceState::Created);
+    assert_eq!(inst.agent(), None);
+    assert_eq!(agents.count(), 0);
+    assert_eq!(
+        events(&inst, &log).last(),
+        Some(&LaunchEvent::ExecutableRejected)
+    );
 }
 
 // ---------------------------------------------------------------------

--- a/crates/rvm-launch/src/witness.rs
+++ b/crates/rvm-launch/src/witness.rs
@@ -14,6 +14,7 @@
 //! | `InstanceTerminated` | `TaskTerminate` | 1 | destroyed |
 //! | `IllegalTransition` | `ProofRejected` | 1 | an operation the state machine does not allow |
 //! | `ContextPermitRejected` | `ProofRejected` | 1 | permit identity or actor did not match launch inputs |
+//! | `ExecutableRejected` | `ProofRejected` | 2 | runtime bytes differed from the verified executable |
 //!
 //! # Why the log has two records for a suspend
 //!
@@ -52,11 +53,13 @@ pub enum LaunchEvent {
     IllegalTransition = 9,
     /// A context permit did not match the package identity or placement actor.
     ContextPermitRejected = 10,
+    /// Runtime bytes did not match a verified executable payload.
+    ExecutableRejected = 11,
 }
 
 impl LaunchEvent {
     /// Every event, in declaration order.
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::InstanceCreated,
         Self::InstanceStarted,
         Self::InstanceSuspended,
@@ -67,6 +70,7 @@ impl LaunchEvent {
         Self::InstanceTerminated,
         Self::IllegalTransition,
         Self::ContextPermitRejected,
+        Self::ExecutableRejected,
     ];
 
     /// The `ActionKind` this event is recorded under.
@@ -79,7 +83,10 @@ impl LaunchEvent {
             Self::InstanceResumed => ActionKind::PartitionResume,
             Self::CheckpointTaken => ActionKind::PartitionHibernate,
             Self::CheckpointRestored => ActionKind::PartitionReconstruct,
-            Self::CheckpointRejected | Self::IllegalTransition | Self::ContextPermitRejected => {
+            Self::CheckpointRejected
+            | Self::IllegalTransition
+            | Self::ContextPermitRejected
+            | Self::ExecutableRejected => {
                 ActionKind::ProofRejected
             }
             Self::InstanceTerminated => ActionKind::TaskTerminate,
@@ -93,7 +100,8 @@ impl LaunchEvent {
             Self::InstanceCreated
             | Self::CheckpointTaken
             | Self::CheckpointRestored
-            | Self::CheckpointRejected => 2,
+            | Self::CheckpointRejected
+            | Self::ExecutableRejected => 2,
             _ => 1,
         }
     }
@@ -103,7 +111,10 @@ impl LaunchEvent {
     pub const fn is_refusal(self) -> bool {
         matches!(
             self,
-            Self::CheckpointRejected | Self::IllegalTransition | Self::ContextPermitRejected
+            Self::CheckpointRejected
+                | Self::IllegalTransition
+                | Self::ContextPermitRejected
+                | Self::ExecutableRejected
         )
     }
 }
@@ -202,6 +213,7 @@ pub const fn event_of(record: &WitnessRecord) -> Option<LaunchEvent> {
         8 => LaunchEvent::InstanceTerminated,
         9 => LaunchEvent::IllegalTransition,
         10 => LaunchEvent::ContextPermitRejected,
+        11 => LaunchEvent::ExecutableRejected,
         _ => return None,
     };
     if record.action_kind == tagged.action_kind() as u8 && record.aux[2] == 0 && record.aux[3] == 0

--- a/crates/rvm-launch/src/witness.rs
+++ b/crates/rvm-launch/src/witness.rs
@@ -86,9 +86,7 @@ impl LaunchEvent {
             Self::CheckpointRejected
             | Self::IllegalTransition
             | Self::ContextPermitRejected
-            | Self::ExecutableRejected => {
-                ActionKind::ProofRejected
-            }
+            | Self::ExecutableRejected => ActionKind::ProofRejected,
             Self::InstanceTerminated => ActionKind::TaskTerminate,
         }
     }

--- a/crates/rvm-rvf/src/lib.rs
+++ b/crates/rvm-rvf/src/lib.rs
@@ -118,7 +118,8 @@ pub use format::{
 pub use hash::{content_hash, sha256, verify_content_hash};
 pub use policy::{tally, SizePolicy, SizeTally, SizeViolation};
 pub use verify::{
-    verify, CheckKind, Outcome, VerificationRecord, VerificationReport, VerifyOptions,
+    verify, CheckKind, Outcome, VerificationRecord, VerificationReport, VerifiedExecutable,
+    VerifyOptions,
 };
 pub use witness::{action_kind_for, build_record, emit_record, emit_report, WitnessContext};
 

--- a/crates/rvm-rvf/src/verify.rs
+++ b/crates/rvm-rvf/src/verify.rs
@@ -77,6 +77,27 @@ pub struct VerificationRecord {
     pub detail: DetailCode,
 }
 
+/// Identity of executable payload bytes examined during RVF verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerifiedExecutable {
+    /// Ordinal assigned by the RVF writer.
+    pub segment_id: u64,
+    /// RVF segment type discriminator.
+    pub segment_type: u8,
+    /// Exact executable payload length.
+    pub byte_length: u64,
+    /// SHA-256 of the executable payload bytes.
+    pub sha256: [u8; 32],
+}
+
+impl VerifiedExecutable {
+    /// Whether `module` is exactly the payload represented by this identity.
+    #[must_use]
+    pub fn matches(&self, module: &[u8]) -> bool {
+        self.byte_length == module.len() as u64 && self.sha256 == sha256(module)
+    }
+}
+
 /// The full result of verifying one artifact.
 ///
 /// Carries no timestamp: two verifications of the same bytes under the same
@@ -92,6 +113,9 @@ pub struct VerificationReport {
     pub ok: bool,
     /// How many segments were examined.
     pub segment_count: usize,
+    /// Executable payload identities retained for verify-before-load binding.
+    /// They become execution-eligible only when [`Self::ok`] is true.
+    pub executables: Vec<VerifiedExecutable>,
     /// One record per check performed, in check order.
     pub records: Vec<VerificationRecord>,
     /// The default-deny capability mapping this artifact resolves to.
@@ -250,11 +274,22 @@ pub fn verify(data: &[u8], opts: &VerifyOptions) -> RvfResult<VerificationReport
     }
 
     let ok = !records.iter().any(|r| r.outcome == Outcome::Fail);
+    let executables = segments
+        .iter()
+        .filter(|seg| seg.is_executable())
+        .map(|seg| VerifiedExecutable {
+            segment_id: seg.header.segment_id,
+            segment_type: seg.header.seg_type,
+            byte_length: seg.header.payload_length,
+            sha256: sha256(seg.payload(data)),
+        })
+        .collect();
     Ok(VerificationReport {
         rvf_identity: identity,
         byte_length: data.len() as u64,
         ok,
         segment_count: segments.len(),
+        executables,
         records,
         capabilities,
         size_violations,

--- a/docs/adr/ADR-155-rvf-execution-contract.md
+++ b/docs/adr/ADR-155-rvf-execution-contract.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-08-05
+**Updated**: 2026-08-05 — runtime module bytes are matched against verified executable-segment identities before start or created-state restore (rvm#19).
 **Authors**: Claude Code
 **Supersedes**: None
 **Related**: ADR-132 (Hypervisor Core), ADR-134 (Witness Schema), ADR-135 (Proof Verifier), ADR-140 (Agent Runtime Adapter), ADR-149 (RVF Integration), RuVector ADR-284 (RVF Execution Contract), RuVector ADR-285 (Hosted RVM Security Boundary), RuVector ADR-286 (Capability Schema Mapping), RuVector ADR-287 (WASM Component Model), RuVector ADR-291 (Runtime Compatibility and Version Negotiation)
@@ -119,6 +120,10 @@ inspection and packaging tooling:
    independently against its manifest-declared hash.
 3. **Reject unsigned executable segments by default.** A model or data segment
    may be policy-permitted unsigned; an executable one may not.
+   Before start or a created-state restore, the supplied module bytes must
+   match the length and SHA-256 identity of an executable segment retained by
+   the passing verification report. A mismatch is witnessed and refused
+   before adapter admission or agent creation.
 4. **Never execute RVF content during inspection or packaging.** `rvm inspect`
    and `rvm verify` are first-class operations distinct from `rvm run` precisely
    so that pointing a scanner at a hostile artifact is safe. This is the runtime


### PR DESCRIPTION
Rebase of #22 by @proffesor-for-testing onto current `main`, with the discriminant collision resolved. Original authorship preserved in the commit.

## The gap

`Instance::start` and `Instance::restore` accepted a `module` byte slice that was never checked against the RVF that had just been verified. Verification proved something about one set of bytes; execution could then run a different set. Nothing in the type system connected them.

## The fix

`verify()` now retains a `VerifiedExecutable` per executable segment — segment id, type, exact byte length, and SHA-256 of the payload — on the `VerificationReport`, explicitly execution-eligible only when `report.ok` is true. `Instance` gains `guard_executable`, called on both `start` and the `Created` branch of `restore`, which refuses bytes that don't match and emits an `ExecutableRejected` witness record before returning `ExecutableMismatch`.

## Conflict resolution

`main` had independently added `ContextPermitMismatch` / `ContextPermitRejected = 10` in the same two enums. **Both changes are wanted and both claimed discriminant 10.** Resolved by keeping both and moving `ExecutableRejected` to `11`, updating the decode arm, widening `ALL` to 11, and folding the duplicated match arms in `action_kind`, `is_refusal`, and `From<LaunchError> for RvmError` into single arms listing both variants.

`proof_tier` keeps `ExecutableRejected` at tier 2 while `ContextPermitRejected` falls through to tier 1, matching each event's documented row.

## Verification

`cargo check --workspace --locked` clean; **1,279 tests pass, 0 fail.** The witness encode/decode round-trip covers the renumbered discriminant.

Closes #22.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5