### PR TITLE
perf(context): cut ruv:// parse cost by ~18%, stop allocating in fingerprint

### DIFF
--- a/benches/benches/context.rs
+++ b/benches/benches/context.rs
@@ -1,7 +1,12 @@
-//! Benchmarks for canonical `ruv://` parsing.
+//! Benchmarks for the `ruv://` naming and scope-containment path.
+//!
+//! These two groups cover what a host authorization gate actually runs per
+//! request: parse the name, then decide whether it falls inside a granted
+//! scope. Scope containment is the whole shadow-mode question — it needs no
+//! capability, no runtime and no key — so it is worth measuring on its own.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rvm_context::RuvUri;
+use rvm_context::{ContextScope, ContextViewMask, RuvUri};
 
 const ALIAS: &str =
     "ruv://context.example/acme/agent/researcher/resources/projects/orion/spec?view=overview";
@@ -10,6 +15,7 @@ const PINNED: &str = concat!(
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     "&view=content",
 );
+const BARE: &str = "ruv://context.example/acme/agent/researcher/memory";
 
 fn bench_context_uri(c: &mut Criterion) {
     c.bench_function("ruv_uri_parse_alias", |b| {
@@ -18,6 +24,9 @@ fn bench_context_uri(c: &mut Criterion) {
     c.bench_function("ruv_uri_parse_pinned", |b| {
         b.iter(|| RuvUri::parse(black_box(PINNED)).unwrap());
     });
+    c.bench_function("ruv_uri_parse_bare", |b| {
+        b.iter(|| RuvUri::parse(black_box(BARE)).unwrap());
+    });
 
     let parsed = RuvUri::parse(PINNED).unwrap();
     c.bench_function("ruv_uri_format_pinned", |b| {
@@ -25,5 +34,39 @@ fn bench_context_uri(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_context_uri);
+fn bench_scope(c: &mut Criterion) {
+    let mask = ContextViewMask::from_bits(0b0000_0111).expect("mask");
+    let root = RuvUri::parse("ruv://context.example/acme/agent/researcher/resources").unwrap();
+    let granted = ContextScope::from_uri(&root, mask);
+
+    // Inside the grant, three segments deeper.
+    let inside = ContextScope::from_uri(&RuvUri::parse(ALIAS).unwrap(), mask);
+    // A different tenant: the cross-tenant reach a gateway must refuse.
+    let other_tenant = ContextScope::from_uri(
+        &RuvUri::parse("ruv://context.example/borl/agent/researcher/resources/projects").unwrap(),
+        mask,
+    );
+    // Same tenant and prefix depth, diverging at the LAST prefix segment —
+    // the position a short-circuiting comparison gets wrong.
+    let diverges_last = ContextScope::from_uri(
+        &RuvUri::parse("ruv://context.example/acme/agent/researcher/skills/projects/orion/spec")
+            .unwrap(),
+        mask,
+    );
+
+    c.bench_function("scope_from_uri", |b| {
+        b.iter(|| ContextScope::from_uri(black_box(&root), black_box(mask)));
+    });
+    c.bench_function("scope_contains_hit", |b| {
+        b.iter(|| black_box(&granted).contains_scope(black_box(&inside)));
+    });
+    c.bench_function("scope_contains_miss_tenant", |b| {
+        b.iter(|| black_box(&granted).contains_scope(black_box(&other_tenant)));
+    });
+    c.bench_function("scope_contains_miss_last_segment", |b| {
+        b.iter(|| black_box(&granted).contains_scope(black_box(&diverges_last)));
+    });
+}
+
+criterion_group!(benches, bench_context_uri, bench_scope);
 criterion_main!(benches);

--- a/crates/rvm-context/src/capability.rs
+++ b/crates/rvm-context/src/capability.rs
@@ -309,18 +309,22 @@ impl ContextScope {
     fn fingerprint(&self) -> u64 {
         let mut hasher = Sha256::new();
         hasher.update(b"RUV-CONTEXT-SCOPE-V1");
-        hasher.update(self.authority.to_string().as_bytes());
+        // `Display` for each of these is exactly `f.write_str(self.as_str())`,
+        // so `as_str` hashes byte-identical input to the `to_string` this
+        // replaces -- without allocating a String per component to read it.
+        // `fingerprint_is_unchanged_by_the_as_str_rewrite` pins that.
+        hasher.update(self.authority.as_str().as_bytes());
         hasher.update([0]);
-        hasher.update(self.tenant.to_string().as_bytes());
+        hasher.update(self.tenant.as_str().as_bytes());
         hasher.update([0]);
         hasher.update(self.subject.kind().as_str().as_bytes());
         hasher.update([0]);
         hasher.update(self.subject.id().as_str().as_bytes());
         hasher.update([0]);
-        hasher.update(self.collection.to_string().as_bytes());
+        hasher.update(self.collection.as_str().as_bytes());
         for segment in &self.path_prefix {
             hasher.update([0xff]);
-            hasher.update(segment.to_string().as_bytes());
+            hasher.update(segment.as_str().as_bytes());
         }
         hasher.update([self.views.bits()]);
         let digest = hasher.finalize();
@@ -1127,6 +1131,36 @@ mod tests {
                 ContextScope::from_uri(&uri("docs", None, false), ContextViewMask::ALL),
             ),
             Err(ContextError::AccessDenied)
+        );
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_stability_tests {
+    use super::*;
+    use crate::uri::RuvUri;
+
+    fn fp(uri: &str) -> u64 {
+        let parsed = RuvUri::parse(uri).expect("parses");
+        let mask = ContextViewMask::from_bits(0b0000_0111).expect("mask");
+        ContextScope::from_uri(&parsed, mask).fingerprint()
+    }
+
+    /// A scope fingerprint becomes a capability badge, so its bytes are an
+    /// identity, not an implementation detail. These values were captured
+    /// before `fingerprint` moved from `to_string` to `as_str`; they must not
+    /// move again without a deliberate, versioned change to the hash input.
+    #[test]
+    fn fingerprint_is_unchanged_by_the_as_str_rewrite() {
+        assert_eq!(
+            fp("ruv://context.example/acme/agent/researcher/memory"),
+            0xded4_a8a4_26a1_881d,
+            "bare-collection scope fingerprint changed"
+        );
+        assert_eq!(
+            fp("ruv://context.example/acme/agent/researcher/resources/projects/orion/spec"),
+            0x668d_962c_6040_c9ea,
+            "path-prefixed scope fingerprint changed"
         );
     }
 }

--- a/crates/rvm-context/src/uri.rs
+++ b/crates/rvm-context/src/uri.rs
@@ -111,13 +111,24 @@ impl fmt::Display for UriError {
 impl std::error::Error for UriError {}
 
 fn reject_forbidden_octets(value: &str) -> Result<(), UriError> {
-    if !value.is_ascii() {
+    // One pass collecting three verdicts. The verdicts are ranked after the
+    // scan rather than during it, so which error a caller sees never depends on
+    // which forbidden byte happens to appear first.
+    let mut non_ascii = false;
+    let mut percent = false;
+    let mut fragment = false;
+    for &byte in value.as_bytes() {
+        non_ascii |= !byte.is_ascii();
+        percent |= byte == b'%';
+        fragment |= byte == b'#';
+    }
+    if non_ascii {
         return Err(UriError::NonAscii);
     }
-    if value.as_bytes().contains(&b'%') {
+    if percent {
         return Err(UriError::PercentEncodingNotAllowed);
     }
-    if value.as_bytes().contains(&b'#') {
+    if fragment {
         return Err(UriError::FragmentNotAllowed);
     }
     Ok(())
@@ -151,6 +162,18 @@ impl Authority {
     /// or contains credentials, a port, percent encoding, or non-ASCII bytes.
     pub fn new(value: &str) -> Result<Self, UriError> {
         reject_forbidden_octets(value)?;
+        Self::new_prevalidated(value)
+    }
+
+    /// Constructs without re-scanning for globally forbidden octets.
+    ///
+    /// [`RuvUri::from_str`] validates the whole input with
+    /// [`reject_forbidden_octets`] before it splits on `/`, so every component it
+    /// derives is already known to be ASCII and free of `%` and `#`. Re-scanning
+    /// each component repeats that work once per component. The public `new`
+    /// constructors keep the scan, because their callers arrive with text nobody
+    /// has checked.
+    fn new_prevalidated(value: &str) -> Result<Self, UriError> {
         if value.as_bytes().contains(&b'@') {
             return Err(UriError::CredentialsNotAllowed);
         }
@@ -224,6 +247,18 @@ impl TenantId {
     /// 63 bytes or contains a globally forbidden URI byte.
     pub fn new(value: &str) -> Result<Self, UriError> {
         reject_forbidden_octets(value)?;
+        Self::new_prevalidated(value)
+    }
+
+    /// Constructs without re-scanning for globally forbidden octets.
+    ///
+    /// [`RuvUri::from_str`] validates the whole input with
+    /// [`reject_forbidden_octets`] before it splits on `/`, so every component it
+    /// derives is already known to be ASCII and free of `%` and `#`. Re-scanning
+    /// each component repeats that work once per component. The public `new`
+    /// constructors keep the scan, because their callers arrive with text nobody
+    /// has checked.
+    fn new_prevalidated(value: &str) -> Result<Self, UriError> {
         if !is_slug(value) {
             return Err(UriError::InvalidTenant);
         }
@@ -278,6 +313,18 @@ impl SubjectId {
     /// 63 bytes or contains a globally forbidden URI byte.
     pub fn new(value: &str) -> Result<Self, UriError> {
         reject_forbidden_octets(value)?;
+        Self::new_prevalidated(value)
+    }
+
+    /// Constructs without re-scanning for globally forbidden octets.
+    ///
+    /// [`RuvUri::from_str`] validates the whole input with
+    /// [`reject_forbidden_octets`] before it splits on `/`, so every component it
+    /// derives is already known to be ASCII and free of `%` and `#`. Re-scanning
+    /// each component repeats that work once per component. The public `new`
+    /// constructors keep the scan, because their callers arrive with text nobody
+    /// has checked.
+    fn new_prevalidated(value: &str) -> Result<Self, UriError> {
         if !is_slug(value) {
             return Err(UriError::InvalidSubjectId);
         }
@@ -448,6 +495,18 @@ impl PathSegment {
     /// set.
     pub fn new(value: &str) -> Result<Self, UriError> {
         reject_forbidden_octets(value)?;
+        Self::new_prevalidated(value)
+    }
+
+    /// Constructs without re-scanning for globally forbidden octets.
+    ///
+    /// [`RuvUri::from_str`] validates the whole input with
+    /// [`reject_forbidden_octets`] before it splits on `/`, so every component it
+    /// derives is already known to be ASCII and free of `%` and `#`. Re-scanning
+    /// each component repeats that work once per component. The public `new`
+    /// constructors keep the scan, because their callers arrive with text nobody
+    /// has checked.
+    fn new_prevalidated(value: &str) -> Result<Self, UriError> {
         if value.is_empty() {
             return Err(UriError::EmptyPathSegment);
         }
@@ -799,10 +858,12 @@ impl FromStr for RuvUri {
             return Err(UriError::EmptyPathSegment);
         }
 
-        let authority = Authority::new(components[0])?;
-        let tenant = TenantId::new(components[1])?;
+        // reject_forbidden_octets ran over the whole input above, so the
+        // components carved out of it need no second scan.
+        let authority = Authority::new_prevalidated(components[0])?;
+        let tenant = TenantId::new_prevalidated(components[1])?;
         let subject_kind = components[2].parse()?;
-        let subject_id = SubjectId::new(components[3])?;
+        let subject_id = SubjectId::new_prevalidated(components[3])?;
         let collection = components[4].parse()?;
         let path_count = component_count - 5;
         if path_count > MAX_PATH_SEGMENTS {
@@ -816,7 +877,7 @@ impl FromStr for RuvUri {
         }
         let path = path_parts
             .iter()
-            .map(|part| PathSegment::new(part))
+            .map(|part| PathSegment::new_prevalidated(part))
             .collect::<Result<Vec<_>, _>>()?;
         let (revision, view) = parse_query(query)?;
 


### PR DESCRIPTION
A gateway placing the `ruv://` gate in front of its own traffic parses a name on **every request**, so parse is the hot path. Three redundancies, each measured rather than assumed.

## Measurements

`criterion --save-baseline` against unmodified `main`, same bench file both sides:

| benchmark | main | this branch | change |
|---|---:|---:|---:|
| `ruv_uri_parse_alias` | 293.4 ns | 243.2 ns | **−17.6%** |
| `ruv_uri_parse_pinned` | 285.9 ns | 236.1 ns | **−18.0%** |
| `ruv_uri_parse_bare` | 177.9 ns | 134.9 ns | **−24.5%** |
| `scope_from_uri` | 36.5 ns | 35.0 ns | −3.9% |

## What changed

**1. Redundant octet scans (−14.6% alone).** `reject_forbidden_octets` ran once over the whole input in `from_str`, then *again* inside `Authority::new`, `TenantId::new`, `SubjectId::new` and every `PathSegment::new` — seven calls for a three-segment name, each making three separate passes. Since `from_str` validates the entire input *before* splitting on `/`, every component it derives is already known clean. Each constructor splits into a public `new` that keeps the scan for callers arriving with unchecked text, and a private `new_prevalidated` used by `from_str`.

**2. Three passes → one (−4.4% more).** The scan now collects three verdicts in a single pass, **ranked after the scan rather than during it**, so which error a caller sees still doesn't depend on which forbidden byte happens to appear first. Error precedence is unchanged.

**3. `fingerprint` stops allocating.** It called `.to_string()` on the authority, tenant, collection and every path segment purely to read their bytes. `Display` for each is exactly `f.write_str(self.as_str())`, so `as_str` hashes byte-identical input.

A scope fingerprint becomes a **capability badge**, so those bytes are an identity, not an implementation detail. I captured the values *before* the rewrite and pinned them in a new test — they are unchanged, and the test makes that suite-checkable rather than reviewer-checkable.

## New coverage

Scope containment had **no benchmark at all**, despite being the whole shadow-mode question. It measures **4.7–7.7 ns** and is allocation-free — so once a name is parsed, deciding whether it falls inside a grant is ~7 ns, and **parse dominates per-request cost by roughly 30×**. If shadow-mode throughput ever matters, parse is where to look, not containment.

Added a bare-collection parse case too, which isolates the per-path-segment allocation cost (~35 ns/segment).

## Tried and reverted

`Box<str>` component storage shrinks `RuvUri` from 144 → 120 bytes but **regressed parse ~3%**, so it lost on the metric being optimised and is not in this branch.

## Honest note

`scope_contains_miss_last_segment` shows +2.6%. `contains_scope` is untouched by this branch; that is 0.18 ns of codegen noise on a 7 ns measurement, not a real regression.

## Verification

1,280 workspace tests pass. `aarch64-unknown-none` and the `wasm32-unknown-unknown` binding both still build clean, and `rvm-context-wasm` clippy is clean under `-D warnings`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5