### PR TITLE
fix(deps): move off the yanked spin 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
-spin = { version = "0.9", default-features = false }
+spin = { version = "0.10", default-features = false }
 bitflags = { version = "2", default-features = false }
 
 # Testing


### PR DESCRIPTION
`cargo audit` reports `spin 0.9.8` as **yanked**. Bumps the workspace pin to `0.10` (resolves to 0.10.1). No source changes were needed.

Supersedes #30 by @proffesor-for-testing, which carried the same one-line bump but had drifted into a `Cargo.lock` conflict against `main`.

Verified: `cargo check --workspace --locked` and the full test suite pass. The `rvm-hal` `uninlined_format_args` clippy failure reproduces identically on pristine `main` with the local 1.97 toolchain and is unrelated to this change — CI runs stable and is unaffected.

Closes #30.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5