### PR TITLE
docs: refresh stale counts, complete the ADR table, link LatentMesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,22 @@ See [ADR-144](docs/adr/ADR-144-gpu-compute-support.md) for the complete architec
 | ADR-140 | Agent runtime adapter |
 | ADR-141 | Coherence engine kernel integration and runtime pipeline |
 | ADR-142 | TEE-backed cryptographic verification (SHA-256, Ed25519, HMAC-SHA256, TEE pipeline) |
+| ADR-143 | Nightly verified release pipeline |
+| ADR-144 | GPU compute support via cuda-rust-wasm |
+| ADR-145 | IPC protocol semantics |
+| ADR-146 | SMP scheduling model |
+| ADR-147 | Hardware abstraction layer contract |
+| ADR-148 | Error model and recovery state machine |
+| ADR-149 | RVF integration for RVM |
+| ADR-150 | Device lease lifecycle protocol |
+| ADR-151 | GPU witness event registry |
+| ADR-152 | GPU MinCut correctness model |
+| ADR-153 | Multi-node mesh protocol |
+| ADR-154 | Formal verification roadmap |
+| ADR-155 | RVF execution contract for RVForge packages |
+| ADR-156 | External receipt anchoring into the witness chain |
+| ADR-157 | Capability-governed `ruv://` context namespace |
+| ADR-158 | Durable hosted `ruv://` context service |
 
 </details>
 
@@ -893,6 +909,17 @@ revisions.
 See [ADR-155](docs/adr/ADR-155-rvf-execution-contract.md) for the decision
 record and [RVForge Integration Map](docs/RVFORGE-INTEGRATION.md) for the
 crate-by-crate division of responsibility and roadmap.
+
+---
+
+## Related
+
+[`ruvnet/LatentMesh`](https://github.com/ruvnet/LatentMesh) — a research prototype for
+causally-verified latent agent communication. Its
+[ADR-008](https://github.com/ruvnet/LatentMesh/blob/main/docs/adr/008-capability-governed-execution.md)
+names RVM as the intended capability-ceiling enforcer for latent execution,
+mirroring how RVM already enforces authority ceilings for code. Design-stage:
+not yet wired to a live RVM runtime.
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,4 +33,4 @@ cargo test -p rvm-tests
 
 ## Workspace Dependencies
 
-All 13 RVM crates (rvm-types through rvm-kernel).
+All 21 RVM crates, `rvm-types` through `rvm-launch`.

--- a/userguide/01-quickstart.md
+++ b/userguide/01-quickstart.md
@@ -45,7 +45,8 @@ qemu-system-aarch64 --version   # should print 8.0 or higher
 
 ## Step 1: Clone and Build
 
-Clone the repository and verify that all 945 tests pass on your host machine:
+Clone the repository and verify that the full suite passes on your host machine
+(1,279 tests at the time of writing; treat CI as the current authority):
 
 ```bash
 git clone https://github.com/ruvnet/rvm.git

--- a/userguide/04-crate-reference.md
+++ b/userguide/04-crate-reference.md
@@ -1,6 +1,11 @@
-# Crate Reference: All 13 RVM Crates
+# Crate Reference: The 13 Core RVM Crates
 
-This chapter provides a concise reference for every crate in the RVM workspace.
+This chapter provides a concise reference for the thirteen core crates, `rvm-types`
+through `rvm-kernel`.
+
+The workspace has since grown to 21. Not yet covered here: `rvm-anchor`,
+`rvm-context`, `rvm-context-service`, `rvm-context-wasm`, `rvm-gpu`, `rvm-host`,
+`rvm-launch`, and `rvm-rvf`.
 Each section describes what the crate does, lists its key public types, notes
 its feature flags and internal dependencies, and points to the chapter with
 deeper coverage.

--- a/userguide/15-glossary.md
+++ b/userguide/15-glossary.md
@@ -218,7 +218,7 @@ the root partition delegating subsets of its authority. See [Bare-Metal
 Deployment](12-bare-metal.md).
 
 **RVM** (RuVix Virtual Machine) -- The coherence-native bare-metal
-microhypervisor. 13 crates, 648 tests, 11 benchmarks.
+microhypervisor. 21 crates, 1,279 tests, 9 benchmark groups.
 
 **RuVector** -- An optional library providing production-grade graph
 algorithms: MinCut, sparsification, spectral solvers, and IIT-inspired

--- a/userguide/cross-reference.md
+++ b/userguide/cross-reference.md
@@ -150,7 +150,7 @@ defined and the chapter that explains their usage.
 |---|---|
 | Build and run RVM for the first time | [01-quickstart.md](01-quickstart.md) |
 | Understand RVM's key ideas before diving into code | [02-core-concepts.md](02-core-concepts.md) |
-| See how the 13 crates fit together | [03-architecture.md](03-architecture.md) |
+| See how the crates fit together | [03-architecture.md](03-architecture.md) |
 | Find the API for a specific crate | [04-crate-reference.md](04-crate-reference.md) |
 | Add capability checks to an operation | [05-capabilities-proofs.md](05-capabilities-proofs.md) |
 | Submit and verify a proof | [05-capabilities-proofs.md](05-capabilities-proofs.md) |


### PR DESCRIPTION
Supersedes #12, #14 and #34 by @proffesor-for-testing — each had drifted past the tree it was correcting.

## Counts

#14 proposed 13 → 14 crates and 648 → 945 tests. The tree now has **21 crates and 1,279 passing tests**, so its corrected numbers were themselves stale. Fixed with measured values, including **9 criterion benchmark groups** rather than 11. `01-quickstart.md` no longer asserts an exact suite size as a precondition and points at CI as the authority.

## The one worth reading

`userguide/04-crate-reference.md` documents thirteen crates and only thirteen. Raising its title to 21 would have **claimed coverage the chapter does not have** — the stale-count fix would have made the page more wrong, not less. Retitled to name its real scope, with the eight uncovered crates listed explicitly (`rvm-anchor`, `rvm-context`, `rvm-context-service`, `rvm-context-wasm`, `rvm-gpu`, `rvm-host`, `rvm-launch`, `rvm-rvf`).

## ADR table

#12 proposed extending 132–144 to 132–154; the tree has **132–158**, and the badge already reads "index" rather than a range, so only the table needed work. Extended through ADR-158 with titles read from the files rather than from the PR.

## Related section

The rest of #34 — the `rvm-host`/`rvm-launch` rows, the RVForge Pages URL, the redrawn contract diagram — is **already on main**, so only the LatentMesh link remained. I verified the repo is public and that `docs/adr/008-capability-governed-execution.md` exists before repeating the claim, and linked that ADR directly.

Closes #12. Closes #14. Closes #34.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5