### PR TITLE
feat(context): monotonic flow labels and explicit context egress budgets

### DIFF
--- a/crates/rvm-context/src/flow.rs
+++ b/crates/rvm-context/src/flow.rs
@@ -1,0 +1,523 @@
+//! Monotonic data-flow labels and explicit egress budgets for governed context.
+//!
+//! This module protects a boundary that action-scoped capability checks alone
+//! cannot express: whether data derived from sensitive runtime context may be
+//! disclosed to a particular sink. Labels are evidence about data lineage, not
+//! execution authority. An [`EgressBudget`] is likewise a policy input and does
+//! not mint, widen, or replace an RVM capability.
+//!
+//! Version 1 intentionally has no declassification API. Transformations may
+//! preserve or add sensitivity through [`FlowLabel::join`], but ordinary model,
+//! tool, memory, summary, or delegation paths cannot remove a class.
+
+use alloc::vec::Vec;
+use sha2::{Digest, Sha256};
+
+/// Maximum number of parents accepted by one flow join.
+pub const MAX_FLOW_PARENTS: usize = 64;
+
+/// Maximum byte length of a source or transformation tag.
+pub const MAX_FLOW_TAG_BYTES: usize = 4096;
+
+const FLOW_SOURCE_DOMAIN: &[u8] = b"rvm-context-flow-source-v1";
+const FLOW_DERIVE_DOMAIN: &[u8] = b"rvm-context-flow-derive-v1";
+const FLOW_JOIN_DOMAIN: &[u8] = b"rvm-context-flow-join-v1";
+
+/// Data classes propagated through model-facing context transformations.
+///
+/// The representation is deliberately compact so it can cross WASM, embedded,
+/// and bare-metal boundaries without allocation. Unknown bits are rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FlowClasses(u16);
+
+impl FlowClasses {
+    /// Public data that may be disclosed when the sink policy permits it.
+    pub const PUBLIC: Self = Self(1 << 0);
+    /// User or task input scoped to the current task.
+    pub const TASK_INPUT: Self = Self(1 << 1);
+    /// Ephemeral runtime context such as conversation or execution state.
+    pub const RUNTIME_CONTEXT: Self = Self(1 << 2);
+    /// Persistent memory or knowledge retrieved across task boundaries.
+    pub const PERSISTENT_MEMORY: Self = Self(1 << 3);
+    /// Tool names, descriptions, schemas, or other tool metadata.
+    pub const TOOL_METADATA: Self = Self(1 << 4);
+    /// Explicit secrets, credentials, or similarly restricted material.
+    pub const SECRET: Self = Self(1 << 5);
+    /// Every class understood by this contract version.
+    pub const ALL: Self = Self(
+        Self::PUBLIC.0
+            | Self::TASK_INPUT.0
+            | Self::RUNTIME_CONTEXT.0
+            | Self::PERSISTENT_MEMORY.0
+            | Self::TOOL_METADATA.0
+            | Self::SECRET.0,
+    );
+    /// No data classes. Useful for a deny-all egress budget.
+    pub const NONE: Self = Self(0);
+
+    /// Construct a class set from raw bits, rejecting unknown classes.
+    #[must_use]
+    pub const fn from_bits(bits: u16) -> Option<Self> {
+        if bits & !Self::ALL.0 == 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    /// Return the stable wire representation.
+    #[must_use]
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+
+    /// Return true when this set contains no classes.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Return the union of two class sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Return true when every class in `self` is allowed by `other`.
+    #[must_use]
+    pub const fn is_subset_of(self, other: Self) -> bool {
+        self.0 & !other.0 == 0
+    }
+
+    /// Return true when this set includes every class in `other`.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        other.is_subset_of(self)
+    }
+}
+
+/// Error returned by flow-label construction or transformation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowError {
+    /// A source label was created without any data class.
+    EmptyClasses,
+    /// A task scope identifier was all zeroes.
+    EmptyTaskScope,
+    /// A sink identifier was all zeroes.
+    EmptySink,
+    /// A source or transformation tag was empty.
+    EmptyTag,
+    /// A source or transformation tag exceeded [`MAX_FLOW_TAG_BYTES`].
+    TagTooLarge,
+    /// A join was requested without parent labels.
+    NoParents,
+    /// A join exceeded [`MAX_FLOW_PARENTS`].
+    TooManyParents,
+    /// Parent labels from different task scopes were mixed.
+    CrossTaskJoin,
+}
+
+/// Result type for flow operations.
+pub type FlowResult<T> = core::result::Result<T, FlowError>;
+
+/// Monotonic sensitivity and lineage attached to a context value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FlowLabel {
+    classes: FlowClasses,
+    task_scope: [u8; 32],
+    lineage_hash: [u8; 32],
+}
+
+impl FlowLabel {
+    /// Create a source label.
+    ///
+    /// `source_tag` should identify the originating evidence or artifact. It is
+    /// hashed into the lineage and is never interpreted as authority.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty class set, an all-zero task scope, an empty tag, or a
+    /// tag larger than [`MAX_FLOW_TAG_BYTES`].
+    pub fn source(
+        classes: FlowClasses,
+        task_scope: [u8; 32],
+        source_tag: &[u8],
+    ) -> FlowResult<Self> {
+        validate_source(classes, &task_scope, source_tag)?;
+        let mut hasher = Sha256::new();
+        hasher.update(FLOW_SOURCE_DOMAIN);
+        hasher.update(classes.bits().to_be_bytes());
+        hasher.update(task_scope);
+        hasher.update((source_tag.len() as u64).to_be_bytes());
+        hasher.update(source_tag);
+        Ok(Self {
+            classes,
+            task_scope,
+            lineage_hash: hasher.finalize().into(),
+        })
+    }
+
+    /// Derive a child label while preserving all parent sensitivity classes.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty transformation tag or a tag larger than
+    /// [`MAX_FLOW_TAG_BYTES`].
+    pub fn derive(&self, transform_tag: &[u8]) -> FlowResult<Self> {
+        validate_tag(transform_tag)?;
+        let mut hasher = Sha256::new();
+        hasher.update(FLOW_DERIVE_DOMAIN);
+        hasher.update(self.lineage_hash);
+        hasher.update(self.classes.bits().to_be_bytes());
+        hasher.update((transform_tag.len() as u64).to_be_bytes());
+        hasher.update(transform_tag);
+        Ok(Self {
+            classes: self.classes,
+            task_scope: self.task_scope,
+            lineage_hash: hasher.finalize().into(),
+        })
+    }
+
+    /// Join multiple parents into one label, unioning every sensitivity class.
+    ///
+    /// Parent order is intentionally committed to the lineage because ordered
+    /// transformations may have different semantics. No parent class can be
+    /// removed by a join.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero parents, too many parents, mixed task scopes, or an invalid
+    /// transformation tag.
+    pub fn join(parents: &[Self], transform_tag: &[u8]) -> FlowResult<Self> {
+        if parents.is_empty() {
+            return Err(FlowError::NoParents);
+        }
+        if parents.len() > MAX_FLOW_PARENTS {
+            return Err(FlowError::TooManyParents);
+        }
+        validate_tag(transform_tag)?;
+
+        let task_scope = parents[0].task_scope;
+        let mut classes = FlowClasses::NONE;
+        for parent in parents {
+            if parent.task_scope != task_scope {
+                return Err(FlowError::CrossTaskJoin);
+            }
+            classes = classes.union(parent.classes);
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(FLOW_JOIN_DOMAIN);
+        hasher.update((parents.len() as u64).to_be_bytes());
+        for parent in parents {
+            hasher.update(parent.lineage_hash);
+            hasher.update(parent.classes.bits().to_be_bytes());
+        }
+        hasher.update((transform_tag.len() as u64).to_be_bytes());
+        hasher.update(transform_tag);
+
+        Ok(Self {
+            classes,
+            task_scope,
+            lineage_hash: hasher.finalize().into(),
+        })
+    }
+
+    /// Return the sensitivity classes carried by this value.
+    #[must_use]
+    pub const fn classes(&self) -> FlowClasses {
+        self.classes
+    }
+
+    /// Return the exact task scope to which this value belongs.
+    #[must_use]
+    pub const fn task_scope(&self) -> &[u8; 32] {
+        &self.task_scope
+    }
+
+    /// Return the deterministic evidence-lineage digest.
+    #[must_use]
+    pub const fn lineage_hash(&self) -> &[u8; 32] {
+        &self.lineage_hash
+    }
+}
+
+/// Reason recorded for an egress authorization decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EgressDecision {
+    /// The label fits the sink's explicit task scope and class budget.
+    Allowed,
+    /// The data belongs to a different task scope from the sink budget.
+    TaskScopeMismatch,
+    /// At least one sensitivity class is not allowed to reach the sink.
+    ClassDenied,
+}
+
+impl EgressDecision {
+    /// Return true only for an allowed disclosure decision.
+    #[must_use]
+    pub const fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
+/// Explicit disclosure budget for one sink and one task scope.
+///
+/// This object must be constructed from trusted policy state. Tool metadata,
+/// model output, memory, and peer-agent messages must never be permitted to
+/// manufacture or widen it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EgressBudget {
+    sink_id: [u8; 32],
+    task_scope: [u8; 32],
+    allowed_classes: FlowClasses,
+}
+
+impl EgressBudget {
+    /// Construct a sink-specific disclosure budget.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an all-zero sink identifier or task scope.
+    pub fn new(
+        sink_id: [u8; 32],
+        task_scope: [u8; 32],
+        allowed_classes: FlowClasses,
+    ) -> FlowResult<Self> {
+        if is_zero(&sink_id) {
+            return Err(FlowError::EmptySink);
+        }
+        if is_zero(&task_scope) {
+            return Err(FlowError::EmptyTaskScope);
+        }
+        Ok(Self {
+            sink_id,
+            task_scope,
+            allowed_classes,
+        })
+    }
+
+    /// Evaluate whether a labeled value may be disclosed to this sink.
+    ///
+    /// The method always returns a receipt so denied flows are as observable as
+    /// allowed flows. Callers must still hold whatever RVM execution capability
+    /// is required to invoke the sink.
+    #[must_use]
+    pub const fn check(&self, label: &FlowLabel) -> EgressReceipt {
+        let decision = if label.task_scope != self.task_scope {
+            EgressDecision::TaskScopeMismatch
+        } else if !label.classes.is_subset_of(self.allowed_classes) {
+            EgressDecision::ClassDenied
+        } else {
+            EgressDecision::Allowed
+        };
+        EgressReceipt {
+            sink_id: self.sink_id,
+            task_scope: label.task_scope,
+            lineage_hash: label.lineage_hash,
+            classes: label.classes,
+            decision,
+        }
+    }
+
+    /// Return the sink identity committed by this budget.
+    #[must_use]
+    pub const fn sink_id(&self) -> &[u8; 32] {
+        &self.sink_id
+    }
+
+    /// Return the task scope accepted by this budget.
+    #[must_use]
+    pub const fn task_scope(&self) -> &[u8; 32] {
+        &self.task_scope
+    }
+
+    /// Return the maximum classes this sink may receive.
+    #[must_use]
+    pub const fn allowed_classes(&self) -> FlowClasses {
+        self.allowed_classes
+    }
+}
+
+/// Auditable result of checking one data label against one sink budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EgressReceipt {
+    sink_id: [u8; 32],
+    task_scope: [u8; 32],
+    lineage_hash: [u8; 32],
+    classes: FlowClasses,
+    decision: EgressDecision,
+}
+
+impl EgressReceipt {
+    /// Return the sink identity that was checked.
+    #[must_use]
+    pub const fn sink_id(&self) -> &[u8; 32] {
+        &self.sink_id
+    }
+
+    /// Return the task scope carried by the candidate data.
+    #[must_use]
+    pub const fn task_scope(&self) -> &[u8; 32] {
+        &self.task_scope
+    }
+
+    /// Return the evidence lineage of the candidate data.
+    #[must_use]
+    pub const fn lineage_hash(&self) -> &[u8; 32] {
+        &self.lineage_hash
+    }
+
+    /// Return the data classes presented to the sink policy.
+    #[must_use]
+    pub const fn classes(&self) -> FlowClasses {
+        self.classes
+    }
+
+    /// Return the policy decision.
+    #[must_use]
+    pub const fn decision(&self) -> EgressDecision {
+        self.decision
+    }
+}
+
+fn validate_source(classes: FlowClasses, task_scope: &[u8; 32], tag: &[u8]) -> FlowResult<()> {
+    if classes.is_empty() {
+        return Err(FlowError::EmptyClasses);
+    }
+    if is_zero(task_scope) {
+        return Err(FlowError::EmptyTaskScope);
+    }
+    validate_tag(tag)
+}
+
+fn validate_tag(tag: &[u8]) -> FlowResult<()> {
+    if tag.is_empty() {
+        return Err(FlowError::EmptyTag);
+    }
+    if tag.len() > MAX_FLOW_TAG_BYTES {
+        return Err(FlowError::TagTooLarge);
+    }
+    Ok(())
+}
+
+const fn is_zero(value: &[u8; 32]) -> bool {
+    let mut i = 0;
+    while i < value.len() {
+        if value[i] != 0 {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TASK_A: [u8; 32] = [1; 32];
+    const TASK_B: [u8; 32] = [2; 32];
+    const SINK: [u8; 32] = [7; 32];
+
+    fn source(classes: FlowClasses) -> FlowLabel {
+        FlowLabel::source(classes, TASK_A, b"source").expect("valid source")
+    }
+
+    #[test]
+    fn permits_only_explicitly_budgeted_classes() {
+        let label = source(FlowClasses::TASK_INPUT);
+        let budget = EgressBudget::new(SINK, TASK_A, FlowClasses::TASK_INPUT).unwrap();
+        assert_eq!(budget.check(&label).decision(), EgressDecision::Allowed);
+    }
+
+    #[test]
+    fn runtime_context_is_denied_without_explicit_budget() {
+        let label = source(FlowClasses::RUNTIME_CONTEXT);
+        let budget = EgressBudget::new(SINK, TASK_A, FlowClasses::TASK_INPUT).unwrap();
+        assert_eq!(budget.check(&label).decision(), EgressDecision::ClassDenied);
+    }
+
+    #[test]
+    fn task_scope_mismatch_fails_closed() {
+        let label = source(FlowClasses::TASK_INPUT);
+        let budget = EgressBudget::new(SINK, TASK_B, FlowClasses::ALL).unwrap();
+        assert_eq!(
+            budget.check(&label).decision(),
+            EgressDecision::TaskScopeMismatch
+        );
+    }
+
+    #[test]
+    fn derivation_preserves_classes_and_changes_lineage() {
+        let parent = source(FlowClasses::RUNTIME_CONTEXT);
+        let child = parent.derive(b"summary").unwrap();
+        assert_eq!(child.classes(), parent.classes());
+        assert_ne!(child.lineage_hash(), parent.lineage_hash());
+    }
+
+    #[test]
+    fn join_unions_sensitivity() {
+        let task = source(FlowClasses::TASK_INPUT);
+        let memory = source(FlowClasses::PERSISTENT_MEMORY);
+        let joined = FlowLabel::join(&[task, memory], b"compose").unwrap();
+        assert!(joined.classes().contains(FlowClasses::TASK_INPUT));
+        assert!(joined.classes().contains(FlowClasses::PERSISTENT_MEMORY));
+    }
+
+    #[test]
+    fn cross_task_join_is_rejected() {
+        let a = source(FlowClasses::TASK_INPUT);
+        let b = FlowLabel::source(FlowClasses::PUBLIC, TASK_B, b"other").unwrap();
+        assert_eq!(
+            FlowLabel::join(&[a, b], b"compose"),
+            Err(FlowError::CrossTaskJoin)
+        );
+    }
+
+    #[test]
+    fn malformed_inputs_are_rejected() {
+        assert_eq!(
+            FlowLabel::source(FlowClasses::NONE, TASK_A, b"source"),
+            Err(FlowError::EmptyClasses)
+        );
+        assert_eq!(
+            FlowLabel::source(FlowClasses::PUBLIC, [0; 32], b"source"),
+            Err(FlowError::EmptyTaskScope)
+        );
+        assert_eq!(
+            FlowLabel::source(FlowClasses::PUBLIC, TASK_A, b""),
+            Err(FlowError::EmptyTag)
+        );
+        assert!(FlowClasses::from_bits(FlowClasses::ALL.bits() | (1 << 15)).is_none());
+    }
+
+    #[test]
+    fn tool_metadata_cannot_widen_an_egress_budget() {
+        let task = source(FlowClasses::TASK_INPUT);
+        let metadata = source(FlowClasses::TOOL_METADATA);
+        let influenced = FlowLabel::join(&[task, metadata], b"tool-call-arguments").unwrap();
+        let budget = EgressBudget::new(SINK, TASK_A, FlowClasses::TASK_INPUT).unwrap();
+        assert_eq!(
+            budget.check(&influenced).decision(),
+            EgressDecision::ClassDenied
+        );
+    }
+
+    #[test]
+    fn deny_all_budget_denies_even_public_data() {
+        let label = source(FlowClasses::PUBLIC);
+        let budget = EgressBudget::new(SINK, TASK_A, FlowClasses::NONE).unwrap();
+        assert!(!budget.check(&label).decision().is_allowed());
+    }
+
+    #[test]
+    fn parent_limit_blocks_resource_exhaustion() {
+        let parent = source(FlowClasses::PUBLIC);
+        let parents: Vec<_> = core::iter::repeat_n(parent, MAX_FLOW_PARENTS + 1).collect();
+        assert_eq!(
+            FlowLabel::join(&parents, b"too-many"),
+            Err(FlowError::TooManyParents)
+        );
+    }
+}

--- a/crates/rvm-context/src/flow.rs
+++ b/crates/rvm-context/src/flow.rs
@@ -10,7 +10,6 @@
 //! preserve or add sensitivity through [`FlowLabel::join`], but ordinary model,
 //! tool, memory, summary, or delegation paths cannot remove a class.
 
-use alloc::vec::Vec;
 use sha2::{Digest, Sha256};
 
 /// Maximum number of parents accepted by one flow join.
@@ -144,11 +143,12 @@ impl FlowLabel {
         source_tag: &[u8],
     ) -> FlowResult<Self> {
         validate_source(classes, &task_scope, source_tag)?;
+        let tag_len = u16::try_from(source_tag.len()).map_err(|_| FlowError::TagTooLarge)?;
         let mut hasher = Sha256::new();
         hasher.update(FLOW_SOURCE_DOMAIN);
         hasher.update(classes.bits().to_be_bytes());
         hasher.update(task_scope);
-        hasher.update((source_tag.len() as u64).to_be_bytes());
+        hasher.update(tag_len.to_be_bytes());
         hasher.update(source_tag);
         Ok(Self {
             classes,
@@ -165,11 +165,12 @@ impl FlowLabel {
     /// [`MAX_FLOW_TAG_BYTES`].
     pub fn derive(&self, transform_tag: &[u8]) -> FlowResult<Self> {
         validate_tag(transform_tag)?;
+        let tag_len = u16::try_from(transform_tag.len()).map_err(|_| FlowError::TagTooLarge)?;
         let mut hasher = Sha256::new();
         hasher.update(FLOW_DERIVE_DOMAIN);
         hasher.update(self.lineage_hash);
         hasher.update(self.classes.bits().to_be_bytes());
-        hasher.update((transform_tag.len() as u64).to_be_bytes());
+        hasher.update(tag_len.to_be_bytes());
         hasher.update(transform_tag);
         Ok(Self {
             classes: self.classes,
@@ -197,6 +198,8 @@ impl FlowLabel {
         }
         validate_tag(transform_tag)?;
 
+        let parent_count = u8::try_from(parents.len()).map_err(|_| FlowError::TooManyParents)?;
+        let tag_len = u16::try_from(transform_tag.len()).map_err(|_| FlowError::TagTooLarge)?;
         let task_scope = parents[0].task_scope;
         let mut classes = FlowClasses::NONE;
         for parent in parents {
@@ -208,12 +211,12 @@ impl FlowLabel {
 
         let mut hasher = Sha256::new();
         hasher.update(FLOW_JOIN_DOMAIN);
-        hasher.update((parents.len() as u64).to_be_bytes());
+        hasher.update([parent_count]);
         for parent in parents {
             hasher.update(parent.lineage_hash);
             hasher.update(parent.classes.bits().to_be_bytes());
         }
-        hasher.update((transform_tag.len() as u64).to_be_bytes());
+        hasher.update(tag_len.to_be_bytes());
         hasher.update(transform_tag);
 
         Ok(Self {
@@ -303,7 +306,7 @@ impl EgressBudget {
     /// allowed flows. Callers must still hold whatever RVM execution capability
     /// is required to invoke the sink.
     #[must_use]
-    pub const fn check(&self, label: &FlowLabel) -> EgressReceipt {
+    pub fn check(&self, label: &FlowLabel) -> EgressReceipt {
         let decision = if label.task_scope != self.task_scope {
             EgressDecision::TaskScopeMismatch
         } else if !label.classes.is_subset_of(self.allowed_classes) {
@@ -415,6 +418,7 @@ const fn is_zero(value: &[u8; 32]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     const TASK_A: [u8; 32] = [1; 32];
     const TASK_B: [u8; 32] = [2; 32];
@@ -514,7 +518,7 @@ mod tests {
     #[test]
     fn parent_limit_blocks_resource_exhaustion() {
         let parent = source(FlowClasses::PUBLIC);
-        let parents: Vec<_> = core::iter::repeat_n(parent, MAX_FLOW_PARENTS + 1).collect();
+        let parents = vec![parent; MAX_FLOW_PARENTS + 1];
         assert_eq!(
             FlowLabel::join(&parents, b"too-many"),
             Err(FlowError::TooManyParents)

--- a/crates/rvm-context/src/lib.rs
+++ b/crates/rvm-context/src/lib.rs
@@ -24,6 +24,7 @@ extern crate std;
 
 pub mod capability;
 pub mod error;
+pub mod flow;
 pub mod profile;
 pub mod receipt;
 pub mod resolver;
@@ -35,6 +36,10 @@ pub use capability::{
     ContextOperation, ContextRequest, ContextScope, ContextViewMask, MAX_SEARCH_RESULTS,
 };
 pub use error::{ContextError, ContextResult};
+pub use flow::{
+    EgressBudget, EgressDecision, EgressReceipt, FlowClasses, FlowError, FlowLabel, FlowResult,
+    MAX_FLOW_PARENTS, MAX_FLOW_TAG_BYTES,
+};
 pub use profile::{
     ContextProfile, ContextProfileError, DerivedView, ProfileTrust, ProfileView,
     VerifiedContextProfile, CONTEXT_PROFILE_MAGIC, CONTEXT_PROFILE_VERSION, MAX_CONTEXT_RVF_BYTES,

--- a/docs/adr/ADR-160-flow-egress-policy.md
+++ b/docs/adr/ADR-160-flow-egress-policy.md
@@ -1,0 +1,186 @@
+# ADR-160: Monotonic Context Flow Labels and Explicit Egress Budgets
+
+Status: Proposed
+Date: 2026-08-31
+Owners: RVM context and security maintainers
+Related: #53, #54, ADR-159
+
+## Context
+
+RVM already provides capability-scoped authorization for governed `ruv://` operations. That answers whether an actor may perform an action. It does not by itself answer whether data derived from sensitive runtime context may cross a later sink boundary through a sequence of individually authorized operations.
+
+Two recent results sharpen this gap.
+
+* ContextLeak, arXiv:2608.27800, submitted 2026-08-28, demonstrates malicious tool metadata that induces an agent both to select the tool and to pass runtime context as tool arguments. The originating team reports transfer to Claude Code backed by Claude Sonnet 4.6: 22 malicious selections in 100 trials, with near-complete extraction conditional on selection. PromptGuard, DataSentinel, PromptArmor, and Ant MCPScan show 0.97 to 1.00 false-negative rates against the evaluated malicious metadata.
+* ToolMinimize, arXiv:2608.24957, accepted at PST 2026, measures ordinary privacy oversharing even without a malicious tool. Across GPT-4o, Claude 3.5 Sonnet, and Llama-3.3-70B, 81 to 88 percent of default tool calls contain unnecessary privacy-sensitive data. The paper reports schema-aware argument rewriting reducing privacy cost by 81.2 to 92.0 percent at 100 percent argument-level validity, with 1.77 ms median middleware latency.
+
+These results suggest that tool trust screening and prompt hardening are necessary but insufficient. The runtime needs an authoritative boundary that constrains what classes of context may leave a task through a sink, independently of what the model or tool metadata requests.
+
+## Decision
+
+Add a small, no-std flow policy primitive to `rvm-context` with three rules.
+
+1. Every model-facing value that can reach an external sink may carry a `FlowLabel` containing a task scope, sensitivity class set, and deterministic lineage hash.
+2. Ordinary transformations are monotonic. Derivation preserves every class. Multi-source composition unions every parent class. Version 1 deliberately exposes no declassification API.
+3. Before disclosure, trusted policy supplies an `EgressBudget` for one sink and one task scope. Disclosure is allowed only when the label scope exactly matches and every carried class is explicitly permitted.
+
+The initial classes are `PUBLIC`, `TASK_INPUT`, `RUNTIME_CONTEXT`, `PERSISTENT_MEMORY`, `TOOL_METADATA`, and `SECRET`.
+
+A flow label or hash is evidence, not authority. It never grants `READ`, `WRITE`, `EXECUTE`, `GRANT`, `REVOKE`, or network authority. A caller still requires the relevant live RVM capability. Tool metadata, model output, memory, peer messages, consensus, and confidence are never allowed to create or widen an egress budget.
+
+## Why this primitive is intentionally small
+
+A full information-flow language is already tracked in issue #53. The first production primitive should be independently useful, easily reviewable, and reversible. It establishes the invariant needed by MCP, Ruflo, Core Memory, LatentMesh, and agent runtimes without committing RVM to a particular policy DSL or privacy classifier.
+
+It also separates two problems that should not be conflated.
+
+* Classification decides what a value contains or derives from.
+* Authorization decides whether that class may cross a sink boundary.
+
+Future argument minimization can reduce a label before the sink only through an explicit, separately reviewed release mechanism that proves the sensitive source material is no longer represented. Version 1 has no such mechanism.
+
+## Security invariants
+
+1. Unknown class bits are rejected.
+2. Source labels require non-empty classes and a non-zero task scope.
+3. Derivation cannot remove sensitivity.
+4. Joining values unions all sensitivity and rejects cross-task composition.
+5. Egress budgets are sink specific and task specific.
+6. A deny-all budget is representable.
+7. Flow lineage cannot be interpreted as an execution capability.
+8. Model-controlled content cannot mutate the budget.
+9. Parent count and transformation tag length are bounded to limit resource exhaustion.
+10. Missing flow labels at an enforced boundary must be treated as unknown and denied by the integration layer. This crate does not silently invent a permissive label.
+
+## Interfaces
+
+```rust
+let context = FlowLabel::source(
+    FlowClasses::RUNTIME_CONTEXT,
+    task_scope,
+    b"conversation:turn:42",
+)?;
+
+let summarized = context.derive(b"summary:v1")?;
+
+let budget = EgressBudget::new(
+    weather_tool_sink,
+    task_scope,
+    FlowClasses::PUBLIC.union(FlowClasses::TASK_INPUT),
+)?;
+
+let receipt = budget.check(&summarized);
+assert!(!receipt.decision().is_allowed());
+```
+
+## Cross-stack integration
+
+* RVM: enforce the final egress decision next to the existing capability check.
+* MCP: bind server and tool identity to the sink identifier; never derive the budget from tool descriptions.
+* Core Memory: label retrieved memory before rendering it into model context.
+* Ruflo and Autogenous: preserve labels in delegation and tool-call receipts.
+* LatentMesh: propagate labels alongside compressed or latent payloads; compression cannot remove classes.
+* RVF: sign portable artifacts and future controlled-release decisions.
+* MetaHarness: independently reproduce malicious and benign context-passing cases.
+* MidStream: observe denied flows and anomaly patterns without gaining authority to override the decision.
+
+## Migration
+
+The feature is additive. Existing context APIs remain unchanged. Integrations opt into enforcement one sink boundary at a time. No stored RVF or `ruv://` data migration is required.
+
+Recommended rollout:
+
+1. Shadow mode records flow decisions without blocking.
+2. Enforce `SECRET` and `RUNTIME_CONTEXT` for untrusted third-party sinks.
+3. Add Core Memory and MCP label propagation.
+4. Expand to agent delegation and LatentMesh only after zero-loss propagation tests pass.
+5. Consider controlled release or schema-aware argument minimization only after independent benchmark evidence.
+
+## Benchmark protocol
+
+The benchmark must compare current RVM behavior, metadata/tool scanning plus prompt hardening, flow-label enforcement, and flow-label enforcement plus any later argument minimizer.
+
+Workload:
+
+* ContextLeak-style user prompt, conversation history, tool list, persistent-memory, and mixed-context cases.
+* Benign tools that legitimately require task input.
+* Third-party and first-party sinks.
+* At least two backend model families.
+* At least 100 trials per attack class and matched benign class where model cost permits.
+
+Required reporting:
+
+* exact repository commit and branch
+* Rust toolchain and target
+* model/provider/version
+* MCP/tool schemas and sink trust class
+* seeds and sample size
+* malicious tool selection rate
+* unauthorized context disclosure rate
+* benign tool task completion
+* false block rate
+* bytes and sensitivity classes transmitted
+* p50 and p95 policy latency
+* CPU and memory overhead
+* token and provider cost
+* malformed-input failures
+* missing-label behavior
+* cross-task attempts
+* long-lineage and parent-limit cases
+* ablations with task scope removed and class union removed
+* reproduction commands and raw receipts
+
+Primary acceptance gate:
+
+* zero unauthorized disclosure for policy-visible labeled flows
+* benign task success within 3 absolute percentage points of the stronger baseline
+* median local flow-check overhead below 1 ms and below 1 percent of end-to-end tool-call latency
+* zero class loss through summary, memory, MCP, and one agent-delegation transformation
+* no capability expansion
+
+ContextLeak attack-success numbers are originating-team measurements and must not be treated as RuV validation until independently reproduced.
+
+## Dependency and runtime impact
+
+The implementation reuses the existing `sha2` dependency already present in `rvm-context`. It introduces no new dependency, network surface, unsafe code, allocator requirement beyond the crate's existing `alloc` use, or persistent storage format.
+
+## Rollback
+
+Remove flow enforcement from sink adapters and retain existing action-scoped capability checks. Because the API is additive and no persistent data migration is introduced, rollback does not require rewriting stored context or RVF artifacts. Flow receipts may remain as historical evidence.
+
+## Rejected alternatives
+
+### Prompt-only privacy instructions
+
+Rejected as an authority boundary. ContextLeak and ToolMinimize both report large residual leakage under instruction-level defenses.
+
+### Tool metadata screening only
+
+Rejected as a complete defense. ContextLeak reports false-negative rates of 0.97 to 1.00 for evaluated metadata detectors.
+
+### Block every tool carrying sensitive input
+
+Rejected as the target architecture because it destroys legitimate utility. RVM needs explicit per-sink budgets and, later, controlled minimization rather than universal blocking.
+
+### Full policy DSL in this change
+
+Deferred. Issue #53 remains the broader flow-policy program. A minimal invariant is easier to verify and gives the stack an immediate reusable boundary.
+
+## Consequences
+
+Positive:
+
+* runtime context cannot be disclosed solely because a model or malicious tool asks for it
+* the same primitive spans MCP, memory, agent delegation, latent transport, and external network sinks
+* no model-specific defense is required
+* the fast path is deterministic and local
+* rollout and rollback are incremental
+
+Negative:
+
+* labels are only as correct as the trusted classification boundary that creates them
+* coarse classes can over-block without a later minimization or controlled-release mechanism
+* cross-stack integrations must preserve labels exactly
+* a hash proves lineage identity, not semantic absence of sensitive information
+
+The dominant unresolved risk is source misclassification. The fix path is to bind source-label creation to authenticated principals and schema/data classifiers, then test false-negative classification separately from egress authorization.


### PR DESCRIPTION
## Finding

ContextLeak (arXiv:2608.27800, 2026-08-28) demonstrates that malicious tool metadata can induce an agent both to select a tool and pass runtime context as tool arguments. The originating team reports transfer to Claude Code backed by Claude Sonnet 4.6, with 22 malicious selections in 100 trials and near-complete extraction conditional on selection. The same paper reports 0.97 to 1.00 false-negative rates for several prompt and MCP metadata detectors.

ToolMinimize (arXiv:2608.24957, PST 2026) independently measures ordinary tool-call oversharing and reports 81 to 88 percent of default calls carrying unnecessary privacy-sensitive data across three production LLM families.

This PR implements the first narrow production primitive from #53: a deterministic egress boundary below model and tool metadata.

## Changes

* add `FlowClasses` for public, task input, runtime context, persistent memory, tool metadata, and secrets
* add `FlowLabel` with task scope and SHA-256 lineage
* enforce monotonic derivation: normal transforms cannot remove sensitivity
* join multiple values by unioning classes and rejecting cross-task composition
* add sink-specific `EgressBudget`
* add auditable allow/deny `EgressReceipt`
* bound tag length and parent count for resource exhaustion resistance
* add adversarial and malformed-input unit tests
* add ADR-160 with rollout, benchmark, security, migration, and rollback plan

## Security model

Labels and hashes are evidence, never authority. This PR does not grant network access or execution rights. Callers still require live RVM capabilities. Tool descriptions, model output, memory, peer messages, consensus, and confidence cannot create or widen an egress budget.

Version 1 deliberately has no declassification API. Missing labels at an enforced integration boundary must fail closed. Controlled release and schema-aware argument minimization are follow-up work only after independent evaluation.

## Benchmark gate before promotion

Compare current behavior, prompt and metadata hardening, this flow gate, and any later argument minimizer on ContextLeak-style and benign tool-use cases. Require:

* zero unauthorized disclosure for policy-visible labeled flows
* benign task success within 3 absolute percentage points of the stronger baseline
* median local flow-check overhead below 1 ms and below 1 percent of end-to-end tool-call latency
* zero class loss through summary, memory, MCP, and one agent-delegation transformation
* zero capability expansion

Originating-team attack numbers are not treated as RuV validation until independently reproduced.

## Rollback

Additive API only. Disable sink enforcement and retain existing action-scoped capability checks. No persistent data migration.

Closes no issue automatically. Implements the first bounded slice of #53. Keep draft until repository CI, dependency/security review, and independent MetaHarness reproduction are complete.